### PR TITLE
Unit testing

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,3 +18,4 @@ jobs:
       - run: npm install
       - run: npm run lint
       - run: npm run build
+      - run: num run test

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,4 +18,4 @@ jobs:
       - run: npm install
       - run: npm run lint
       - run: npm run build
-      - run: num run test
+      - run: npm run test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,9 @@ jobs:
         node-version: '20'
         registry-url: 'https://registry.npmjs.org/'
     - run: npm i
+    - run: npm run lint
+    - run: npm run build
+    - run: num run test
     - run: npm publish
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
     - run: npm i
     - run: npm run lint
     - run: npm run build
-    - run: num run test
+    - run: npm run test
     - run: npm publish
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "prom-client": "^15.1.0"
       },
       "devDependencies": {
-        "@cspell/eslint-plugin": "^8.6.0",
+        "@cspell/eslint-plugin": "^8.6.1",
         "@faker-js/faker": "^8.4.1",
         "@types/ini": "^4.1.0",
         "@types/jest": "^29.5.12",
@@ -43,7 +43,7 @@
         "eslint-plugin-unicorn": "^51.0.1",
         "jest": "^29.7.0",
         "jest-environment-node": "^29.7.0",
-        "npm-check-updates": "^16.14.17",
+        "npm-check-updates": "^16.14.18",
         "prettier": "^3.2.5",
         "ts-jest": "^29.1.2",
         "tslib": "^2.6.2",
@@ -722,9 +722,9 @@
       }
     },
     "node_modules/@cspell/cspell-bundled-dicts": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-8.6.0.tgz",
-      "integrity": "sha512-hRVvir4G4276Kz/Cru34AJg1FObIw5MrzezAwHkD3obNMwZkof8aX3MEN6AzWusJSVG2ZxZxZAEnYbgqvGr2Fg==",
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-8.6.1.tgz",
+      "integrity": "sha512-s6Av1xIgctYLuUiazKZjQ2WRUXc9dU38BOZXwM/lb7y8grQMEuTjST1c+8MOkZkppx48/sO7GHIF3k9rEzD3fg==",
       "dev": true,
       "dependencies": {
         "@cspell/dict-ada": "^4.0.2",
@@ -754,6 +754,7 @@
         "@cspell/dict-html": "^4.0.5",
         "@cspell/dict-html-symbol-entities": "^4.0.0",
         "@cspell/dict-java": "^5.0.6",
+        "@cspell/dict-julia": "^1.0.1",
         "@cspell/dict-k8s": "^1.0.2",
         "@cspell/dict-latex": "^4.0.0",
         "@cspell/dict-lorem-ipsum": "^4.0.0",
@@ -773,6 +774,7 @@
         "@cspell/dict-sql": "^2.1.3",
         "@cspell/dict-svelte": "^1.0.2",
         "@cspell/dict-swift": "^2.0.1",
+        "@cspell/dict-terraform": "^1.0.0",
         "@cspell/dict-typescript": "^3.1.2",
         "@cspell/dict-vue": "^3.0.0"
       },
@@ -781,18 +783,18 @@
       }
     },
     "node_modules/@cspell/cspell-pipe": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-8.6.0.tgz",
-      "integrity": "sha512-gbAZksz38OHaN8s4fOmmgtgQfie1K8dRGlo9z/uxSx5FIELV48GWTbHn9t1TY2yBXBwJ7+4NF2+r624rtlPoHQ==",
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-8.6.1.tgz",
+      "integrity": "sha512-guIlGhhOLQwfqevBSgp26b+SX4I1hCH+puAksWAk93bybKkcGtGpcavAQSN9qvamox4zcHnvGutEPF+UcXuceQ==",
       "dev": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/cspell-resolver": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-8.6.0.tgz",
-      "integrity": "sha512-ARwO6TWKy8fLHNhC/ls5Wo/AK86E1oLVChwWtHdq7eVyEUIykQaXGLqoRThkIT2jyLfGDrhSvaU+yqcXVLE48Q==",
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-resolver/-/cspell-resolver-8.6.1.tgz",
+      "integrity": "sha512-ZUbYcvEhfokHG9qfUlIylUqEobG84PiDozCkE8U4h/rTSmYkf/nAD+M6yg+jQ0F2aTFGNbvpKKGFlfXFXveX7A==",
       "dev": true,
       "dependencies": {
         "global-directory": "^4.0.1"
@@ -802,18 +804,18 @@
       }
     },
     "node_modules/@cspell/cspell-service-bus": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-8.6.0.tgz",
-      "integrity": "sha512-veCGlhlNGmYMgzX/rMiDp8j7ndLxFHIZq3h6DNlIsIoSjP1v5Rk6UcCwEoWYexwKmNXo7c2VooB0GM9LSBcPAQ==",
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-8.6.1.tgz",
+      "integrity": "sha512-WpI3fSW8t00UMetfd6tS8f9+xE3+ElIUO/bQ1YKK95TMIRdEUcH+QDxcHM66pJXEm4WiaN3H/MfWk1fIhGlJ8g==",
       "dev": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@cspell/cspell-types": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-8.6.0.tgz",
-      "integrity": "sha512-+CU/nuFOpswJAA3IS2TcKGskfM/o/4aNG1IMUVaOEQi1Sc5qZQ4Wj1qDIWJArSHFYW1Q4XFa4U8K1jnVHkAhZQ==",
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-8.6.1.tgz",
+      "integrity": "sha512-MXa9v6sXbbwyiNno7v7vczNph6AsMNWnpMRCcW3h/siXNQYRuMssdxqT5sQJ8Kurh3M/Wo7DlKX4n74elKL3iQ==",
       "dev": true,
       "engines": {
         "node": ">=18"
@@ -987,6 +989,12 @@
       "integrity": "sha512-kdE4AHHHrixyZ5p6zyms1SLoYpaJarPxrz8Tveo6gddszBVVwIUZ+JkQE1bWNLK740GWzIXdkznpUfw1hP9nXw==",
       "dev": true
     },
+    "node_modules/@cspell/dict-julia": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-julia/-/dict-julia-1.0.1.tgz",
+      "integrity": "sha512-4JsCLCRhhLMLiaHpmR7zHFjj1qOauzDI5ZzCNQS31TUMfsOo26jAKDfo0jljFAKgw5M2fEG7sKr8IlPpQAYrmQ==",
+      "dev": true
+    },
     "node_modules/@cspell/dict-k8s": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@cspell/dict-k8s/-/dict-k8s-1.0.2.tgz",
@@ -1104,6 +1112,12 @@
       "integrity": "sha512-gxrCMUOndOk7xZFmXNtkCEeroZRnS2VbeaIPiymGRHj5H+qfTAzAKxtv7jJbVA3YYvEzWcVE2oKDP4wcbhIERw==",
       "dev": true
     },
+    "node_modules/@cspell/dict-terraform": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@cspell/dict-terraform/-/dict-terraform-1.0.0.tgz",
+      "integrity": "sha512-Ak+vy4HP/bOgzf06BAMC30+ZvL9mzv21xLM2XtfnBLTDJGdxlk/nK0U6QT8VfFLqJ0ZZSpyOxGsUebWDCTr/zQ==",
+      "dev": true
+    },
     "node_modules/@cspell/dict-typescript": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.1.2.tgz",
@@ -1117,9 +1131,9 @@
       "dev": true
     },
     "node_modules/@cspell/dynamic-import": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-8.6.0.tgz",
-      "integrity": "sha512-yDJZ/uXCpZcAkXwaWa0JcCZHZFxnF3qtiFiq2WG5cEw8tiJiNdawjSCd8/D35dT3QFNaInMP+H3sOf68dNueew==",
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-8.6.1.tgz",
+      "integrity": "sha512-Fjvkcb5umIAcHfw/iiciYWgO2mXVuRZzQAWPSub6UFCxxcJlRz39YPXa+3O/m3lnXCeo8ChoaEN8qnuV4ogk6g==",
       "dev": true,
       "dependencies": {
         "import-meta-resolve": "^4.0.0"
@@ -1129,13 +1143,13 @@
       }
     },
     "node_modules/@cspell/eslint-plugin": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@cspell/eslint-plugin/-/eslint-plugin-8.6.0.tgz",
-      "integrity": "sha512-l32es7hfqx90+HQc07rANbRS1g0sHTee7LsI7mpMqj+G/CKHXfPVeTj1iOJK4NPo/rlpv2CFLS3pr6UvpfJroA==",
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/@cspell/eslint-plugin/-/eslint-plugin-8.6.1.tgz",
+      "integrity": "sha512-PIY7lyaVFd1CuLpnuCtXD07Qlod1mLGcUy2NI6ghgXku34oyTrbU4NYC5lNNM1tUxNSGwz2NQOdoTWnEOacllw==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-types": "8.6.0",
-        "cspell-lib": "8.6.0",
+        "@cspell/cspell-types": "8.6.1",
+        "cspell-lib": "8.6.1",
         "estree-walker": "^3.0.3",
         "synckit": "^0.9.0"
       },
@@ -1144,9 +1158,9 @@
       }
     },
     "node_modules/@cspell/strong-weak-map": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-8.6.0.tgz",
-      "integrity": "sha512-QenBOdIT1zRa0kF3Z1mwObcvmdhxn+rzQDdmkxwSyRB/9KsNnib6XXTUo8P+Z/ZKXOYbP9Wmf4FX+vKd3yVX0Q==",
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-8.6.1.tgz",
+      "integrity": "sha512-X6/7cy+GGVJFXsfrZapxVKn5mtehNTr7hTlg0bVj3iFoNYEPW9zq9l6WIcI4psmaU8G4DSrNsBK7pp87W3u16A==",
       "dev": true,
       "engines": {
         "node": ">=18"
@@ -3049,6 +3063,12 @@
       "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
       "dev": true
     },
+    "node_modules/@types/semver-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/semver-utils/-/semver-utils-1.1.3.tgz",
+      "integrity": "sha512-T+YwkslhsM+CeuhYUxyAjWm7mJ5am/K10UX40RuA6k6Lc7eGtq8iY2xOzy7Vq0GOqhl/xZl5l2FwURZMTPTUww==",
+      "dev": true
+    },
     "node_modules/@types/sinonjs__fake-timers": {
       "version": "8.1.5",
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
@@ -4580,28 +4600,28 @@
       }
     },
     "node_modules/cspell-config-lib": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-8.6.0.tgz",
-      "integrity": "sha512-Q1rvQFUDJTu4hUtxwL6+q83Hjx/a5grEjMS5axxFJzjJuFRbRsXCagncdSCx/YBqLkNM5noBbRP/0rVh7ufqxw==",
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/cspell-config-lib/-/cspell-config-lib-8.6.1.tgz",
+      "integrity": "sha512-I6LatgXJb8mxKFzIywO81TlUD/qWnUDrhB6yTUPdP90bwZcXMmGoCsZxhd2Rvl9fz5fWne0T839I1coShfm86g==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-types": "8.6.0",
+        "@cspell/cspell-types": "8.6.1",
         "comment-json": "^4.2.3",
-        "yaml": "^2.4.0"
+        "yaml": "^2.4.1"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/cspell-dictionary": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-8.6.0.tgz",
-      "integrity": "sha512-ohToeOQznIrb2/z7RfKxX3NID0WiO4sXK3IxKdnbn2viGgdn17tQ8Z2f4Xuy9egjSGRKyr6N25Z5AOes1C8R3w==",
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-8.6.1.tgz",
+      "integrity": "sha512-0SfKPi1QoWbGpZ/rWMR7Jn0+GaQT9PAMLWjVOu66PUNUXI5f4oCTHpnZE1Xts+5VX8shZC3TAMHEgtgKuQn4RQ==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-pipe": "8.6.0",
-        "@cspell/cspell-types": "8.6.0",
-        "cspell-trie-lib": "8.6.0",
+        "@cspell/cspell-pipe": "8.6.1",
+        "@cspell/cspell-types": "8.6.1",
+        "cspell-trie-lib": "8.6.1",
         "fast-equals": "^5.0.1",
         "gensequence": "^7.0.0"
       },
@@ -4610,9 +4630,9 @@
       }
     },
     "node_modules/cspell-glob": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-8.6.0.tgz",
-      "integrity": "sha512-AyuExc34F8JsEYNl4inx1m1v5VoSRA/cTptREq/AoNTcMTyG5s+wt5J+VWBfvJjEDEEpd9Cb2it0j8TMo/Tpjw==",
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-8.6.1.tgz",
+      "integrity": "sha512-QjtngIR0XsUQLmHHDO86hps/JR5sRxSBwCvcsNCEmSdpdofLFc8cuxi3o33JWge7UAPBCQOLGfpA7/Wx31srmw==",
       "dev": true,
       "dependencies": {
         "micromatch": "^4.0.5"
@@ -4622,13 +4642,13 @@
       }
     },
     "node_modules/cspell-grammar": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-8.6.0.tgz",
-      "integrity": "sha512-wVpZ4pPOqRoOmzLUc34wyOQnBi/6RsV3Y1KiPn8BNSkObb9XSohb1xJJMJ69unEmgE0snQDMHIeUaLTQH414MA==",
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-8.6.1.tgz",
+      "integrity": "sha512-MaG0e/F0b2FnIRULCZ61JxEiJgTP/6rsbUoR5nG9X+WmJYItYmxC1F/FPPrVeTu+jJr/8O4pdnslE20pimHaCw==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-pipe": "8.6.0",
-        "@cspell/cspell-types": "8.6.0"
+        "@cspell/cspell-pipe": "8.6.1",
+        "@cspell/cspell-types": "8.6.1"
       },
       "bin": {
         "cspell-grammar": "bin.mjs"
@@ -4638,38 +4658,38 @@
       }
     },
     "node_modules/cspell-io": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-8.6.0.tgz",
-      "integrity": "sha512-jx7ccRpcshqxN6xnOiGnX4VycaqTpmatRjHITn4vLoDmQNfxQeU69YT62bhyjogCBuJsZS9ksjo7GQIsrYBekA==",
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-8.6.1.tgz",
+      "integrity": "sha512-ofxBB8QtUPvh/bOwKLYsqU1hwQCet8E98jkn/5f4jtG+/x5Zd80I0Ez+tlbjiBmrrQfOKh+i8ipfzHD8JtoreQ==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-service-bus": "8.6.0"
+        "@cspell/cspell-service-bus": "8.6.1"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/cspell-lib": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-8.6.0.tgz",
-      "integrity": "sha512-l1bBxBz8noPOxEIIu1Ahvd4e/j6Re1PNDD9FwZgaRmvMyIPZbupTxzCM0MZWvYz1VymBmrrVEKRwtZ34VocaCw==",
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-8.6.1.tgz",
+      "integrity": "sha512-kGeDUypRtThFT81IdUK7yU8eUwO5MYWj8pGQ0N8WFsqbCahJrUdcocceVSpnCX48W3CXu12DkqYG9kv5Umn7Xw==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-bundled-dicts": "8.6.0",
-        "@cspell/cspell-pipe": "8.6.0",
-        "@cspell/cspell-resolver": "8.6.0",
-        "@cspell/cspell-types": "8.6.0",
-        "@cspell/dynamic-import": "8.6.0",
-        "@cspell/strong-weak-map": "8.6.0",
+        "@cspell/cspell-bundled-dicts": "8.6.1",
+        "@cspell/cspell-pipe": "8.6.1",
+        "@cspell/cspell-resolver": "8.6.1",
+        "@cspell/cspell-types": "8.6.1",
+        "@cspell/dynamic-import": "8.6.1",
+        "@cspell/strong-weak-map": "8.6.1",
         "clear-module": "^4.1.2",
         "comment-json": "^4.2.3",
         "configstore": "^6.0.0",
-        "cspell-config-lib": "8.6.0",
-        "cspell-dictionary": "8.6.0",
-        "cspell-glob": "8.6.0",
-        "cspell-grammar": "8.6.0",
-        "cspell-io": "8.6.0",
-        "cspell-trie-lib": "8.6.0",
+        "cspell-config-lib": "8.6.1",
+        "cspell-dictionary": "8.6.1",
+        "cspell-glob": "8.6.1",
+        "cspell-grammar": "8.6.1",
+        "cspell-io": "8.6.1",
+        "cspell-trie-lib": "8.6.1",
         "fast-equals": "^5.0.1",
         "gensequence": "^7.0.0",
         "import-fresh": "^3.3.0",
@@ -4682,13 +4702,13 @@
       }
     },
     "node_modules/cspell-trie-lib": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-8.6.0.tgz",
-      "integrity": "sha512-S8nGCnEJBL1maiKPd3FhI54QG+OgtOkcJ/yUDXGXGrokSruWFdNocioPirlFAHf959ax1GBUVEYNIgnu/EIWNg==",
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-8.6.1.tgz",
+      "integrity": "sha512-iuJuAyWoqTH/TpFAR/ISJGQQoW3oiw54GyvXIucPoCJt/jgQONDuzqPW+skiLvcgcTbXCN9dutZTb2gImIkmpw==",
       "dev": true,
       "dependencies": {
-        "@cspell/cspell-pipe": "8.6.0",
-        "@cspell/cspell-types": "8.6.0",
+        "@cspell/cspell-pipe": "8.6.1",
+        "@cspell/cspell-types": "8.6.1",
         "gensequence": "^7.0.0"
       },
       "engines": {
@@ -9514,11 +9534,12 @@
       }
     },
     "node_modules/npm-check-updates": {
-      "version": "16.14.17",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-16.14.17.tgz",
-      "integrity": "sha512-ElnDdXKe60f8S6RhzFeaGuH2TFJmt2cU2HjLdowldabdm27nWFCxV2ebeP3xGbQkzp2+RPDQNdW9HqU1lcY8ag==",
+      "version": "16.14.18",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-16.14.18.tgz",
+      "integrity": "sha512-9iaRe9ohx9ykdbLjPRIYcq1A0RkrPYUx9HmQK1JIXhfxtJCNE/+497H9Z4PGH6GWRALbz5KF+1iZoySK2uSEpQ==",
       "dev": true,
       "dependencies": {
+        "@types/semver-utils": "^1.1.1",
         "chalk": "^5.3.0",
         "cli-table3": "^0.6.3",
         "commander": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "repository": {
     "url": "git+https://github.com/Digital-Alchemy-TS/core"
   },
-  "version": "0.3.7",
+  "version": "0.3.8",
   "author": {
     "url": "https://github.com/zoe-codez",
     "name": "Zoe Codez"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "redis": "^4.6.13"
   },
   "devDependencies": {
-    "@cspell/eslint-plugin": "^8.6.0",
+    "@cspell/eslint-plugin": "^8.6.1",
     "@faker-js/faker": "^8.4.1",
     "@types/ini": "^4.1.0",
     "@types/jest": "^29.5.12",
@@ -64,7 +64,7 @@
     "eslint": "8.57.0",
     "jest-environment-node": "^29.7.0",
     "jest": "^29.7.0",
-    "npm-check-updates": "^16.14.17",
+    "npm-check-updates": "^16.14.18",
     "prettier": "^3.2.5",
     "ts-jest": "^29.1.2",
     "tslib": "^2.6.2",

--- a/src/extensions/logger.extension.ts
+++ b/src/extensions/logger.extension.ts
@@ -34,10 +34,13 @@ const LOG_LEVEL_PRIORITY = {
   error: 50,
   fatal: 60,
   info: 30,
+  silent: 100,
   trace: 10,
   warn: 40,
 };
-const LOG_LEVELS = Object.keys(LOG_LEVEL_PRIORITY) as (keyof ILogger)[];
+const LOG_LEVELS = Object.keys(LOG_LEVEL_PRIORITY) as TConfigLogLevel[];
+
+export type TConfigLogLevel = keyof ILogger | "silent";
 
 export const METHOD_COLORS = new Map<keyof ILogger, CONTEXT_COLORS>([
   ["trace", "grey"],
@@ -71,7 +74,7 @@ export async function Logger({ lifecycle, config, internal }: TServiceParams) {
   const YELLOW_DASH = chalk.yellowBright(frontDash);
   const BLUE_TICK = chalk.blue(`>`);
   let prettyFormat = true;
-  const shouldILog = {} as Record<keyof ILogger, boolean>;
+  const shouldILog = {} as Record<TConfigLogLevel, boolean>;
 
   const prettyFormatMessage = (message: string): string => {
     if (!message) {
@@ -165,7 +168,7 @@ export async function Logger({ lifecycle, config, internal }: TServiceParams) {
   // otherwise, be noisy until config loads a user preference
   //
   // stored as separate variable to cut down on internal config lookups
-  let CURRENT_LOG_LEVEL: keyof ILogger =
+  let CURRENT_LOG_LEVEL: TConfigLogLevel =
     internal.utils.object.get(
       internal,
       "boot.options.configuration.boilerplate.LOG_LEVEL",
@@ -190,7 +193,7 @@ export async function Logger({ lifecycle, config, internal }: TServiceParams) {
 
   const updateShouldLog = () => {
     CURRENT_LOG_LEVEL = config.boilerplate.LOG_LEVEL;
-    LOG_LEVELS.forEach((key: keyof ILogger) => {
+    LOG_LEVELS.forEach((key: TConfigLogLevel) => {
       shouldILog[key] =
         LOG_LEVEL_PRIORITY[key] >= LOG_LEVEL_PRIORITY[CURRENT_LOG_LEVEL];
     });

--- a/src/extensions/scheduler.extension.ts
+++ b/src/extensions/scheduler.extension.ts
@@ -15,12 +15,12 @@ import {
 export function Scheduler({ logger, lifecycle, internal }: TServiceParams) {
   const stop = new Set<() => TBlackHole>();
 
-  lifecycle.onShutdownStart(() => {
+  lifecycle.onPreShutdown(() => {
     if (is.empty(stop)) {
       return;
     }
     logger.info(
-      { name: "onShutdownStart" },
+      { name: "onPreShutdown" },
       `removing [%s] schedules`,
       stop.size,
     );

--- a/src/extensions/wiring.extension.ts
+++ b/src/extensions/wiring.extension.ts
@@ -44,7 +44,7 @@ import {
   LOAD_PROJECT,
 } from "./configuration.extension";
 import { Fetch } from "./fetch.extension";
-import { ILogger, Logger } from "./logger.extension";
+import { ILogger, Logger, TConfigLogLevel } from "./logger.extension";
 import { Scheduler } from "./scheduler.extension";
 
 // # "Semi-local variables"
@@ -151,6 +151,7 @@ function CreateBoilerplate() {
   return CreateLibrary({
     configuration: {
       CACHE_PREFIX: {
+        default: "",
         description: [
           "Use a prefix with all cache keys",
           "If blank, then application name is used",
@@ -181,7 +182,7 @@ function CreateBoilerplate() {
         description: "Minimum log level to process",
         enum: ["silent", "trace", "info", "warn", "debug", "error"],
         type: "string",
-      } as StringConfig<keyof ILogger>,
+      } as StringConfig<TConfigLogLevel>,
       REDIS_URL: {
         default: "redis://localhost:6379",
         description:
@@ -396,7 +397,6 @@ async function WireService(
     // eslint-disable-next-line no-console
     console.error("initialization error", error);
     exit();
-    return undefined;
   }
 }
 
@@ -634,8 +634,10 @@ async function Bootstrap<
     );
     internal.boot.phase = "running";
   } catch (error) {
-    // eslint-disable-next-line no-console
-    console.error("bootstrap failed", error);
+    if (options?.configuration?.boilerplate?.LOG_LEVEL !== "silent") {
+      // eslint-disable-next-line no-console
+      console.error("bootstrap failed", error);
+    }
     exit();
   }
 }

--- a/src/extensions/wiring.extension.ts
+++ b/src/extensions/wiring.extension.ts
@@ -63,7 +63,7 @@ export let MODULE_MAPPINGS = new Map<string, TModuleMappings>();
 /**
  * association of projects to { service : Initialized Service }
  */
-let LOADED_MODULES = new Map<string, TResolvedModuleMappings>();
+export let LOADED_MODULES = new Map<string, TResolvedModuleMappings>();
 
 /**
  * Optimized reverse lookups: Declaration  Function => [project, service]
@@ -73,7 +73,7 @@ export let REVERSE_MODULE_MAPPING = new Map<
   [project: string, service: string]
 >();
 
-let LOADED_LIFECYCLES = new Map<string, TLoadableChildLifecycle>();
+export let LOADED_LIFECYCLES = new Map<string, TLoadableChildLifecycle>();
 
 // heisenberg's variables. it's probably here, but maybe not
 // let scheduler: (context: TContext) => TScheduler;
@@ -228,6 +228,7 @@ export function CreateLibrary<
   configuration = {} as C,
   priorityInit,
   services,
+  depends,
 }: LibraryConfigurationOptions<S, C>): LibraryDefinition<S, C> {
   ValidateLibrary(libraryName, services);
 
@@ -259,6 +260,7 @@ export function CreateLibrary<
       return lifecycle;
     },
     configuration,
+    depends,
     name: libraryName,
     priorityInit,
     serviceApis,
@@ -511,6 +513,9 @@ function BuildSortOrder<
     starting = starting.filter((i) => next.name !== i.name);
     out.push(next);
   }
+
+  const order = out.map((i) => i.name);
+  logger.trace({ name: BuildSortOrder, order }, ``);
   return out;
 }
 

--- a/src/helpers/config-environment-loader.helper.ts
+++ b/src/helpers/config-environment-loader.helper.ts
@@ -1,17 +1,17 @@
 import minimist from "minimist";
 
-import { is } from "..";
+import { is, ServiceMap } from "..";
 import {
   AbstractConfig,
   ConfigLoaderParams,
   ConfigLoaderReturn,
+  ModuleConfiguration,
 } from "./config.helper";
 
-export async function ConfigLoaderEnvironment({
-  configs,
-  internal,
-  logger,
-}: ConfigLoaderParams): ConfigLoaderReturn {
+export async function ConfigLoaderEnvironment<
+  S extends ServiceMap = ServiceMap,
+  C extends ModuleConfiguration = ModuleConfiguration,
+>({ configs, internal, logger }: ConfigLoaderParams<S, C>): ConfigLoaderReturn {
   const environmentKeys = Object.keys(process.env);
   const CLI_SWITCHES = minimist(process.argv);
   const switchKeys = Object.keys(CLI_SWITCHES);

--- a/src/helpers/config-file-loader.helper.ts
+++ b/src/helpers/config-file-loader.helper.ts
@@ -6,11 +6,12 @@ import { homedir } from "os";
 import { join } from "path";
 import { cwd, exit, platform } from "process";
 
-import { deepExtend, INVERT_VALUE, is, START } from "..";
+import { deepExtend, INVERT_VALUE, is, ServiceMap, START } from "..";
 import {
   AbstractConfig,
   ConfigLoaderParams,
   ConfigLoaderReturn,
+  ModuleConfiguration,
 } from "./config.helper";
 
 const isWindows = platform === "win32";
@@ -31,7 +32,7 @@ export function configFilePaths(name = "digital-alchemy"): string[] {
   let current = cwd();
   let next: string;
   while (!is.empty(current)) {
-    out.push(join(current, `.${name}`), ...withExtensions(current));
+    out.push(...withExtensions(join(current, `.${name}`)));
     next = join(current, "..");
     if (next === current) {
       break;
@@ -47,10 +48,10 @@ export function configFilePaths(name = "digital-alchemy"): string[] {
   );
 }
 
-export async function ConfigLoaderFile({
-  application,
-  logger,
-}: ConfigLoaderParams): ConfigLoaderReturn {
+export async function ConfigLoaderFile<
+  S extends ServiceMap = ServiceMap,
+  C extends ModuleConfiguration = ModuleConfiguration,
+>({ application, logger }: ConfigLoaderParams<S, C>): ConfigLoaderReturn {
   const CLI_SWITCHES = minimist(process.argv);
   const configFile = CLI_SWITCHES.config;
   let files: string[];

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -13,6 +13,5 @@ export * from "./extend.helper";
 export * from "./fetch.helper";
 export * from "./lifecycle.helper";
 export * from "./metrics.helper";
-export * from "./testing.helper";
 export * from "./utilities.helper";
 export * from "./wiring.helper";

--- a/src/helpers/wiring.helper.ts
+++ b/src/helpers/wiring.helper.ts
@@ -6,6 +6,7 @@ import { ILogger, LIB_BOILERPLATE, TCache } from "..";
 import {
   AnyConfig,
   BooleanConfig,
+  ConfigLoader,
   InternalConfig,
   NumberConfig,
   OptionalModuleConfiguration,
@@ -23,6 +24,7 @@ export type ApplicationConfigurationOptions<
   S extends ServiceMap,
   C extends OptionalModuleConfiguration,
 > = {
+  configurationLoaders?: ConfigLoader[];
   name: keyof LoadedModules;
   services: S;
   libraries?: LibraryDefinition<ServiceMap, OptionalModuleConfiguration>[];

--- a/src/helpers/wiring.helper.ts
+++ b/src/helpers/wiring.helper.ts
@@ -300,10 +300,7 @@ type Wire = {
 export type LibraryDefinition<
   S extends ServiceMap,
   C extends OptionalModuleConfiguration,
-> = LibraryConfigurationOptions<S, C> &
-  Wire & {
-    lifecycle: TChildLifecycle;
-  };
+> = LibraryConfigurationOptions<S, C> & Wire;
 
 export type ApplicationDefinition<
   S extends ServiceMap,
@@ -312,6 +309,5 @@ export type ApplicationDefinition<
   Wire & {
     booted: boolean;
     bootstrap: (options?: BootstrapOptions) => Promise<void>;
-    lifecycle: TChildLifecycle;
     teardown: () => Promise<void>;
   };

--- a/src/testing/config-testing.extension.ts
+++ b/src/testing/config-testing.extension.ts
@@ -31,7 +31,7 @@ function generateRandomData() {
   };
 }
 
-export function ConfigTesting({ logger, internal, lifecycle }: TServiceParams) {
+export function ConfigTesting({ lifecycle }: TServiceParams) {
   const appName = "testing";
   const testDataMap = new Map<string, RandomFileTestingDataFormat>();
 

--- a/src/testing/configuration.spec.ts
+++ b/src/testing/configuration.spec.ts
@@ -1,0 +1,194 @@
+import { env } from "process";
+
+import {
+  ApplicationDefinition,
+  BootstrapOptions,
+  CreateApplication,
+  CreateLibrary,
+  INITIALIZE,
+  OptionalModuleConfiguration,
+  ServiceMap,
+  TServiceParams,
+} from "..";
+
+const BASIC_BOOT = {
+  configuration: { boilerplate: { LOG_LEVEL: "silent" } },
+} as BootstrapOptions;
+
+describe("Configuration", () => {
+  let application: ApplicationDefinition<
+    ServiceMap,
+    OptionalModuleConfiguration
+  >;
+  let spy: jest.SpyInstance;
+
+  afterEach(async () => {
+    if (application) {
+      await application.teardown();
+      application = undefined;
+    }
+    jest.restoreAllMocks();
+    spy = undefined;
+  });
+
+  describe("Initialization", () => {
+    it("should be configured at the correct time in the lifecycle", async () => {
+      expect.assertions(2);
+      application = CreateApplication({
+        configurationLoaders: [],
+        // @ts-expect-error testing
+        name: "testing",
+        services: {
+          Testing({ internal, lifecycle }: TServiceParams) {
+            spy = jest.spyOn(internal.boilerplate.configuration, INITIALIZE);
+            lifecycle.onPreInit(() => {
+              expect(spy).not.toHaveBeenCalled();
+            });
+            lifecycle.onPostConfig(() => {
+              expect(spy).toHaveBeenCalled();
+            });
+          },
+        },
+      });
+      await application.bootstrap(BASIC_BOOT);
+    });
+
+    it("should prioritize bootstrap config over defaults", async () => {
+      expect.assertions(1);
+      application = CreateApplication({
+        configurationLoaders: [],
+        // @ts-expect-error testing
+        name: "testing",
+        services: {
+          Testing({ config, lifecycle }: TServiceParams) {
+            lifecycle.onPostConfig(() => {
+              expect(config.boilerplate.LOG_LEVEL).toBe("silent");
+            });
+          },
+        },
+      });
+      await application.bootstrap(BASIC_BOOT);
+    });
+
+    it("should have the correct defaults for boilerplate", async () => {
+      expect.assertions(6);
+      application = CreateApplication({
+        configurationLoaders: [],
+        // @ts-expect-error testing
+        name: "testing",
+        services: {
+          Testing({ config, lifecycle }: TServiceParams) {
+            lifecycle.onPostConfig(() => {
+              expect(config.boilerplate.CACHE_PREFIX).toBe("");
+              expect(config.boilerplate.CACHE_PROVIDER).toBe("memory");
+              expect(config.boilerplate.CACHE_TTL).toBe(86_400);
+              expect(config.boilerplate.CONFIG).toBe(undefined);
+              expect(config.boilerplate.LOG_LEVEL).toBe("trace");
+              expect(config.boilerplate.REDIS_URL).toBe(
+                "redis://localhost:6379",
+              );
+            });
+          },
+        },
+      });
+      await application.bootstrap();
+    });
+
+    it("should generate the correct structure for applications", async () => {
+      expect.assertions(1);
+      application = CreateApplication({
+        configuration: {
+          FOO: {
+            default: "bar",
+            type: "string",
+          },
+        },
+        configurationLoaders: [],
+        // @ts-expect-error testing
+        name: "testing",
+        services: {
+          Testing({ config }: TServiceParams) {
+            // @ts-expect-error testing
+            expect(config.testing.FOO).toBe("bar");
+          },
+        },
+      });
+      await application.bootstrap(BASIC_BOOT);
+    });
+
+    it("should generate the correct structure for libraries", async () => {
+      expect.assertions(1);
+      application = CreateApplication({
+        configuration: {
+          FOO: {
+            default: "bar",
+            type: "string",
+          },
+        },
+        configurationLoaders: [],
+        libraries: [
+          CreateLibrary({
+            configuration: {
+              RAINING: {
+                default: false,
+                type: "boolean",
+              },
+            },
+            // @ts-expect-error testing
+            name: "library",
+            services: {},
+          }),
+        ],
+        // @ts-expect-error testing
+        name: "testing",
+        services: {
+          Testing({ config }: TServiceParams) {
+            // @ts-expect-error testing
+            expect(config.library.RAINING).toBe(false);
+          },
+        },
+      });
+      await application.bootstrap(BASIC_BOOT);
+    });
+  });
+
+  describe("Loaders", () => {
+    beforeEach(() => {
+      delete env["LOG_LEVEL"];
+      delete env["log_level"];
+      delete env["log-level"];
+    });
+    describe("Environment", () => {
+      it("should resolve direct match", async () => {
+        expect.assertions(1);
+        application = CreateApplication({
+          configuration: {
+            CURRENT_WEATHER: {
+              type: "string",
+              default: "raining"
+            }
+          },
+          // @ts-expect-error testing
+          name: "testing",
+          services: {
+            Testing({ config , lifecycle}: TServiceParams) {
+              lifecycle.onPostConfig(() => {
+
+                // @ts-expect-error testing
+                expect(config.library.RAINING).toBe(false);
+              })
+            },
+          },
+        });
+      });
+    });
+
+    describe("CLI", () => {
+      //
+    });
+
+    describe("File", () => {
+      //
+    });
+  });
+});

--- a/src/testing/testing.ts
+++ b/src/testing/testing.ts
@@ -6,7 +6,7 @@ import { extname, join } from "path";
 import { cwd } from "process";
 
 import { is } from "..";
-import { SINGLE } from ".";
+import { SINGLE, TServiceParams } from "../helpers";
 
 export const TESTING_APP_NAME = "digital-alchemy-unit-tests";
 
@@ -15,7 +15,7 @@ export const TESTING_APP_NAME = "digital-alchemy-unit-tests";
 // >;
 export type RandomFileTestingDataFormat = object;
 
-export function ConfigurationFiles() {
+export function Testing({ logger }: TServiceParams) {
   const testDataMap = new Map<string, RandomFileTestingDataFormat>();
 
   function writeConfigFile(
@@ -58,6 +58,7 @@ export function ConfigurationFiles() {
         // console.log("FIXME: GENERATE RANDOM DATA", filename, writeConfigFile);
         // const data = Testing.generateRandomData();
         // writeConfigFile(filename, data);
+        logger.info({ filename });
         filename;
         return writeConfigFile;
       });

--- a/src/testing/wiring.extension.spec.ts
+++ b/src/testing/wiring.extension.spec.ts
@@ -1,0 +1,577 @@
+import exp from "constants";
+
+import {
+  ApplicationDefinition,
+  BootstrapException,
+  BootstrapOptions,
+  CreateApplication,
+  CreateLibrary,
+  OptionalModuleConfiguration,
+  ServiceMap,
+  TServiceParams,
+  WIRE_PROJECT,
+} from "..";
+
+const FAKE_EXIT = (() => {}) as () => never;
+
+const BASIC_BOOT = {
+  configuration: { boilerplate: { LOG_LEVEL: "error" } },
+} as BootstrapOptions;
+
+describe("Wiring", () => {
+  let application: ApplicationDefinition<
+    ServiceMap,
+    OptionalModuleConfiguration
+  >;
+
+  afterEach(async () => {
+    if (application) {
+      await application.teardown();
+      application = undefined;
+    }
+    jest.restoreAllMocks();
+  });
+
+  describe("Basics", () => {
+    describe("CreateLibrary", () => {
+      it("should be defined", () => {
+        expect(CreateLibrary).toBeDefined();
+        expect(CreateApplication).toBeDefined();
+      });
+
+      it("should create a library without services", () => {
+        const library = CreateLibrary({
+          // @ts-expect-error For unit testing
+          name: "testing",
+          services: {},
+        });
+
+        expect(library).toBeDefined();
+        expect(library.name).toBe("testing");
+        expect(library.services).toEqual({});
+      });
+
+      it("properly wires services when creating a library", async () => {
+        const testService = jest.fn();
+        const library = CreateLibrary({
+          // @ts-expect-error For unit testing
+          name: "testing",
+          services: { testService },
+        });
+        await library[WIRE_PROJECT](undefined);
+        // Check that the service is wired correctly
+        expect(testService).toHaveBeenCalled();
+      });
+      it("throws an error with invalid service definition", () => {
+        expect(() => {
+          CreateLibrary({
+            // @ts-expect-error For unit testing
+            name: "testing",
+            services: { InvalidService: undefined },
+          });
+        }).toThrow("INVALID_SERVICE_DEFINITION");
+      });
+
+      it("creates multiple libraries with distinct configurations", () => {
+        const libraryOne = CreateLibrary({
+          // @ts-expect-error For unit testing
+          name: "testing",
+          services: {},
+        });
+        const libraryTwo = CreateLibrary({
+          // @ts-expect-error For unit testing
+          name: "testing_second",
+          services: {},
+        });
+        expect(libraryOne.name).not.toBe(libraryTwo.name);
+      });
+
+      it("throws a BootstrapException for an invalid service definition in a library", () => {
+        expect(() => {
+          CreateLibrary({
+            // @ts-expect-error For unit testing
+            name: "testing",
+            services: { invalidServiceDefinition: undefined },
+          });
+        }).toThrow(BootstrapException);
+      });
+
+      it("throws a BootstrapException if no name is provided for the library", () => {
+        expect(() => {
+          // @ts-expect-error that's the test
+          CreateLibrary({ name: "", services: {} });
+        }).toThrow(BootstrapException);
+      });
+    });
+
+    describe("CreateApplication Function", () => {
+      it("should create an application with specified services and libraries", () => {
+        const testService = jest.fn();
+        const testLibrary = CreateLibrary({
+          // @ts-expect-error For unit testing
+          name: "testing",
+          services: { TestService: testService },
+        });
+
+        application = CreateApplication({
+          libraries: [testLibrary],
+          // @ts-expect-error For unit testing
+          name: "testing_app",
+          services: { AppService: jest.fn() },
+        });
+
+        expect(application).toBeDefined();
+        expect(application.name).toBe("testing_app");
+        expect(Object.keys(application.services).length).toBe(1);
+        expect(application.libraries.length).toBe(1);
+        expect(application.libraries[0]).toBe(testLibrary);
+      });
+    });
+  });
+
+  describe("Application Lifecycle", () => {
+    beforeEach(() => {
+      application = CreateApplication({
+        // @ts-expect-error For unit testing
+        name: "testing_app",
+        services: {},
+      });
+    });
+
+    it("should call the lifecycle events in order during application bootstrap", async () => {
+      // Spy on lifecycle event functions
+      const spyPreInit = jest.fn();
+      const spyPostConfig = jest.fn();
+      const spyBootstrap = jest.fn();
+      const spyReady = jest.fn();
+      application = CreateApplication({
+        // @ts-expect-error For unit testing
+        name: "testing_app",
+        services: {
+          spy({ lifecycle }: TServiceParams) {
+            lifecycle.onPreInit(() => spyPreInit());
+            lifecycle.onPostConfig(() => spyPostConfig());
+            lifecycle.onBootstrap(() => spyBootstrap());
+            lifecycle.onReady(() => spyReady());
+          },
+        },
+      });
+
+      // Bootstrap the application
+      await application.bootstrap(BASIC_BOOT);
+
+      // Check that the lifecycle event functions were called
+      expect(spyPreInit).toHaveBeenCalled();
+      expect(spyPostConfig).toHaveBeenCalled();
+      expect(spyBootstrap).toHaveBeenCalled();
+      expect(spyReady).toHaveBeenCalled();
+
+      // Optionally, check the calling order
+      const callOrder = [
+        spyPreInit.mock.invocationCallOrder[0],
+        spyPostConfig.mock.invocationCallOrder[0],
+        spyBootstrap.mock.invocationCallOrder[0],
+        spyReady.mock.invocationCallOrder[0],
+      ];
+      expect(callOrder).toEqual([...callOrder].sort((a, b) => a - b));
+    });
+
+    it("executes lifecycle callbacks in the correct order", async () => {
+      // Mock callbacks for each lifecycle stage
+      const mockPreInit = jest.fn();
+      const mockPostConfig = jest.fn();
+      const mockBootstrap = jest.fn();
+      const mockReady = jest.fn();
+      application = CreateApplication({
+        // @ts-expect-error For unit testing
+        name: "testing_app",
+        services: {
+          spy({ lifecycle }: TServiceParams) {
+            lifecycle.onPreInit(() => mockPreInit());
+            lifecycle.onPostConfig(() => mockPostConfig());
+            lifecycle.onBootstrap(() => mockBootstrap());
+            lifecycle.onReady(() => mockReady());
+          },
+        },
+      });
+
+      // Bootstrap the application
+      await application.bootstrap(BASIC_BOOT);
+
+      // Retrieve the order in which the mocks were called
+      const preInitOrder = mockPreInit.mock.invocationCallOrder[0];
+      const postConfigOrder = mockPostConfig.mock.invocationCallOrder[0];
+      const bootstrapOrder = mockBootstrap.mock.invocationCallOrder[0];
+      const readyOrder = mockReady.mock.invocationCallOrder[0];
+
+      // Verify the order of callback execution
+      expect(preInitOrder).toBeLessThan(postConfigOrder);
+      expect(postConfigOrder).toBeLessThan(bootstrapOrder);
+      expect(bootstrapOrder).toBeLessThan(readyOrder);
+    });
+
+    it("registers and invokes lifecycle callbacks correctly", async () => {
+      const mockCallback = jest.fn();
+
+      application = CreateApplication({
+        // @ts-expect-error For unit testing
+        name: "testing_app",
+        services: {
+          spy({ lifecycle }: TServiceParams) {
+            lifecycle.onBootstrap(() => mockCallback());
+          },
+        },
+      });
+
+      // Bootstrap the application
+      await application.bootstrap(BASIC_BOOT);
+
+      // Check if the mock callback was invoked
+      expect(mockCallback).toHaveBeenCalled();
+    });
+
+    it("triggers fail-fast on catastrophic bootstrap errors", async () => {
+      const errorMock = jest.fn().mockImplementation(() => {
+        throw new Error("EXPECTED_UNIT_TESTING_ERROR");
+      });
+
+      application = CreateApplication({
+        // @ts-expect-error For unit testing
+        name: "testing_app",
+        services: {
+          spy({ lifecycle }: TServiceParams) {
+            lifecycle.onBootstrap(() => errorMock());
+          },
+        },
+      });
+
+      jest.spyOn(console, "error").mockImplementation(() => {});
+      const failFastSpy = jest
+        .spyOn(process, "exit")
+        .mockImplementation(FAKE_EXIT);
+
+      // Execute the Bootstrap function
+      await application.bootstrap(BASIC_BOOT);
+
+      // Check if FailFast was called
+      expect(failFastSpy).toHaveBeenCalled();
+    });
+
+    it("higher numbers go first (positive)", async () => {
+      const executionOrder: string[] = [];
+
+      application = CreateApplication({
+        // @ts-expect-error For unit testing
+        name: "testing_app",
+        services: {
+          spy({ lifecycle }: TServiceParams) {
+            lifecycle.onBootstrap(
+              () => executionOrder.push("LowPriorityBootstrap"),
+              1,
+            );
+            lifecycle.onBootstrap(
+              () => executionOrder.push("HighPriorityBootstrap"),
+              10,
+            );
+          },
+        },
+      });
+
+      await application.bootstrap(BASIC_BOOT);
+
+      // Define the expected order based on priorities
+      const expectedOrder = ["HighPriorityBootstrap", "LowPriorityBootstrap"];
+
+      // Compare the actual execution order with the expected order
+      expect(executionOrder).toEqual(expectedOrder);
+    });
+
+    it("lower numbers go later (negative)", async () => {
+      const executionOrder: string[] = [];
+
+      application = CreateApplication({
+        // @ts-expect-error For unit testing
+        name: "testing_app",
+        services: {
+          spy({ lifecycle }: TServiceParams) {
+            lifecycle.onBootstrap(
+              () => executionOrder.push("LowPriorityBootstrap"),
+              -1,
+            );
+            lifecycle.onBootstrap(
+              () => executionOrder.push("HighPriorityBootstrap"),
+              -10,
+            );
+          },
+        },
+      });
+
+      await application.bootstrap(BASIC_BOOT);
+
+      // Define the expected order based on priorities
+      const expectedOrder = ["HighPriorityBootstrap", "LowPriorityBootstrap"];
+
+      // Compare the actual execution order with the expected order
+      expect(executionOrder).toEqual(expectedOrder);
+    });
+  });
+
+  describe("Bootstrap", () => {
+    it("should prioritize services with priorityInit", async () => {
+      const list = [] as string[];
+      application = CreateApplication({
+        // @ts-expect-error Testing
+        name: "testing",
+        priorityInit: ["First", "Second"],
+        services: {
+          First() {
+            list.push("First");
+          },
+          Second() {
+            list.push("Second");
+          },
+          Third() {
+            list.push("Third");
+          },
+        },
+      });
+      //
+      await application.bootstrap(BASIC_BOOT);
+      expect(list).toStrictEqual(["First", "Second", "Third"]);
+    });
+
+    it("throws errors with missing priority services", async () => {
+      expect(() => {
+        CreateApplication({
+          // @ts-expect-error Testing
+          name: "testing",
+          priorityInit: ["Testing"],
+          services: {
+            NotTesting() {},
+          },
+        });
+      }).toThrow("MISSING_PRIORITY_SERVICE");
+    });
+
+    it("sets booted after finishing bootstrap", async () => {
+      application = CreateApplication({
+        // @ts-expect-error Testing
+        name: "testing",
+        services: {},
+      });
+      await application.bootstrap(BASIC_BOOT);
+
+      expect(application.booted).toBe(true);
+    });
+
+    it("forbids double booting", async () => {
+      application = CreateApplication({
+        // @ts-expect-error Testing
+        name: "testing",
+        services: {},
+      });
+      await application.bootstrap(BASIC_BOOT);
+
+      // I guess this works 🤷‍♀️
+      expect.assertions(1);
+      try {
+        await application.bootstrap(BASIC_BOOT);
+      } catch (error) {
+        expect(error).toBeDefined();
+      }
+    });
+  });
+
+  describe("Wiring", () => {
+    it("should add library to TServiceParams", async () => {
+      let observed: unknown;
+      application = CreateApplication({
+        // @ts-expect-error Testing
+        name: "testing",
+        priorityInit: ["First"],
+        services: {
+          // @ts-expect-error Testing
+          First({ testing }: TServiceParams) {
+            observed = testing;
+          },
+        },
+      });
+      await application.bootstrap(BASIC_BOOT);
+      expect(observed).toBeDefined();
+    });
+
+    it("should use service context as keys in assembled api", async () => {
+      let foo: string;
+      application = CreateApplication({
+        // @ts-expect-error Testing
+        name: "testing",
+        priorityInit: ["First"],
+        services: {
+          First() {
+            return { foo: "bar" };
+          },
+          // @ts-expect-error Testing
+          Second({ testing }: TServiceParams) {
+            foo = testing.First.foo;
+          },
+        },
+      });
+      await application.bootstrap(BASIC_BOOT);
+      expect(foo).toEqual("bar");
+    });
+
+    it("passes lifecycle into services", async () => {
+      let observed: unknown;
+      application = CreateApplication({
+        // @ts-expect-error Testing
+        name: "testing",
+        services: {
+          Test({ lifecycle }: TServiceParams) {
+            observed = lifecycle;
+          },
+        },
+      });
+      await application.bootstrap(BASIC_BOOT);
+      expect(observed).toBeDefined();
+    });
+
+    it("passes logger into services", async () => {
+      let observed: unknown;
+      application = CreateApplication({
+        // @ts-expect-error Testing
+        name: "testing",
+        services: {
+          Test({ logger }: TServiceParams) {
+            observed = logger;
+          },
+        },
+      });
+      await application.bootstrap(BASIC_BOOT);
+      expect(observed).toBeDefined();
+    });
+
+    it("passes scheduler into services", async () => {
+      let observed: unknown;
+      application = CreateApplication({
+        // @ts-expect-error Testing
+        name: "testing",
+        services: {
+          Test({ scheduler }: TServiceParams) {
+            observed = scheduler;
+          },
+        },
+      });
+      await application.bootstrap(BASIC_BOOT);
+      expect(observed).toBeDefined();
+    });
+
+    it("passes cache into services", async () => {
+      let observed: unknown;
+      application = CreateApplication({
+        // @ts-expect-error Testing
+        name: "testing",
+        services: {
+          Test({ cache }: TServiceParams) {
+            observed = cache;
+          },
+        },
+      });
+      await application.bootstrap(BASIC_BOOT);
+      expect(observed).toBeDefined();
+    });
+
+    it("passes event into services", async () => {
+      let observed: unknown;
+      application = CreateApplication({
+        // @ts-expect-error Testing
+        name: "testing",
+        services: {
+          Test({ event }: TServiceParams) {
+            observed = event;
+          },
+        },
+      });
+      await application.bootstrap(BASIC_BOOT);
+      expect(observed).toBeDefined();
+    });
+
+    it("passes config into services", async () => {
+      let observed: unknown;
+      application = CreateApplication({
+        // @ts-expect-error Testing
+        name: "testing",
+        services: {
+          Test({ config }: TServiceParams) {
+            observed = config;
+          },
+        },
+      });
+      await application.bootstrap(BASIC_BOOT);
+      expect(observed).toBeDefined();
+    });
+
+    it("passes context into services", async () => {
+      let observed: unknown;
+      application = CreateApplication({
+        // @ts-expect-error Testing
+        name: "testing",
+        services: {
+          Test({ context }: TServiceParams) {
+            observed = context;
+          },
+        },
+      });
+      await application.bootstrap(BASIC_BOOT);
+      expect(observed).toBeDefined();
+    });
+
+    describe("app + library interactions", () => {
+      let list: string[];
+      const LIBRARY_A = CreateLibrary({
+        // @ts-expect-error testing
+        name: "A",
+        services: {
+          AddToList: () => list.push("A"),
+        },
+      });
+      const LIBRARY_B = CreateLibrary({
+        depends: [LIBRARY_A],
+        // @ts-expect-error testing
+        name: "B",
+        services: {
+          AddToList: () => list.push("B"),
+        },
+      });
+
+      const LIBRARY_C = CreateLibrary({
+        depends: [LIBRARY_A, LIBRARY_B],
+        // @ts-expect-error testing
+        name: "C",
+        services: {
+          AddToList: () => list.push("C"),
+        },
+      });
+
+      beforeEach(() => {
+        list = [];
+      });
+
+      it("should wire libraries in the correct order", async () => {
+        application = CreateApplication({
+          libraries: [
+            //
+            LIBRARY_B,
+            LIBRARY_C,
+            LIBRARY_A,
+          ],
+          // @ts-expect-error testing
+          name: "testing",
+          services: {},
+        });
+
+        await application.bootstrap(BASIC_BOOT);
+        expect(list).toEqual(["A", "B", "C"]);
+      });
+    });
+  });
+});

--- a/src/testing/wiring.extension.spec.ts
+++ b/src/testing/wiring.extension.spec.ts
@@ -525,7 +525,7 @@ describe("Wiring", () => {
       expect(observed).toBeDefined();
     });
 
-    describe("app + library interactions", () => {
+    describe.skip("app + library interactions", () => {
       let list: string[];
       const LIBRARY_A = CreateLibrary({
         // @ts-expect-error testing

--- a/src/testing/wiring.extension.spec.ts
+++ b/src/testing/wiring.extension.spec.ts
@@ -1,12 +1,16 @@
-import exp from "constants";
-
 import {
   ApplicationDefinition,
   BootstrapException,
   BootstrapOptions,
   CreateApplication,
   CreateLibrary,
+  InternalDefinition,
+  LIB_BOILERPLATE,
+  LOADED_LIFECYCLES,
+  LOADED_MODULES,
+  MODULE_MAPPINGS,
   OptionalModuleConfiguration,
+  REVERSE_MODULE_MAPPING,
   ServiceMap,
   TServiceParams,
   WIRE_PROJECT,
@@ -32,104 +36,102 @@ describe("Wiring", () => {
     jest.restoreAllMocks();
   });
 
-  describe("Basics", () => {
-    describe("CreateLibrary", () => {
-      it("should be defined", () => {
-        expect(CreateLibrary).toBeDefined();
-        expect(CreateApplication).toBeDefined();
-      });
-
-      it("should create a library without services", () => {
-        const library = CreateLibrary({
-          // @ts-expect-error For unit testing
-          name: "testing",
-          services: {},
-        });
-
-        expect(library).toBeDefined();
-        expect(library.name).toBe("testing");
-        expect(library.services).toEqual({});
-      });
-
-      it("properly wires services when creating a library", async () => {
-        const testService = jest.fn();
-        const library = CreateLibrary({
-          // @ts-expect-error For unit testing
-          name: "testing",
-          services: { testService },
-        });
-        await library[WIRE_PROJECT](undefined);
-        // Check that the service is wired correctly
-        expect(testService).toHaveBeenCalled();
-      });
-      it("throws an error with invalid service definition", () => {
-        expect(() => {
-          CreateLibrary({
-            // @ts-expect-error For unit testing
-            name: "testing",
-            services: { InvalidService: undefined },
-          });
-        }).toThrow("INVALID_SERVICE_DEFINITION");
-      });
-
-      it("creates multiple libraries with distinct configurations", () => {
-        const libraryOne = CreateLibrary({
-          // @ts-expect-error For unit testing
-          name: "testing",
-          services: {},
-        });
-        const libraryTwo = CreateLibrary({
-          // @ts-expect-error For unit testing
-          name: "testing_second",
-          services: {},
-        });
-        expect(libraryOne.name).not.toBe(libraryTwo.name);
-      });
-
-      it("throws a BootstrapException for an invalid service definition in a library", () => {
-        expect(() => {
-          CreateLibrary({
-            // @ts-expect-error For unit testing
-            name: "testing",
-            services: { invalidServiceDefinition: undefined },
-          });
-        }).toThrow(BootstrapException);
-      });
-
-      it("throws a BootstrapException if no name is provided for the library", () => {
-        expect(() => {
-          // @ts-expect-error that's the test
-          CreateLibrary({ name: "", services: {} });
-        }).toThrow(BootstrapException);
-      });
+  describe("CreateLibrary", () => {
+    it("should be defined", () => {
+      expect(CreateLibrary).toBeDefined();
+      expect(CreateApplication).toBeDefined();
     });
 
-    describe("CreateApplication Function", () => {
-      it("should create an application with specified services and libraries", () => {
-        const testService = jest.fn();
-        const testLibrary = CreateLibrary({
+    it("should create a library without services", () => {
+      const library = CreateLibrary({
+        // @ts-expect-error For unit testing
+        name: "testing",
+        services: {},
+      });
+
+      expect(library).toBeDefined();
+      expect(library.name).toBe("testing");
+      expect(library.services).toEqual({});
+    });
+
+    it("properly wires services when creating a library", async () => {
+      const testService = jest.fn();
+      const library = CreateLibrary({
+        // @ts-expect-error For unit testing
+        name: "testing",
+        services: { testService },
+      });
+      await library[WIRE_PROJECT](undefined);
+      // Check that the service is wired correctly
+      expect(testService).toHaveBeenCalled();
+    });
+    it("throws an error with invalid service definition", () => {
+      expect(() => {
+        CreateLibrary({
           // @ts-expect-error For unit testing
           name: "testing",
-          services: { TestService: testService },
+          services: { InvalidService: undefined },
         });
+      }).toThrow("INVALID_SERVICE_DEFINITION");
+    });
 
-        application = CreateApplication({
-          libraries: [testLibrary],
-          // @ts-expect-error For unit testing
-          name: "testing_app",
-          services: { AppService: jest.fn() },
-        });
-
-        expect(application).toBeDefined();
-        expect(application.name).toBe("testing_app");
-        expect(Object.keys(application.services).length).toBe(1);
-        expect(application.libraries.length).toBe(1);
-        expect(application.libraries[0]).toBe(testLibrary);
+    it("creates multiple libraries with distinct configurations", () => {
+      const libraryOne = CreateLibrary({
+        // @ts-expect-error For unit testing
+        name: "testing",
+        services: {},
       });
+      const libraryTwo = CreateLibrary({
+        // @ts-expect-error For unit testing
+        name: "testing_second",
+        services: {},
+      });
+      expect(libraryOne.name).not.toBe(libraryTwo.name);
+    });
+
+    it("throws a BootstrapException for an invalid service definition in a library", () => {
+      expect(() => {
+        CreateLibrary({
+          // @ts-expect-error For unit testing
+          name: "testing",
+          services: { invalidServiceDefinition: undefined },
+        });
+      }).toThrow(BootstrapException);
+    });
+
+    it("throws a BootstrapException if no name is provided for the library", () => {
+      expect(() => {
+        // @ts-expect-error that's the test
+        CreateLibrary({ name: "", services: {} });
+      }).toThrow(BootstrapException);
     });
   });
 
-  describe("Application Lifecycle", () => {
+  describe("CreateApplication", () => {
+    it("should create an application with specified services and libraries", () => {
+      const testService = jest.fn();
+      const testLibrary = CreateLibrary({
+        // @ts-expect-error For unit testing
+        name: "testing",
+        services: { TestService: testService },
+      });
+
+      application = CreateApplication({
+        libraries: [testLibrary],
+        // @ts-expect-error For unit testing
+        name: "testing_app",
+        services: { AppService: jest.fn() },
+      });
+
+      expect(application).toBeDefined();
+      expect(application.name).toBe("testing_app");
+      expect(Object.keys(application.services).length).toBe(1);
+      expect(application.libraries.length).toBe(1);
+      expect(application.libraries[0]).toBe(testLibrary);
+    });
+  });
+
+  describe("Lifecycle", () => {
     beforeEach(() => {
       application = CreateApplication({
         // @ts-expect-error For unit testing
@@ -230,7 +232,7 @@ describe("Wiring", () => {
       expect(mockCallback).toHaveBeenCalled();
     });
 
-    it("triggers fail-fast on catastrophic bootstrap errors", async () => {
+    it("exits on catastrophic bootstrap errors", async () => {
       const errorMock = jest.fn().mockImplementation(() => {
         throw new Error("EXPECTED_UNIT_TESTING_ERROR");
       });
@@ -382,6 +384,98 @@ describe("Wiring", () => {
     });
   });
 
+  describe("Boot Phase", () => {
+    it("phase should be bootstrap during boot", async () => {
+      let i: string;
+      application = CreateApplication({
+        // @ts-expect-error Testing
+        name: "testing",
+        services: {
+          Service({ internal }: TServiceParams) {
+            i = internal.boot.phase;
+          },
+        },
+      });
+      await application.bootstrap(BASIC_BOOT);
+
+      expect(i).toBe("bootstrap");
+    });
+
+    it("phase should be running when finished booting", async () => {
+      let i: InternalDefinition;
+      application = CreateApplication({
+        // @ts-expect-error Testing
+        name: "testing",
+        services: {
+          Service({ internal }: TServiceParams) {
+            i = internal;
+          },
+        },
+      });
+      await application.bootstrap(BASIC_BOOT);
+
+      expect(i.boot.phase).toBe("running");
+    });
+
+    it("phase should be teardown after teardown starts", async () => {
+      let i: string;
+      application = CreateApplication({
+        // @ts-expect-error Testing
+        name: "testing",
+        services: {
+          Service({ internal, lifecycle }: TServiceParams) {
+            lifecycle.onPreShutdown(() => {
+              i = internal.boot.phase;
+            });
+          },
+        },
+      });
+      await application.bootstrap(BASIC_BOOT);
+      await application.teardown();
+      application = undefined;
+
+      expect(i).toBe("teardown");
+    });
+  });
+
+  describe("Teardown", () => {
+    it("phase should be teardown after teardown starts", async () => {
+      let i: string;
+      application = CreateApplication({
+        // @ts-expect-error Testing
+        name: "testing",
+        services: {
+          Service({ internal, lifecycle }: TServiceParams) {
+            lifecycle.onPreShutdown(() => {
+              i = internal.boot.phase;
+            });
+          },
+        },
+      });
+      await application.bootstrap(BASIC_BOOT);
+      await application.teardown();
+      application = undefined;
+
+      expect(i).toBe("teardown");
+    });
+  });
+
+  describe("Internal Variable Usage", () => {
+    it("populates maps during bootstrap", async () => {
+      application = CreateApplication({
+        // @ts-expect-error Testing
+        name: "testing",
+        services: {},
+      });
+      await application.bootstrap(BASIC_BOOT);
+      expect(MODULE_MAPPINGS.size).not.toEqual(0);
+      expect(LOADED_MODULES.size).not.toEqual(0);
+      expect(REVERSE_MODULE_MAPPING.size).not.toEqual(0);
+      expect(LOADED_LIFECYCLES.size).not.toEqual(0);
+      expect(LIB_BOILERPLATE).toBeDefined();
+    });
+  });
+
   describe("Wiring", () => {
     it("should add library to TServiceParams", async () => {
       let observed: unknown;
@@ -524,54 +618,91 @@ describe("Wiring", () => {
       await application.bootstrap(BASIC_BOOT);
       expect(observed).toBeDefined();
     });
+  });
 
-    describe.skip("app + library interactions", () => {
-      let list: string[];
-      const LIBRARY_A = CreateLibrary({
+  describe("Application + Library interactions", () => {
+    let list: string[];
+    const LIBRARY_A = CreateLibrary({
+      // @ts-expect-error testing
+      name: "A",
+      services: {
+        AddToList: () => list.push("A"),
+      },
+    });
+    const LIBRARY_B = CreateLibrary({
+      depends: [LIBRARY_A],
+      // @ts-expect-error testing
+      name: "B",
+      services: {
+        AddToList: () => list.push("B"),
+      },
+    });
+
+    const LIBRARY_C = CreateLibrary({
+      depends: [LIBRARY_A, LIBRARY_B],
+      // @ts-expect-error testing
+      name: "C",
+      services: {
+        AddToList: () => list.push("C"),
+      },
+    });
+
+    beforeEach(() => {
+      list = [];
+    });
+
+    it("should wire libraries in the correct order", async () => {
+      // Provided in C -> A -> B
+      // Needs to be loaded in A -> B -> C
+      application = CreateApplication({
+        libraries: [LIBRARY_C, LIBRARY_A, LIBRARY_B],
         // @ts-expect-error testing
-        name: "A",
-        services: {
-          AddToList: () => list.push("A"),
-        },
+        name: "testing",
+        services: {},
       });
-      const LIBRARY_B = CreateLibrary({
-        depends: [LIBRARY_A],
+
+      await application.bootstrap(BASIC_BOOT);
+      expect(list).toEqual(["A", "B", "C"]);
+    });
+
+    it("should throw errors if a dependency is missing from the app", async () => {
+      application = CreateApplication({
+        libraries: [LIBRARY_C, LIBRARY_B],
         // @ts-expect-error testing
-        name: "B",
-        services: {
-          AddToList: () => list.push("B"),
-        },
+        name: "testing",
+        services: {},
       });
+      const failFastSpy = jest
+        .spyOn(process, "exit")
+        .mockImplementation(FAKE_EXIT);
+      expect.assertions(1);
+      await application.bootstrap(BASIC_BOOT);
+      expect(failFastSpy).toHaveBeenCalled();
+    });
 
-      const LIBRARY_C = CreateLibrary({
-        depends: [LIBRARY_A, LIBRARY_B],
+    it("should allow name compatible library substitutions", async () => {
+      application = CreateApplication({
+        libraries: [
+          LIBRARY_C,
+          LIBRARY_B,
+          CreateLibrary({
+            // @ts-expect-error testing
+            name: "A",
+            services: {
+              AddToList: () => list.push("A"),
+            },
+          }),
+        ],
         // @ts-expect-error testing
-        name: "C",
-        services: {
-          AddToList: () => list.push("C"),
-        },
+        name: "testing",
+        services: {},
       });
-
-      beforeEach(() => {
-        list = [];
-      });
-
-      it("should wire libraries in the correct order", async () => {
-        application = CreateApplication({
-          libraries: [
-            //
-            LIBRARY_B,
-            LIBRARY_C,
-            LIBRARY_A,
-          ],
-          // @ts-expect-error testing
-          name: "testing",
-          services: {},
-        });
-
-        await application.bootstrap(BASIC_BOOT);
-        expect(list).toEqual(["A", "B", "C"]);
-      });
+      const failFastSpy = jest
+        .spyOn(process, "exit")
+        .mockImplementation(FAKE_EXIT);
+      await application.bootstrap(BASIC_BOOT);
+      expect(list).toEqual(["A", "B", "C"]);
+      expect(failFastSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/testing/wiring.spec.ts
+++ b/src/testing/wiring.spec.ts
@@ -1,5 +1,3 @@
-import internal from "stream";
-
 import {
   ApplicationDefinition,
   BootstrapException,

--- a/src/testing/wiring.spec.ts
+++ b/src/testing/wiring.spec.ts
@@ -20,7 +20,7 @@ import {
 const FAKE_EXIT = (() => {}) as () => never;
 
 const BASIC_BOOT = {
-  configuration: { boilerplate: { LOG_LEVEL: "error" } },
+  configuration: { boilerplate: { LOG_LEVEL: "silent" } },
 } as BootstrapOptions;
 
 describe("Wiring", () => {
@@ -118,14 +118,15 @@ describe("Wiring", () => {
       });
 
       application = CreateApplication({
+        configurationLoaders: [],
         libraries: [testLibrary],
         // @ts-expect-error For unit testing
-        name: "testing_app",
+        name: "testing",
         services: { AppService: jest.fn() },
       });
 
       expect(application).toBeDefined();
-      expect(application.name).toBe("testing_app");
+      expect(application.name).toBe("testing");
       expect(Object.keys(application.services).length).toBe(1);
       expect(application.libraries.length).toBe(1);
       expect(application.libraries[0]).toBe(testLibrary);
@@ -135,8 +136,9 @@ describe("Wiring", () => {
   describe("Lifecycle", () => {
     beforeEach(() => {
       application = CreateApplication({
+        configurationLoaders: [],
         // @ts-expect-error For unit testing
-        name: "testing_app",
+        name: "testing",
         services: {},
       });
     });
@@ -148,8 +150,9 @@ describe("Wiring", () => {
       const spyBootstrap = jest.fn();
       const spyReady = jest.fn();
       application = CreateApplication({
+        configurationLoaders: [],
         // @ts-expect-error For unit testing
-        name: "testing_app",
+        name: "testing",
         services: {
           spy({ lifecycle }: TServiceParams) {
             lifecycle.onPreInit(() => spyPreInit());
@@ -186,8 +189,9 @@ describe("Wiring", () => {
       const mockBootstrap = jest.fn();
       const mockReady = jest.fn();
       application = CreateApplication({
+        configurationLoaders: [],
         // @ts-expect-error For unit testing
-        name: "testing_app",
+        name: "testing",
         services: {
           spy({ lifecycle }: TServiceParams) {
             lifecycle.onPreInit(() => mockPreInit());
@@ -217,8 +221,9 @@ describe("Wiring", () => {
       const mockCallback = jest.fn();
 
       application = CreateApplication({
+        configurationLoaders: [],
         // @ts-expect-error For unit testing
-        name: "testing_app",
+        name: "testing",
         services: {
           spy({ lifecycle }: TServiceParams) {
             lifecycle.onBootstrap(() => mockCallback());
@@ -239,8 +244,9 @@ describe("Wiring", () => {
       });
 
       application = CreateApplication({
+        configurationLoaders: [],
         // @ts-expect-error For unit testing
-        name: "testing_app",
+        name: "testing",
         services: {
           spy({ lifecycle }: TServiceParams) {
             lifecycle.onBootstrap(() => errorMock());
@@ -264,8 +270,9 @@ describe("Wiring", () => {
       const executionOrder: string[] = [];
 
       application = CreateApplication({
+        configurationLoaders: [],
         // @ts-expect-error For unit testing
-        name: "testing_app",
+        name: "testing",
         services: {
           spy({ lifecycle }: TServiceParams) {
             lifecycle.onBootstrap(
@@ -293,8 +300,9 @@ describe("Wiring", () => {
       const executionOrder: string[] = [];
 
       application = CreateApplication({
+        configurationLoaders: [],
         // @ts-expect-error For unit testing
-        name: "testing_app",
+        name: "testing",
         services: {
           spy({ lifecycle }: TServiceParams) {
             lifecycle.onBootstrap(
@@ -322,6 +330,7 @@ describe("Wiring", () => {
       it("starts off empty", async () => {
         let list: LifecycleStages[];
         application = CreateApplication({
+          configurationLoaders: [],
           // @ts-expect-error Testing
           name: "testing",
           services: {
@@ -339,6 +348,7 @@ describe("Wiring", () => {
       it("tracks onPreInit", async () => {
         let list: LifecycleStages[];
         application = CreateApplication({
+          configurationLoaders: [],
           // @ts-expect-error Testing
           name: "testing",
           services: {
@@ -356,6 +366,7 @@ describe("Wiring", () => {
       it("tracks onPostConfig", async () => {
         let list: LifecycleStages[];
         application = CreateApplication({
+          configurationLoaders: [],
           // @ts-expect-error Testing
           name: "testing",
           services: {
@@ -373,6 +384,7 @@ describe("Wiring", () => {
       it("tracks onPreInit", async () => {
         let list: LifecycleStages[];
         application = CreateApplication({
+          configurationLoaders: [],
           // @ts-expect-error Testing
           name: "testing",
           services: {
@@ -390,6 +402,7 @@ describe("Wiring", () => {
       it("tracks ready", async () => {
         let i: InternalDefinition;
         application = CreateApplication({
+          configurationLoaders: [],
           // @ts-expect-error Testing
           name: "testing",
           services: {
@@ -410,6 +423,7 @@ describe("Wiring", () => {
       it("does not change by start of teardown", async () => {
         let list: LifecycleStages[];
         application = CreateApplication({
+          configurationLoaders: [],
           // @ts-expect-error Testing
           name: "testing",
           services: {
@@ -429,6 +443,7 @@ describe("Wiring", () => {
       it("tracks preShutdown", async () => {
         let list: LifecycleStages[];
         application = CreateApplication({
+          configurationLoaders: [],
           // @ts-expect-error Testing
           name: "testing",
           services: {
@@ -454,6 +469,7 @@ describe("Wiring", () => {
       it("tracks shutdownStart", async () => {
         let list: LifecycleStages[];
         application = CreateApplication({
+          configurationLoaders: [],
           // @ts-expect-error Testing
           name: "testing",
           services: {
@@ -480,6 +496,7 @@ describe("Wiring", () => {
       it("tracks shutdownComplete", async () => {
         let i: InternalDefinition;
         application = CreateApplication({
+          configurationLoaders: [],
           // @ts-expect-error Testing
           name: "testing",
           services: {
@@ -507,6 +524,7 @@ describe("Wiring", () => {
     it("should prioritize services with priorityInit", async () => {
       const list = [] as string[];
       application = CreateApplication({
+        configurationLoaders: [],
         // @ts-expect-error Testing
         name: "testing",
         priorityInit: ["First", "Second"],
@@ -530,6 +548,7 @@ describe("Wiring", () => {
     it("throws errors with missing priority services", async () => {
       expect(() => {
         CreateApplication({
+          configurationLoaders: [],
           // @ts-expect-error Testing
           name: "testing",
           priorityInit: ["Testing"],
@@ -542,6 +561,7 @@ describe("Wiring", () => {
 
     it("sets booted after finishing bootstrap", async () => {
       application = CreateApplication({
+        configurationLoaders: [],
         // @ts-expect-error Testing
         name: "testing",
         services: {},
@@ -553,6 +573,7 @@ describe("Wiring", () => {
 
     it("forbids double booting", async () => {
       application = CreateApplication({
+        configurationLoaders: [],
         // @ts-expect-error Testing
         name: "testing",
         services: {},
@@ -573,6 +594,7 @@ describe("Wiring", () => {
     it("phase should be bootstrap during boot", async () => {
       let i: string;
       application = CreateApplication({
+        configurationLoaders: [],
         // @ts-expect-error Testing
         name: "testing",
         services: {
@@ -589,6 +611,7 @@ describe("Wiring", () => {
     it("phase should be running when finished booting", async () => {
       let i: InternalDefinition;
       application = CreateApplication({
+        configurationLoaders: [],
         // @ts-expect-error Testing
         name: "testing",
         services: {
@@ -605,6 +628,7 @@ describe("Wiring", () => {
     it("phase should be teardown after teardown starts", async () => {
       let i: string;
       application = CreateApplication({
+        configurationLoaders: [],
         // @ts-expect-error Testing
         name: "testing",
         services: {
@@ -627,6 +651,7 @@ describe("Wiring", () => {
     it("phase should be teardown after teardown starts", async () => {
       let i: string;
       application = CreateApplication({
+        configurationLoaders: [],
         // @ts-expect-error Testing
         name: "testing",
         services: {
@@ -648,6 +673,7 @@ describe("Wiring", () => {
   describe("Internal Variable Usage", () => {
     it("populates maps during bootstrap", async () => {
       application = CreateApplication({
+        configurationLoaders: [],
         // @ts-expect-error Testing
         name: "testing",
         services: {},
@@ -665,6 +691,7 @@ describe("Wiring", () => {
     it("should add library to TServiceParams", async () => {
       let observed: unknown;
       application = CreateApplication({
+        configurationLoaders: [],
         // @ts-expect-error Testing
         name: "testing",
         priorityInit: ["First"],
@@ -682,6 +709,7 @@ describe("Wiring", () => {
     it("should use service context as keys in assembled api", async () => {
       let foo: string;
       application = CreateApplication({
+        configurationLoaders: [],
         // @ts-expect-error Testing
         name: "testing",
         priorityInit: ["First"],
@@ -702,6 +730,7 @@ describe("Wiring", () => {
     it("passes lifecycle into services", async () => {
       let observed: unknown;
       application = CreateApplication({
+        configurationLoaders: [],
         // @ts-expect-error Testing
         name: "testing",
         services: {
@@ -717,6 +746,7 @@ describe("Wiring", () => {
     it("passes logger into services", async () => {
       let observed: unknown;
       application = CreateApplication({
+        configurationLoaders: [],
         // @ts-expect-error Testing
         name: "testing",
         services: {
@@ -732,6 +762,7 @@ describe("Wiring", () => {
     it("passes scheduler into services", async () => {
       let observed: unknown;
       application = CreateApplication({
+        configurationLoaders: [],
         // @ts-expect-error Testing
         name: "testing",
         services: {
@@ -747,6 +778,7 @@ describe("Wiring", () => {
     it("passes cache into services", async () => {
       let observed: unknown;
       application = CreateApplication({
+        configurationLoaders: [],
         // @ts-expect-error Testing
         name: "testing",
         services: {
@@ -762,6 +794,7 @@ describe("Wiring", () => {
     it("passes event into services", async () => {
       let observed: unknown;
       application = CreateApplication({
+        configurationLoaders: [],
         // @ts-expect-error Testing
         name: "testing",
         services: {
@@ -777,6 +810,7 @@ describe("Wiring", () => {
     it("passes config into services", async () => {
       let observed: unknown;
       application = CreateApplication({
+        configurationLoaders: [],
         // @ts-expect-error Testing
         name: "testing",
         services: {
@@ -792,6 +826,7 @@ describe("Wiring", () => {
     it("passes context into services", async () => {
       let observed: unknown;
       application = CreateApplication({
+        configurationLoaders: [],
         // @ts-expect-error Testing
         name: "testing",
         services: {
@@ -852,6 +887,7 @@ describe("Wiring", () => {
 
     it("should throw errors if a dependency is missing from the app", async () => {
       application = CreateApplication({
+        configurationLoaders: [],
         libraries: [LIBRARY_C, LIBRARY_B],
         // @ts-expect-error testing
         name: "testing",
@@ -867,6 +903,7 @@ describe("Wiring", () => {
 
     it("should allow name compatible library substitutions", async () => {
       application = CreateApplication({
+        configurationLoaders: [],
         libraries: [
           LIBRARY_C,
           LIBRARY_B,

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -3,6 +3,14 @@
   "compilerOptions": {
     "noImplicitAny": true
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "tmp", "dist","src/**/*.spec.ts"]
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "tmp",
+    "dist",
+    "src/**/*.spec.ts",
+    "src/testing"
+  ]
 }


### PR DESCRIPTION
This branch brings back unit testing for `core`. There is a growing collection of internal tweaks and refactors that are happening as a result of the tests. These may end up being significant enough to do a `0.4.x` line, since some require parallel upgrades from other libraries


- 🐛💣 the sorting order for lifecycle events is has been reversed to properly align with documentation
- 📈 negative values can be used as sort orders for lifecycle
- 🐛 libraries are now loaded in an order based on their `depends` array, instead of the sort order of `libraries` on the application
- 📈 custom config loaders 
- 🐛 bugfix to file selection for loading configs