### PR TITLE
Multiboot support

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "repository": {
     "url": "git+https://github.com/Digital-Alchemy-TS/core"
   },
-  "version": "0.3.11",
+  "version": "0.3.12",
   "author": {
     "url": "https://github.com/zoe-codez",
     "name": "Zoe Codez"

--- a/src/extensions/internal.extension.ts
+++ b/src/extensions/internal.extension.ts
@@ -21,6 +21,7 @@ import {
   START,
   TBlackHole,
   TContext,
+  TLoadableChildLifecycle,
   YEAR,
 } from "..";
 
@@ -240,6 +241,7 @@ export class InternalDefinition {
      * Roughly speaking, what's the application doing? Mostly useful for debugging
      */
     phase: Phase;
+    lifecycleHooks: Map<string, TLoadableChildLifecycle>;
   };
   public utils = new InternalUtils();
 

--- a/src/extensions/internal.extension.ts
+++ b/src/extensions/internal.extension.ts
@@ -22,6 +22,8 @@ import {
   TBlackHole,
   TContext,
   TLoadableChildLifecycle,
+  TModuleMappings,
+  TResolvedModuleMappings,
   YEAR,
 } from "..";
 
@@ -241,7 +243,22 @@ export class InternalDefinition {
      * Roughly speaking, what's the application doing? Mostly useful for debugging
      */
     phase: Phase;
+
+    /**
+     * Registry for various lifecycle events that were registered by services
+     */
     lifecycleHooks: Map<string, TLoadableChildLifecycle>;
+
+    /**
+     * association of projects to { service : Declaration Function }
+     */
+    moduleMappings: Map<string, TModuleMappings>;
+
+    /**
+     * association of projects to { service : Initialized Service }
+     */
+    loadedModules: Map<string, TResolvedModuleMappings>;
+    startup: Date;
   };
   public utils = new InternalUtils();
 

--- a/src/extensions/lifecycle.extension.ts
+++ b/src/extensions/lifecycle.extension.ts
@@ -1,0 +1,59 @@
+import {
+  CallbackList,
+  LIFECYCLE_STAGES,
+  LifecycleCallback,
+  LifecycleStages,
+  TLoadableChildLifecycle,
+} from "../helpers";
+import { InternalDefinition } from "./internal.extension";
+import { ILogger } from "./logger.extension";
+
+export function CreateChildLifecycle(
+  internal: InternalDefinition,
+  logger: ILogger,
+): TLoadableChildLifecycle {
+  const childCallbacks = {} as Record<LifecycleStages, CallbackList>;
+
+  const [
+    // ! This list must be sorted!
+    onPreInit,
+    onPostConfig,
+    onBootstrap,
+    onReady,
+    onPreShutdown,
+    onShutdownStart,
+    onShutdownComplete,
+  ] = LIFECYCLE_STAGES.map((stage) => {
+    childCallbacks[stage] = [];
+    return (callback: LifecycleCallback, priority?: number) => {
+      if (internal.boot.completedLifecycleEvents.has(stage)) {
+        // this is makes "earliest run time" logic way easier to implement
+        // intended mode of operation
+        if (["PreInit", "PostConfig", "Bootstrap", "Ready"].includes(stage)) {
+          setImmediate(async () => await callback());
+          return;
+        }
+        // What does this mean in reality?
+        // Probably a broken unit test, I really don't know what workflow would cause this
+        logger.fatal(
+          { name: CreateChildLifecycle },
+          `on${stage} late attach, cannot attach callback`,
+        );
+        return;
+      }
+      childCallbacks[stage].push([callback, priority]);
+    };
+  });
+
+  return {
+    getCallbacks: (stage: LifecycleStages) =>
+      childCallbacks[stage] as CallbackList,
+    onBootstrap,
+    onPostConfig,
+    onPreInit,
+    onPreShutdown,
+    onReady,
+    onShutdownComplete,
+    onShutdownStart,
+  };
+}

--- a/src/extensions/wiring.extension.ts
+++ b/src/extensions/wiring.extension.ts
@@ -15,7 +15,6 @@ import {
   eachSeries,
   GetApis,
   GetApisResult,
-  LibraryDefinition,
   LifecyclePrioritizedCallback,
   LifecycleStages,
   LoadedModules,
@@ -24,9 +23,6 @@ import {
   ServiceMap,
   StringConfig,
   TLifecycleBase,
-  TLoadableChildLifecycle,
-  TModuleMappings,
-  TResolvedModuleMappings,
   TServiceParams,
   TServiceReturn,
   UP,
@@ -112,422 +108,408 @@ const PRE_CALLBACKS_START = 0;
 // unclear if this variable even serves a purpose beyond types
 export let LIB_BOILERPLATE: ReturnType<typeof CreateBoilerplate>;
 
-export const CreateApplication = (() => {
-  // #MARK: Variables
-  // These are resettable variables, which are scoped to outside the function on purpose
-  // If these were moved inside the service function, then re-running the method would result in application / library references being stranded
-  // Items like lib_boilerplate would still exist, but their lifecycles would be not accessible by the current application
-  //
-  // By moving to outside the function, the internal methods will be able to re-initialize as expected, without needing to fully rebuild every reference everywhere
-  // ... in theory
+const RUNNING_APPLICATIONS = new Map<
+  string,
+  ApplicationDefinition<ServiceMap, OptionalModuleConfiguration>
+>();
 
-  /**
-   * association of projects to { service : Declaration Function }
-   */
-  let MODULE_MAPPINGS = new Map<string, TModuleMappings>();
+// #MARK: QuickShutdown
+async function QuickShutdown(reason: string) {
+  await each([...RUNNING_APPLICATIONS.values()], async (application) => {
+    application.logger.warn({ reason }, `starting shutdown`);
+    await application.teardown();
+  });
+}
 
-  /**
-   * association of projects to { service : Initialized Service }
-   */
-  let LOADED_MODULES = new Map<string, TResolvedModuleMappings>();
+// #MARK: processEvents
+const processEvents = new Map([
+  [
+    "SIGTERM",
+    async () => {
+      await QuickShutdown("SIGTERM");
+      exit();
+    },
+  ],
+  [
+    "SIGINT",
+    async () => {
+      await QuickShutdown("SIGINT");
+      exit();
+    },
+  ],
+  // ["uncaughtException", () => {}],
+  // ["unhandledRejection", (reason, promise) => {}],
+]);
 
-  // heisenberg's variables. it's probably here, but maybe not
-  // let scheduler: (context: TContext) => TScheduler;
-  let logger: ILogger;
+const BOILERPLATE = (internal: InternalDefinition) =>
+  internal.boot.loadedModules.get("boilerplate") as GetApis<
+    ReturnType<typeof CreateBoilerplate>
+  >;
+
+// #MARK: CreateApplication
+export function CreateApplication<
+  S extends ServiceMap,
+  C extends OptionalModuleConfiguration,
+>({
+  name,
+  services = {} as S,
+  configurationLoaders,
+  libraries = [],
+  configuration = {} as C,
+  priorityInit = [],
+}: ApplicationConfigurationOptions<S, C>) {
   let internal: InternalDefinition;
-  // (re)defined at bootstrap
-  // exporting a let makes me feel dirty inside
-  // at least it's only for testing
 
-  // #MARK: processEvents
-  const processEvents = new Map([
-    [
-      "SIGTERM",
-      async () => {
-        logger.warn({ name: "SIGTERM" }, `starting`);
-        await Teardown();
-        exit();
-      },
-    ],
-    [
-      "SIGINT",
-      async () => {
-        logger.warn({ name: "SIGINT" }, `starting`);
-        await Teardown();
-        exit();
-      },
-    ],
-    // ["uncaughtException", () => {}],
-    // ["unhandledRejection", (reason, promise) => {}],
-  ]);
-
-  const BOILERPLATE = () =>
-    LOADED_MODULES.get("boilerplate") as GetApis<
-      ReturnType<typeof CreateBoilerplate>
-    >;
-
-  // #MARK: CreateApplication
-  function CreateApplication<
-    S extends ServiceMap,
-    C extends OptionalModuleConfiguration,
-  >({
-    name,
-    services = {} as S,
-    configurationLoaders,
-    libraries = [],
-    configuration = {} as C,
-    priorityInit = [],
-  }: ApplicationConfigurationOptions<S, C>) {
-    priorityInit.forEach((name) => {
-      if (!is.function(services[name])) {
+  priorityInit.forEach((name) => {
+    if (!is.function(services[name])) {
+      throw new BootstrapException(
+        WIRING_CONTEXT,
+        "MISSING_PRIORITY_SERVICE",
+        `${name} was listed as priority init, but was not found in services`,
+      );
+    }
+  });
+  const serviceApis = {} as GetApisResult<ServiceMap>;
+  const application = {
+    [WIRE_PROJECT]: async (internal: InternalDefinition) => {
+      const lifecycle = CreateChildLifecycle(internal, application.logger);
+      internal.boot.lifecycleHooks.set(name, lifecycle);
+      BOILERPLATE(internal)?.configuration?.[LOAD_PROJECT](
+        name as keyof LoadedModules,
+        configuration,
+      );
+      await eachSeries(
+        WireOrder(priorityInit, Object.keys(services)),
+        async (service) => {
+          serviceApis[service] = await WireService(
+            name,
+            service,
+            services[service],
+            lifecycle,
+            internal,
+          );
+        },
+      );
+      return lifecycle;
+    },
+    booted: false,
+    bootstrap: async (options) => {
+      if (application.booted) {
         throw new BootstrapException(
           WIRING_CONTEXT,
-          "MISSING_PRIORITY_SERVICE",
-          `${name} was listed as priority init, but was not found in services`,
+          "DOUBLE_BOOT",
+          "Application is already booted! Cannot bootstrap again",
         );
       }
-    });
-    const serviceApis = {} as GetApisResult<ServiceMap>;
-    const application = {
-      [WIRE_PROJECT]: async (internal: InternalDefinition) => {
-        const lifecycle = CreateChildLifecycle(internal, logger);
-        internal.boot.lifecycleHooks.set(name, lifecycle);
-        BOILERPLATE()?.configuration?.[LOAD_PROJECT](
-          name as keyof LoadedModules,
-          configuration,
+      if (internal) {
+        throw new BootstrapException(
+          WIRING_CONTEXT,
+          "NO_DUAL_BOOT",
+          "Another application is already active, please terminate",
         );
-        await eachSeries(
-          WireOrder(priorityInit, Object.keys(services)),
-          async (service) => {
-            serviceApis[service] = await WireService(
-              name,
-              service,
-              services[service],
-              lifecycle,
-              internal,
-            );
-          },
+      }
+      internal = new InternalDefinition();
+      await Bootstrap(application, options, internal);
+      application.booted = true;
+      RUNNING_APPLICATIONS.set(name, application);
+    },
+    configuration,
+    configurationLoaders,
+    libraries,
+    logger: undefined,
+    name,
+    priorityInit,
+    serviceApis,
+    services,
+    teardown: async () => {
+      if (!application.booted) {
+        processEvents.forEach((callback, event) =>
+          process.removeListener(event, callback),
         );
-        return lifecycle;
-      },
-      booted: false,
-      bootstrap: async (options) => {
-        if (application.booted) {
-          throw new BootstrapException(
-            WIRING_CONTEXT,
-            "DOUBLE_BOOT",
-            "Application is already booted! Cannot bootstrap again",
-          );
-        }
-        await Bootstrap(application, options);
-        application.booted = true;
-      },
-      configuration,
-      configurationLoaders,
-      libraries,
-      name,
-      priorityInit,
-      serviceApis,
-      services,
-      teardown: async () => {
-        if (!application.booted) {
-          Reset();
-          return;
-        }
-        await Teardown();
-        application.booted = false;
-      },
-    } as ApplicationDefinition<S, C>;
-    return application;
-  }
-
-  // #MARK: WireService
-  async function WireService(
-    project: string,
-    service: string,
-    definition: ServiceFunction,
-    lifecycle: TLifecycleBase,
-    internal: InternalDefinition,
-  ) {
-    const mappings = MODULE_MAPPINGS.get(project) ?? {};
-    if (!is.undefined(mappings[service])) {
-      throw new BootstrapException(
-        WIRING_CONTEXT,
-        "DUPLICATE_SERVICE_NAME",
-        `${service} is already defined for ${project}`,
-      );
-    }
-    mappings[service] = definition;
-    MODULE_MAPPINGS.set(project, mappings);
-    const context = COERCE_CONTEXT(`${project}:${service}`);
-
-    // logger gets defined first, so this really is only for the start of the start of bootstrapping
-    const boilerplate = BOILERPLATE();
-    const logger = boilerplate?.logger?.context(context);
-    const loaded = LOADED_MODULES.get(project) ?? {};
-    LOADED_MODULES.set(project, loaded);
-    try {
-      logger?.trace({ name: WireService }, `initializing`);
-      const inject = Object.fromEntries(
-        [...LOADED_MODULES.keys()].map((project) => [
-          project as keyof TServiceParams,
-          LOADED_MODULES.get(project),
-        ]),
-      );
-
-      loaded[service] = (await definition({
-        ...inject,
-        cache: boilerplate?.cache,
-        config: boilerplate?.configuration?.[INJECTED_DEFINITIONS](),
-        context,
-        event: internal?.utils?.event,
-        internal,
-        lifecycle,
-        logger,
-        scheduler: boilerplate?.scheduler?.(context),
-      })) as TServiceReturn;
-
-      return loaded[service];
-    } catch (error) {
-      // Init errors at this level are considered blocking / fatal
-      // eslint-disable-next-line no-console
-      console.error("initialization error", error);
-      exit();
-    }
-  }
-
-  // #MARK: RunStageCallbacks
-  async function RunStageCallbacks(stage: LifecycleStages): Promise<string> {
-    const start = Date.now();
-    const list = [
-      // boilerplate priority
-      internal.boot.lifecycleHooks.get("boilerplate").getCallbacks(stage),
-      // children next
-      // ...
-      ...[...internal.boot.lifecycleHooks.entries()]
-        .filter(([name]) => name !== "boilerplate")
-        .map(([, thing]) => thing.getCallbacks(stage)),
-    ];
-    await eachSeries(list, async (callbacks) => {
-      if (is.empty(callbacks)) {
         return;
       }
-      const sorted = callbacks.filter(([, sort]) => sort !== undefined);
-      const quick = callbacks.filter(([, sort]) => sort === undefined);
-      const positive = [] as LifecyclePrioritizedCallback[];
-      const negative = [] as LifecyclePrioritizedCallback[];
-      sorted.forEach(([callback, priority]) => {
-        if (priority >= PRE_CALLBACKS_START) {
-          positive.push([callback, priority]);
-          return;
-        }
-        negative.push([callback, priority]);
-      });
+      await Teardown(internal, application.logger);
+      internal?.utils?.event?.removeAllListeners?.();
+      application.booted = false;
+      internal = undefined;
+    },
+  } as ApplicationDefinition<S, C>;
+  return application;
+}
 
-      // * callbacks with a priority greater than 0
-      // larger number happen first
-      await eachSeries(
-        positive.sort(([, a], [, b]) => (a < b ? UP : DOWN)),
-        async ([callback]) => await callback(),
-      );
-
-      // * callbacks without a priority
-      await each(quick, async ([callback]) => await callback());
-
-      // * callbacks with a priority less than 0
-      // smaller numbers happen last
-      await eachSeries(
-        negative.sort(([, a], [, b]) => (a > b ? UP : DOWN)),
-        async ([callback]) => await callback(),
-      );
-    });
-    internal.boot.completedLifecycleEvents.add(stage);
-    return `${Date.now() - start}ms`;
+// #MARK: WireService
+async function WireService(
+  project: string,
+  service: string,
+  definition: ServiceFunction,
+  lifecycle: TLifecycleBase,
+  internal: InternalDefinition,
+) {
+  const mappings = internal.boot.moduleMappings.get(project) ?? {};
+  if (!is.undefined(mappings[service])) {
+    throw new BootstrapException(
+      WIRING_CONTEXT,
+      "DUPLICATE_SERVICE_NAME",
+      `${service} is already defined for ${project}`,
+    );
   }
+  mappings[service] = definition;
+  internal.boot.moduleMappings.set(project, mappings);
+  const context = COERCE_CONTEXT(`${project}:${service}`);
 
-  let startup: Date;
+  // logger gets defined first, so this really is only for the start of the start of bootstrapping
+  const boilerplate = BOILERPLATE(internal);
+  const logger = boilerplate?.logger?.context(context);
+  const loaded = internal.boot.loadedModules.get(project) ?? {};
+  internal.boot.loadedModules.set(project, loaded);
+  try {
+    logger?.trace({ name: WireService }, `initializing`);
+    const inject = Object.fromEntries(
+      [...internal.boot.loadedModules.keys()].map((project) => [
+        project as keyof TServiceParams,
+        internal.boot.loadedModules.get(project),
+      ]),
+    );
 
-  // #MARK: Bootstrap
-  async function Bootstrap<
-    S extends ServiceMap,
-    C extends OptionalModuleConfiguration,
-  >(application: ApplicationDefinition<S, C>, options: BootstrapOptions = {}) {
-    if (internal) {
-      throw new BootstrapException(
-        WIRING_CONTEXT,
-        "NO_DUAL_BOOT",
-        "Another application is already active, please terminate",
-      );
-    }
-    internal = new InternalDefinition();
-    // const
-    internal.boot = {
-      application,
-      completedLifecycleEvents: new Set(),
-      lifecycleHooks: new Map(),
-      options,
-      phase: "bootstrap",
-    };
-    process.title = application.name;
-    startup = new Date();
-    try {
-      const STATS = {} as Record<string, unknown>;
-      const CONSTRUCT = {} as Record<string, unknown>;
+    loaded[service] = (await definition({
+      ...inject,
+      cache: boilerplate?.cache,
+      config: boilerplate?.configuration?.[INJECTED_DEFINITIONS](),
+      context,
+      event: internal?.utils?.event,
+      internal,
+      lifecycle,
+      logger,
+      scheduler: boilerplate?.scheduler?.(context),
+    })) as TServiceReturn;
 
-      // pre-create loaded module for boilerplate, so it can be attached to `internal`
-      // this allows it to be used as part of `internal` during boilerplate construction
-      // otherwise it'd only be there for everyone else
-      const api = {} as GetApis<ReturnType<typeof CreateBoilerplate>>;
-      internal.boilerplate = api;
-      LOADED_MODULES.set("boilerplate", api);
-
-      STATS.Construct = CONSTRUCT;
-      // * Recreate base eventemitter
-      internal.utils.event = new EventEmitter();
-      // ? Some libraries need to be aware of
-
-      // * Generate a new boilerplate module
-      LIB_BOILERPLATE = CreateBoilerplate();
-
-      // * Wire it
-      let start = Date.now();
-      await LIB_BOILERPLATE[WIRE_PROJECT](internal, WireService, logger);
-
-      CONSTRUCT.boilerplate = `${Date.now() - start}ms`;
-      // ~ configuration
-      api.configuration?.[LOAD_PROJECT](
-        LIB_BOILERPLATE.name,
-        LIB_BOILERPLATE.configuration,
-      );
-      logger = api.logger.context(WIRING_CONTEXT);
-      logger.info({ name: Bootstrap }, `[boilerplate] wiring complete`);
-
-      // * Wire in various shutdown events
-      processEvents.forEach((callback, event) => {
-        process.on(event, callback);
-        logger.trace({ event, name: Bootstrap }, "shutdown event");
-      });
-
-      // * Add in libraries
-      application.libraries ??= [];
-      const order = BuildSortOrder(application, logger);
-      await eachSeries(order, async (i) => {
-        start = Date.now();
-        logger.info({ name: Bootstrap }, `[%s] init project`, i.name);
-        await i[WIRE_PROJECT](internal, WireService, logger);
-        CONSTRUCT[i.name] = `${Date.now() - start}ms`;
-      });
-
-      logger.info({ name: Bootstrap }, `init application`);
-      // * Finally the application
-      start = Date.now();
-      await application[WIRE_PROJECT](internal, WireService, logger);
-      CONSTRUCT[application.name] = `${Date.now() - start}ms`;
-
-      // ? Configuration values provided bootstrap take priority over module level
-      if (!is.empty(options?.configuration)) {
-        api.configuration.merge(options?.configuration);
-      }
-
-      // - Kick off lifecycle
-      logger.debug(
-        { name: Bootstrap },
-        `[PreInit] running lifecycle callbacks`,
-      );
-      STATS.PreInit = await RunStageCallbacks("PreInit");
-      // - Pull in user configurations
-      logger.debug({ name: Bootstrap }, "loading configuration");
-      STATS.Configure =
-        await BOILERPLATE()?.configuration?.[INITIALIZE](application);
-      // - Run through other events in order
-      logger.debug(
-        { name: Bootstrap },
-        `[PostConfig] running lifecycle callbacks`,
-      );
-      STATS.PostConfig = await RunStageCallbacks("PostConfig");
-      logger.debug(
-        { name: Bootstrap },
-        `[Bootstrap] running lifecycle callbacks`,
-      );
-      STATS.Bootstrap = await RunStageCallbacks("Bootstrap");
-      logger.debug({ name: Bootstrap }, `[Ready] running lifecycle callbacks`);
-      STATS.Ready = await RunStageCallbacks("Ready");
-
-      STATS.Total = `${Date.now() - startup.getTime()}ms`;
-      // * App is ready!
-      logger.info(
-        options?.showExtraBootStats
-          ? { ...STATS, name: Bootstrap }
-          : { Total: STATS.Total, name: Bootstrap },
-        `🪄 [%s] application bootstrapped`,
-        application.name,
-      );
-      internal.boot.phase = "running";
-    } catch (error) {
-      if (options?.configuration?.boilerplate?.LOG_LEVEL !== "silent") {
-        // eslint-disable-next-line no-console
-        console.error("bootstrap failed", error);
-      }
-      exit();
-    }
+    return loaded[service];
+  } catch (error) {
+    // Init errors at this level are considered blocking / fatal
+    // eslint-disable-next-line no-console
+    console.error("initialization error", error);
+    exit();
   }
+}
 
-  // #MARK: Teardown
-  async function Teardown() {
-    if (!internal) {
+// #MARK: RunStageCallbacks
+async function RunStageCallbacks(
+  stage: LifecycleStages,
+  internal: InternalDefinition,
+): Promise<string> {
+  const start = Date.now();
+  const list = [
+    // boilerplate priority
+    internal.boot.lifecycleHooks.get("boilerplate").getCallbacks(stage),
+    // children next
+    // ...
+    ...[...internal.boot.lifecycleHooks.entries()]
+      .filter(([name]) => name !== "boilerplate")
+      .map(([, thing]) => thing.getCallbacks(stage)),
+  ];
+  await eachSeries(list, async (callbacks) => {
+    if (is.empty(callbacks)) {
       return;
     }
-    // * Announce
-    logger.warn({ name: Teardown }, `received teardown request`);
-    internal.boot.phase = "teardown";
-    try {
-      // * PreShutdown
-      logger.debug(
-        { name: Teardown },
-        `[PreShutdown] running lifecycle callbacks`,
-      );
-      await RunStageCallbacks("PreShutdown");
+    const sorted = callbacks.filter(([, sort]) => sort !== undefined);
+    const quick = callbacks.filter(([, sort]) => sort === undefined);
+    const positive = [] as LifecyclePrioritizedCallback[];
+    const negative = [] as LifecyclePrioritizedCallback[];
+    sorted.forEach(([callback, priority]) => {
+      if (priority >= PRE_CALLBACKS_START) {
+        positive.push([callback, priority]);
+        return;
+      }
+      negative.push([callback, priority]);
+    });
 
-      // * Formally shutting down
-      logger.info({ name: Teardown }, `tearing down application`);
-      logger.debug(
-        { name: Teardown },
-        `[ShutdownStart] running lifecycle callbacks`,
-      );
-      await RunStageCallbacks("ShutdownStart");
-      logger.debug(
-        { name: Teardown },
-        `[ShutdownComplete] running lifecycle callbacks`,
-      );
-      await RunStageCallbacks("ShutdownComplete");
-    } catch (error) {
-      // ! oof
-      logger.error(
-        { error, name: Teardown },
-        "error occurred during teardown, some lifecycle events may be incomplete",
-      );
+    // * callbacks with a priority greater than 0
+    // larger number happen first
+    await eachSeries(
+      positive.sort(([, a], [, b]) => (a < b ? UP : DOWN)),
+      async ([callback]) => await callback(),
+    );
+
+    // * callbacks without a priority
+    await each(quick, async ([callback]) => await callback());
+
+    // * callbacks with a priority less than 0
+    // smaller numbers happen last
+    await eachSeries(
+      negative.sort(([, a], [, b]) => (a > b ? UP : DOWN)),
+      async ([callback]) => await callback(),
+    );
+  });
+  internal.boot.completedLifecycleEvents.add(stage);
+  return `${Date.now() - start}ms`;
+}
+
+// #MARK: Bootstrap
+async function Bootstrap<
+  S extends ServiceMap,
+  C extends OptionalModuleConfiguration,
+>(
+  application: ApplicationDefinition<S, C>,
+  options: BootstrapOptions = {},
+  internal: InternalDefinition,
+) {
+  // const
+  internal.boot = {
+    application,
+    completedLifecycleEvents: new Set(),
+    lifecycleHooks: new Map(),
+    loadedModules: new Map(),
+    moduleMappings: new Map(),
+    options,
+    phase: "bootstrap",
+    startup: new Date(),
+  };
+  process.title = application.name;
+  try {
+    const STATS = {} as Record<string, unknown>;
+    const CONSTRUCT = {} as Record<string, unknown>;
+
+    // pre-create loaded module for boilerplate, so it can be attached to `internal`
+    // this allows it to be used as part of `internal` during boilerplate construction
+    // otherwise it'd only be there for everyone else
+    const api = {} as GetApis<ReturnType<typeof CreateBoilerplate>>;
+    internal.boilerplate = api;
+    internal.boot.loadedModules.set("boilerplate", api);
+
+    STATS.Construct = CONSTRUCT;
+    // * Recreate base eventemitter
+    internal.utils.event = new EventEmitter();
+    // ? Some libraries need to be aware of
+
+    // * Generate a new boilerplate module
+    LIB_BOILERPLATE = CreateBoilerplate();
+
+    // * Wire it
+    let start = Date.now();
+    await LIB_BOILERPLATE[WIRE_PROJECT](internal, WireService, undefined);
+
+    CONSTRUCT.boilerplate = `${Date.now() - start}ms`;
+    // ~ configuration
+    api.configuration?.[LOAD_PROJECT](
+      LIB_BOILERPLATE.name,
+      LIB_BOILERPLATE.configuration,
+    );
+    const logger = api.logger.context(WIRING_CONTEXT);
+    application.logger = logger;
+    logger.info({ name: Bootstrap }, `[boilerplate] wiring complete`);
+
+    // * Wire in various shutdown events
+    processEvents.forEach((callback, event) => {
+      process.on(event, callback);
+      logger.trace({ event, name: Bootstrap }, "shutdown event");
+    });
+
+    // * Add in libraries
+    application.libraries ??= [];
+    const order = BuildSortOrder(application, logger);
+    await eachSeries(order, async (i) => {
+      start = Date.now();
+      logger.info({ name: Bootstrap }, `[%s] init project`, i.name);
+      await i[WIRE_PROJECT](internal, WireService, logger);
+      CONSTRUCT[i.name] = `${Date.now() - start}ms`;
+    });
+
+    logger.info({ name: Bootstrap }, `init application`);
+    // * Finally the application
+    start = Date.now();
+    await application[WIRE_PROJECT](internal, WireService, logger);
+    CONSTRUCT[application.name] = `${Date.now() - start}ms`;
+
+    // ? Configuration values provided bootstrap take priority over module level
+    if (!is.empty(options?.configuration)) {
+      api.configuration.merge(options?.configuration);
     }
-    // * Final resource cleanup, attempt to reset everything possible
 
+    // - Kick off lifecycle
+    logger.debug({ name: Bootstrap }, `[PreInit] running lifecycle callbacks`);
+    STATS.PreInit = await RunStageCallbacks("PreInit", internal);
+    // - Pull in user configurations
+    logger.debug({ name: Bootstrap }, "loading configuration");
+    STATS.Configure =
+      await BOILERPLATE(internal)?.configuration?.[INITIALIZE](application);
+    // - Run through other events in order
+    logger.debug(
+      { name: Bootstrap },
+      `[PostConfig] running lifecycle callbacks`,
+    );
+    STATS.PostConfig = await RunStageCallbacks("PostConfig", internal);
+    logger.debug(
+      { name: Bootstrap },
+      `[Bootstrap] running lifecycle callbacks`,
+    );
+    STATS.Bootstrap = await RunStageCallbacks("Bootstrap", internal);
+    logger.debug({ name: Bootstrap }, `[Ready] running lifecycle callbacks`);
+    STATS.Ready = await RunStageCallbacks("Ready", internal);
+
+    STATS.Total = `${Date.now() - internal.boot.startup.getTime()}ms`;
+    // * App is ready!
     logger.info(
-      { name: Teardown, started_at: internal.utils.relativeDate(startup) },
-      `application terminated`,
+      options?.showExtraBootStats
+        ? { ...STATS, name: Bootstrap }
+        : { Total: STATS.Total, name: Bootstrap },
+      `🪄 [%s] application bootstrapped`,
+      application.name,
     );
-    Reset();
+    internal.boot.phase = "running";
+  } catch (error) {
+    if (options?.configuration?.boilerplate?.LOG_LEVEL !== "silent") {
+      // eslint-disable-next-line no-console
+      console.error("bootstrap failed", error);
+    }
+    exit();
   }
+}
 
-  // #MARK: Reset
-  function Reset() {
-    processEvents.forEach((callback, event) =>
-      process.removeListener(event, callback),
+// #MARK: Teardown
+async function Teardown(internal: InternalDefinition, logger: ILogger) {
+  if (!internal) {
+    return;
+  }
+  // * Announce
+  logger.warn({ name: Teardown }, `received teardown request`);
+  internal.boot.phase = "teardown";
+  try {
+    // * PreShutdown
+    logger.debug(
+      { name: Teardown },
+      `[PreShutdown] running lifecycle callbacks`,
     );
-    internal?.utils?.event?.removeAllListeners?.();
+    await RunStageCallbacks("PreShutdown", internal);
 
-    MODULE_MAPPINGS = new Map();
-    LOADED_MODULES = new Map();
-    internal = undefined;
-    logger = undefined;
+    // * Formally shutting down
+    logger.info({ name: Teardown }, `tearing down application`);
+    logger.debug(
+      { name: Teardown },
+      `[ShutdownStart] running lifecycle callbacks`,
+    );
+    await RunStageCallbacks("ShutdownStart", internal);
+    logger.debug(
+      { name: Teardown },
+      `[ShutdownComplete] running lifecycle callbacks`,
+    );
+    await RunStageCallbacks("ShutdownComplete", internal);
+  } catch (error) {
+    // ! oof
+    logger.error(
+      { error, name: Teardown },
+      "error occurred during teardown, some lifecycle events may be incomplete",
+    );
   }
+  // * Final resource cleanup, attempt to reset everything possible
 
-  return CreateApplication;
-})();
+  logger.info(
+    {
+      name: Teardown,
+      started_at: internal.utils.relativeDate(internal.boot.startup),
+    },
+    `application terminated`,
+  );
+  processEvents.forEach((callback, event) =>
+    process.removeListener(event, callback),
+  );
+}

--- a/src/extensions/wiring.extension.ts
+++ b/src/extensions/wiring.extension.ts
@@ -271,7 +271,7 @@ export function CreateApplication<
   C extends OptionalModuleConfiguration,
 >({
   name,
-  services,
+  services = {} as S,
   configurationLoaders,
   libraries = [],
   configuration = {} as C,

--- a/src/extensions/wiring.extension.ts
+++ b/src/extensions/wiring.extension.ts
@@ -6,17 +6,16 @@ import {
   ApplicationDefinition,
   BootstrapException,
   BootstrapOptions,
+  BuildSortOrder,
   CacheProviders,
-  CallbackList,
+  COERCE_CONTEXT,
+  CreateLibrary,
   DOWN,
   each,
   eachSeries,
   GetApis,
   GetApisResult,
-  LibraryConfigurationOptions,
   LibraryDefinition,
-  LIFECYCLE_STAGES,
-  LifecycleCallback,
   LifecyclePrioritizedCallback,
   LifecycleStages,
   LoadedModules,
@@ -24,7 +23,6 @@ import {
   ServiceFunction,
   ServiceMap,
   StringConfig,
-  TContext,
   TLifecycleBase,
   TLoadableChildLifecycle,
   TModuleMappings,
@@ -33,116 +31,26 @@ import {
   TServiceReturn,
   UP,
   WIRE_PROJECT,
+  WireOrder,
+  WIRING_CONTEXT,
 } from "../helpers";
 import { InternalDefinition, is } from ".";
 import { Cache } from "./cache.extension";
 import {
-  ConfigManager,
   Configuration,
   INITIALIZE,
   INJECTED_DEFINITIONS,
   LOAD_PROJECT,
 } from "./configuration.extension";
 import { Fetch } from "./fetch.extension";
+import { CreateChildLifecycle } from "./lifecycle.extension";
 import { ILogger, Logger, TConfigLogLevel } from "./logger.extension";
 import { Scheduler } from "./scheduler.extension";
 
-// #MARK: Variables
-// These are resettable variables, which are scoped to outside the function on purpose
-// If these were moved inside the service function, then re-running the method would result in application / library references being stranded
-// Items like lib_boilerplate would still exist, but their lifecycles would be not accessible by the current application
-//
-// By moving to outside the function, the internal methods will be able to re-initialize as expected, without needing to fully rebuild every reference everywhere
-// ... in theory
-
-/**
- * association of projects to { service : Declaration Function }
- */
-export let MODULE_MAPPINGS = new Map<string, TModuleMappings>();
-
-/**
- * association of projects to { service : Initialized Service }
- */
-export let LOADED_MODULES = new Map<string, TResolvedModuleMappings>();
-
-/**
- * Optimized reverse lookups: Declaration  Function => [project, service]
- */
-export let REVERSE_MODULE_MAPPING = new Map<
-  ServiceFunction,
-  [project: string, service: string]
->();
-
-export let LOADED_LIFECYCLES = new Map<string, TLoadableChildLifecycle>();
-
-// heisenberg's variables. it's probably here, but maybe not
-// let scheduler: (context: TContext) => TScheduler;
-let logger: ILogger;
-let internal: InternalDefinition;
-const COERCE_CONTEXT = (context: string): TContext => context as TContext;
-const WIRING_CONTEXT = COERCE_CONTEXT("boilerplate:wiring");
-// (re)defined at bootstrap
-export let LIB_BOILERPLATE: ReturnType<typeof CreateBoilerplate>;
-// exporting a let makes me feel dirty inside
-// at least it's only for testing
-
-// #MARK: processEvents
-const processEvents = new Map([
-  [
-    "SIGTERM",
-    async () => {
-      logger.warn({ name: "SIGTERM" }, `starting`);
-      await Teardown();
-      exit();
-    },
-  ],
-  [
-    "SIGINT",
-    async () => {
-      logger.warn({ name: "SIGINT" }, `starting`);
-      await Teardown();
-      exit();
-    },
-  ],
-  // ["uncaughtException", () => {}],
-  // ["unhandledRejection", (reason, promise) => {}],
-]);
-
-const BOILERPLATE = () =>
-  LOADED_MODULES.get("boilerplate") as GetApis<
-    ReturnType<typeof CreateBoilerplate>
-  >;
-
-// #MARK: ValidateLibrary
-function ValidateLibrary<S extends ServiceMap>(
-  project: string,
-  serviceList: S,
-): void | never {
-  if (is.empty(project)) {
-    throw new BootstrapException(
-      COERCE_CONTEXT("CreateLibrary"),
-      "MISSING_LIBRARY_NAME",
-      "Library name is required",
-    );
-  }
-  const services = Object.entries(serviceList);
-
-  // Find the first invalid service
-  const invalidService = services.find(
-    ([, definition]) => typeof definition !== "function",
-  );
-  if (invalidService) {
-    const [invalidServiceName, service] = invalidService;
-    throw new BootstrapException(
-      COERCE_CONTEXT("CreateLibrary"),
-      "INVALID_SERVICE_DEFINITION",
-      `Invalid service definition for '${invalidServiceName}' in library '${project}' (${typeof service}})`,
-    );
-  }
-}
-
 // #MARK: CreateBoilerplate
 function CreateBoilerplate() {
+  // ! DO NOT MOVE TO ANOTHER FILE !
+  // While it SEEMS LIKE this can be safely moved, it causes code init race conditions.
   return CreateLibrary({
     configuration: {
       CACHE_PREFIX: {
@@ -198,552 +106,428 @@ function CreateBoilerplate() {
     },
   });
 }
-
-// #MARK: WireOrder
-function WireOrder<T extends string>(priority: T[], list: T[]): T[] {
-  const out = [...(priority || [])];
-  if (!is.empty(priority)) {
-    const check = is.unique(priority);
-    if (check.length !== out.length) {
-      throw new BootstrapException(
-        WIRING_CONTEXT,
-        "DOUBLE_PRIORITY",
-        "There are duplicate items in the priority load list",
-      );
-    }
-  }
-  return [...out, ...list.filter((i) => !out.includes(i))];
-}
-
-// #MARK: CreateLibrary
-export function CreateLibrary<
-  S extends ServiceMap,
-  C extends OptionalModuleConfiguration,
->({
-  name: libraryName,
-  configuration = {} as C,
-  priorityInit,
-  services,
-  depends,
-}: LibraryConfigurationOptions<S, C>): LibraryDefinition<S, C> {
-  ValidateLibrary(libraryName, services);
-
-  const serviceApis = {} as GetApisResult<ServiceMap>;
-
-  const library = {
-    [WIRE_PROJECT]: async (internal: InternalDefinition) => {
-      const lifecycle = CreateChildLifecycle(internal);
-      // This one hasn't been loaded yet, generate an object with all the correct properties
-      LOADED_LIFECYCLES.set(libraryName, lifecycle);
-      // not defined for boilerplate (chicken & egg)
-      // manually added inside the bootstrap process
-      const config = internal?.boilerplate.configuration as ConfigManager;
-      config?.[LOAD_PROJECT](libraryName as keyof LoadedModules, configuration);
-      await eachSeries(
-        WireOrder(priorityInit, Object.keys(services)),
-        async (service) => {
-          serviceApis[service] = await WireService(
-            libraryName,
-            service,
-            services[service],
-            lifecycle,
-            internal,
-          );
-        },
-      );
-      // mental note: people should probably do all their lifecycle attachments at the base level function
-      // otherwise, it'll happen after this wire() call, and go into a black hole (worst case) or fatal error ("best" case)
-      return lifecycle;
-    },
-    configuration,
-    depends,
-    name: libraryName,
-    priorityInit,
-    serviceApis,
-    services,
-  } as LibraryDefinition<S, C>;
-  return library;
-}
-
-// #MARK: CreateApplication
-export function CreateApplication<
-  S extends ServiceMap,
-  C extends OptionalModuleConfiguration,
->({
-  name,
-  services = {} as S,
-  configurationLoaders,
-  libraries = [],
-  configuration = {} as C,
-  priorityInit = [],
-}: ApplicationConfigurationOptions<S, C>) {
-  priorityInit.forEach((name) => {
-    if (!is.function(services[name])) {
-      throw new BootstrapException(
-        WIRING_CONTEXT,
-        "MISSING_PRIORITY_SERVICE",
-        `${name} was listed as priority init, but was not found in services`,
-      );
-    }
-  });
-  const serviceApis = {} as GetApisResult<ServiceMap>;
-  const application = {
-    [WIRE_PROJECT]: async (internal: InternalDefinition) => {
-      const lifecycle = CreateChildLifecycle(internal);
-      LOADED_LIFECYCLES.set(name, lifecycle);
-      BOILERPLATE()?.configuration?.[LOAD_PROJECT](
-        name as keyof LoadedModules,
-        configuration,
-      );
-      await eachSeries(
-        WireOrder(priorityInit, Object.keys(services)),
-        async (service) => {
-          serviceApis[service] = await WireService(
-            name,
-            service,
-            services[service],
-            lifecycle,
-            internal,
-          );
-        },
-      );
-      return lifecycle;
-    },
-    booted: false,
-    bootstrap: async (options) => {
-      if (application.booted) {
-        throw new BootstrapException(
-          WIRING_CONTEXT,
-          "DOUBLE_BOOT",
-          "Application is already booted! Cannot bootstrap again",
-        );
-      }
-      await Bootstrap(application, options);
-      application.booted = true;
-    },
-    configuration,
-    configurationLoaders,
-    libraries,
-    name,
-    priorityInit,
-    serviceApis,
-    services,
-    teardown: async () => {
-      if (!application.booted) {
-        Reset();
-        return;
-      }
-      await Teardown();
-      application.booted = false;
-    },
-  } as ApplicationDefinition<S, C>;
-  return application;
-}
-
-// #MARK: WireService
-async function WireService(
-  project: string,
-  service: string,
-  definition: ServiceFunction,
-  lifecycle: TLifecycleBase,
-  internal: InternalDefinition,
-) {
-  const mappings = MODULE_MAPPINGS.get(project) ?? {};
-  if (!is.undefined(mappings[service])) {
-    throw new BootstrapException(
-      WIRING_CONTEXT,
-      "DUPLICATE_SERVICE_NAME",
-      `${service} is already defined for ${project}`,
-    );
-  }
-  mappings[service] = definition;
-  MODULE_MAPPINGS.set(project, mappings);
-  REVERSE_MODULE_MAPPING.set(definition, [project, service]);
-  const context = COERCE_CONTEXT(`${project}:${service}`);
-
-  // logger gets defined first, so this really is only for the start of the start of bootstrapping
-  const boilerplate = BOILERPLATE();
-  const logger = boilerplate?.logger?.context(context);
-  const loaded = LOADED_MODULES.get(project) ?? {};
-  LOADED_MODULES.set(project, loaded);
-  try {
-    logger?.trace({ name: WireService }, `initializing`);
-    const inject = Object.fromEntries(
-      [...LOADED_MODULES.keys()].map((project) => [
-        project as keyof TServiceParams,
-        LOADED_MODULES.get(project),
-      ]),
-    );
-
-    loaded[service] = (await definition({
-      ...inject,
-      cache: boilerplate?.cache,
-      config: boilerplate?.configuration?.[INJECTED_DEFINITIONS](),
-      context,
-      event: internal?.utils?.event,
-      internal,
-      lifecycle,
-      logger,
-      scheduler: boilerplate?.scheduler?.(context),
-    })) as TServiceReturn;
-
-    return loaded[service];
-  } catch (error) {
-    // Init errors at this level are considered blocking / fatal
-    // eslint-disable-next-line no-console
-    console.error("initialization error", error);
-    exit();
-  }
-}
-
-// #MARK: RunStageCallbacks
-async function RunStageCallbacks(stage: LifecycleStages): Promise<string> {
-  const start = Date.now();
-  const list = [
-    // boilerplate priority
-    LOADED_LIFECYCLES.get("boilerplate").getCallbacks(stage),
-    // children next
-    // ...
-    ...[...LOADED_LIFECYCLES.entries()]
-      .filter(([name]) => name !== "boilerplate")
-      .map(([, thing]) => thing.getCallbacks(stage)),
-  ];
-  await eachSeries(list, async (callbacks) => {
-    if (is.empty(callbacks)) {
-      return;
-    }
-    const sorted = callbacks.filter(([, sort]) => sort !== undefined);
-    const quick = callbacks.filter(([, sort]) => sort === undefined);
-    const positive = [] as LifecyclePrioritizedCallback[];
-    const negative = [] as LifecyclePrioritizedCallback[];
-    sorted.forEach(([callback, priority]) => {
-      if (priority >= PRE_CALLBACKS_START) {
-        positive.push([callback, priority]);
-        return;
-      }
-      negative.push([callback, priority]);
-    });
-
-    // * callbacks with a priority greater than 0
-    // larger number happen first
-    await eachSeries(
-      positive.sort(([, a], [, b]) => (a < b ? UP : DOWN)),
-      async ([callback]) => await callback(),
-    );
-
-    // * callbacks without a priority
-    await each(quick, async ([callback]) => await callback());
-
-    // * callbacks with a priority less than 0
-    // smaller numbers happen last
-    await eachSeries(
-      negative.sort(([, a], [, b]) => (a > b ? UP : DOWN)),
-      async ([callback]) => await callback(),
-    );
-  });
-  internal.boot.completedLifecycleEvents.add(stage);
-  return `${Date.now() - start}ms`;
-}
 const PRE_CALLBACKS_START = 0;
 
-type TLibrary = LibraryDefinition<ServiceMap, OptionalModuleConfiguration>;
+// (re)defined at bootstrap
+// unclear if this variable even serves a purpose beyond types
+export let LIB_BOILERPLATE: ReturnType<typeof CreateBoilerplate>;
 
-// #MARK: BuildSortOrder
-function BuildSortOrder<
-  S extends ServiceMap,
-  C extends OptionalModuleConfiguration,
->(app: ApplicationDefinition<S, C>) {
-  if (is.empty(app.libraries)) {
-    return [];
-  }
-  const libraryMap = new Map<string, TLibrary>(
-    app.libraries.map((i) => [i.name, i]),
-  );
+export const CreateApplication = (() => {
+  // #MARK: Variables
+  // These are resettable variables, which are scoped to outside the function on purpose
+  // If these were moved inside the service function, then re-running the method would result in application / library references being stranded
+  // Items like lib_boilerplate would still exist, but their lifecycles would be not accessible by the current application
+  //
+  // By moving to outside the function, the internal methods will be able to re-initialize as expected, without needing to fully rebuild every reference everywhere
+  // ... in theory
 
-  // Recursive function to check for missing dependencies at any depth
-  function checkDependencies(library: TLibrary) {
-    if (!is.empty(library.depends)) {
-      library.depends.forEach((item) => {
-        const loaded = libraryMap.get(item.name);
-        if (!loaded) {
+  /**
+   * association of projects to { service : Declaration Function }
+   */
+  let MODULE_MAPPINGS = new Map<string, TModuleMappings>();
+
+  /**
+   * association of projects to { service : Initialized Service }
+   */
+  let LOADED_MODULES = new Map<string, TResolvedModuleMappings>();
+
+  // heisenberg's variables. it's probably here, but maybe not
+  // let scheduler: (context: TContext) => TScheduler;
+  let logger: ILogger;
+  let internal: InternalDefinition;
+  // (re)defined at bootstrap
+  // exporting a let makes me feel dirty inside
+  // at least it's only for testing
+
+  // #MARK: processEvents
+  const processEvents = new Map([
+    [
+      "SIGTERM",
+      async () => {
+        logger.warn({ name: "SIGTERM" }, `starting`);
+        await Teardown();
+        exit();
+      },
+    ],
+    [
+      "SIGINT",
+      async () => {
+        logger.warn({ name: "SIGINT" }, `starting`);
+        await Teardown();
+        exit();
+      },
+    ],
+    // ["uncaughtException", () => {}],
+    // ["unhandledRejection", (reason, promise) => {}],
+  ]);
+
+  const BOILERPLATE = () =>
+    LOADED_MODULES.get("boilerplate") as GetApis<
+      ReturnType<typeof CreateBoilerplate>
+    >;
+
+  // #MARK: CreateApplication
+  function CreateApplication<
+    S extends ServiceMap,
+    C extends OptionalModuleConfiguration,
+  >({
+    name,
+    services = {} as S,
+    configurationLoaders,
+    libraries = [],
+    configuration = {} as C,
+    priorityInit = [],
+  }: ApplicationConfigurationOptions<S, C>) {
+    priorityInit.forEach((name) => {
+      if (!is.function(services[name])) {
+        throw new BootstrapException(
+          WIRING_CONTEXT,
+          "MISSING_PRIORITY_SERVICE",
+          `${name} was listed as priority init, but was not found in services`,
+        );
+      }
+    });
+    const serviceApis = {} as GetApisResult<ServiceMap>;
+    const application = {
+      [WIRE_PROJECT]: async (internal: InternalDefinition) => {
+        const lifecycle = CreateChildLifecycle(internal, logger);
+        internal.boot.lifecycleHooks.set(name, lifecycle);
+        BOILERPLATE()?.configuration?.[LOAD_PROJECT](
+          name as keyof LoadedModules,
+          configuration,
+        );
+        await eachSeries(
+          WireOrder(priorityInit, Object.keys(services)),
+          async (service) => {
+            serviceApis[service] = await WireService(
+              name,
+              service,
+              services[service],
+              lifecycle,
+              internal,
+            );
+          },
+        );
+        return lifecycle;
+      },
+      booted: false,
+      bootstrap: async (options) => {
+        if (application.booted) {
           throw new BootstrapException(
             WIRING_CONTEXT,
-            "MISSING_DEPENDENCY",
-            `${item.name} is required by ${library.name}, but was not provided`,
+            "DOUBLE_BOOT",
+            "Application is already booted! Cannot bootstrap again",
           );
         }
-        // just "are they the same object reference?" as the test
-        // you get a warning, and the one the app asks for
-        // hopefully there is no breaking changes
-        if (loaded !== item) {
-          logger.warn(
-            { name: BuildSortOrder },
-            "[%s] depends different version {%s}",
-            library.name,
-            item.name,
-          );
-        }
-      });
-    }
-    return library;
-  }
-
-  let starting = app.libraries.map((i) => checkDependencies(i));
-  const out = [] as TLibrary[];
-  while (!is.empty(starting)) {
-    const next = starting.find((library) => {
-      if (is.empty(library.depends)) {
-        return true;
-      }
-      return library.depends?.every((depend) =>
-        out.some((i) => i.name === depend.name),
-      );
-    });
-    if (!next) {
-      logger.fatal({ current: out.map((i) => i.name), name: BuildSortOrder });
-      throw new BootstrapException(
-        WIRING_CONTEXT,
-        "BAD_SORT",
-        `Cannot find a next lib to load`,
-      );
-    }
-    starting = starting.filter((i) => next.name !== i.name);
-    out.push(next);
-  }
-
-  const order = out.map((i) => i.name);
-  logger.trace({ name: BuildSortOrder, order }, ``);
-  return out;
-}
-
-let startup: Date;
-
-// #MARK: Bootstrap
-async function Bootstrap<
-  S extends ServiceMap,
-  C extends OptionalModuleConfiguration,
->(application: ApplicationDefinition<S, C>, options: BootstrapOptions = {}) {
-  if (internal) {
-    throw new BootstrapException(
-      WIRING_CONTEXT,
-      "NO_DUAL_BOOT",
-      "Another application is already active, please terminate",
-    );
-  }
-  internal = new InternalDefinition();
-  // const
-  internal.boot = {
-    application,
-    completedLifecycleEvents: new Set(),
-    options,
-    phase: "bootstrap",
-  };
-  process.title = application.name;
-  startup = new Date();
-  try {
-    const STATS = {} as Record<string, unknown>;
-    const CONSTRUCT = {} as Record<string, unknown>;
-
-    // pre-create loaded module for boilerplate, so it can be attached to `internal`
-    // this allows it to be used as part of `internal` during boilerplate construction
-    // otherwise it'd only be there for everyone else
-    const api = {} as GetApis<ReturnType<typeof CreateBoilerplate>>;
-    internal.boilerplate = api;
-    LOADED_MODULES.set("boilerplate", api);
-
-    STATS.Construct = CONSTRUCT;
-    // * Recreate base eventemitter
-    internal.utils.event = new EventEmitter();
-    // ? Some libraries need to be aware of
-
-    // * Generate a new boilerplate module
-    LIB_BOILERPLATE = CreateBoilerplate();
-
-    // * Wire it
-    let start = Date.now();
-    await LIB_BOILERPLATE[WIRE_PROJECT](internal);
-
-    CONSTRUCT.boilerplate = `${Date.now() - start}ms`;
-    // ~ configuration
-    api.configuration?.[LOAD_PROJECT](
-      LIB_BOILERPLATE.name,
-      LIB_BOILERPLATE.configuration,
-    );
-    logger = api.logger.context(WIRING_CONTEXT);
-    logger.info({ name: Bootstrap }, `[boilerplate] wiring complete`);
-
-    // * Wire in various shutdown events
-    processEvents.forEach((callback, event) => {
-      process.on(event, callback);
-      logger.trace({ event, name: Bootstrap }, "shutdown event");
-    });
-
-    // * Add in libraries
-    application.libraries ??= [];
-    const order = BuildSortOrder(application);
-    await eachSeries(order, async (i) => {
-      start = Date.now();
-      logger.info({ name: Bootstrap }, `[%s] init project`, i.name);
-      await i[WIRE_PROJECT](internal);
-      CONSTRUCT[i.name] = `${Date.now() - start}ms`;
-    });
-
-    logger.info({ name: Bootstrap }, `init application`);
-    // * Finally the application
-    start = Date.now();
-    await application[WIRE_PROJECT](internal);
-    CONSTRUCT[application.name] = `${Date.now() - start}ms`;
-
-    // ? Configuration values provided bootstrap take priority over module level
-    if (!is.empty(options?.configuration)) {
-      api.configuration.merge(options?.configuration);
-    }
-
-    // - Kick off lifecycle
-    logger.debug({ name: Bootstrap }, `[PreInit] running lifecycle callbacks`);
-    STATS.PreInit = await RunStageCallbacks("PreInit");
-    // - Pull in user configurations
-    logger.debug({ name: Bootstrap }, "loading configuration");
-    STATS.Configure =
-      await BOILERPLATE()?.configuration?.[INITIALIZE](application);
-    // - Run through other events in order
-    logger.debug(
-      { name: Bootstrap },
-      `[PostConfig] running lifecycle callbacks`,
-    );
-    STATS.PostConfig = await RunStageCallbacks("PostConfig");
-    logger.debug(
-      { name: Bootstrap },
-      `[Bootstrap] running lifecycle callbacks`,
-    );
-    STATS.Bootstrap = await RunStageCallbacks("Bootstrap");
-    logger.debug({ name: Bootstrap }, `[Ready] running lifecycle callbacks`);
-    STATS.Ready = await RunStageCallbacks("Ready");
-
-    STATS.Total = `${Date.now() - startup.getTime()}ms`;
-    // * App is ready!
-    logger.info(
-      options?.showExtraBootStats
-        ? { ...STATS, name: Bootstrap }
-        : { Total: STATS.Total, name: Bootstrap },
-      `🪄 [%s] application bootstrapped`,
-      application.name,
-    );
-    internal.boot.phase = "running";
-  } catch (error) {
-    if (options?.configuration?.boilerplate?.LOG_LEVEL !== "silent") {
-      // eslint-disable-next-line no-console
-      console.error("bootstrap failed", error);
-    }
-    exit();
-  }
-}
-
-// #MARK: Teardown
-async function Teardown() {
-  if (!internal) {
-    return;
-  }
-  // * Announce
-  logger.warn({ name: Teardown }, `received teardown request`);
-  internal.boot.phase = "teardown";
-  try {
-    // * PreShutdown
-    logger.debug(
-      { name: Teardown },
-      `[PreShutdown] running lifecycle callbacks`,
-    );
-    await RunStageCallbacks("PreShutdown");
-
-    // * Formally shutting down
-    logger.info({ name: Teardown }, `tearing down application`);
-    logger.debug(
-      { name: Teardown },
-      `[ShutdownStart] running lifecycle callbacks`,
-    );
-    await RunStageCallbacks("ShutdownStart");
-    logger.debug(
-      { name: Teardown },
-      `[ShutdownComplete] running lifecycle callbacks`,
-    );
-    await RunStageCallbacks("ShutdownComplete");
-  } catch (error) {
-    // ! oof
-    logger.error(
-      { error, name: Teardown },
-      "error occurred during teardown, some lifecycle events may be incomplete",
-    );
-  }
-  // * Final resource cleanup, attempt to reset everything possible
-
-  logger.info(
-    { name: Teardown, started_at: internal.utils.relativeDate(startup) },
-    `application terminated`,
-  );
-  Reset();
-}
-
-// #MARK: Reset
-export function Reset() {
-  processEvents.forEach((callback, event) =>
-    process.removeListener(event, callback),
-  );
-  internal?.utils?.event?.removeAllListeners?.();
-
-  MODULE_MAPPINGS = new Map();
-  LOADED_MODULES = new Map();
-  LOADED_LIFECYCLES = new Map();
-  REVERSE_MODULE_MAPPING = new Map();
-  internal = undefined;
-  logger = undefined;
-}
-
-// # Lifecycle
-function CreateChildLifecycle(
-  internal: InternalDefinition,
-): TLoadableChildLifecycle {
-  const childCallbacks = {} as Record<LifecycleStages, CallbackList>;
-
-  const [
-    // ! This list must be sorted!
-    onPreInit,
-    onPostConfig,
-    onBootstrap,
-    onReady,
-    onPreShutdown,
-    onShutdownStart,
-    onShutdownComplete,
-  ] = LIFECYCLE_STAGES.map((stage) => {
-    childCallbacks[stage] = [];
-    return (callback: LifecycleCallback, priority?: number) => {
-      if (internal.boot.completedLifecycleEvents.has(stage)) {
-        // this is makes "earliest run time" logic way easier to implement
-        // intended mode of operation
-        if (["PreInit", "PostConfig", "Bootstrap", "Ready"].includes(stage)) {
-          setImmediate(async () => await callback());
+        await Bootstrap(application, options);
+        application.booted = true;
+      },
+      configuration,
+      configurationLoaders,
+      libraries,
+      name,
+      priorityInit,
+      serviceApis,
+      services,
+      teardown: async () => {
+        if (!application.booted) {
+          Reset();
           return;
         }
-        // What does this mean in reality?
-        // Probably a broken unit test, I really don't know what workflow would cause this
-        logger.fatal(
-          { name: CreateChildLifecycle },
-          `on${stage} late attach, cannot attach callback`,
-        );
+        await Teardown();
+        application.booted = false;
+      },
+    } as ApplicationDefinition<S, C>;
+    return application;
+  }
+
+  // #MARK: WireService
+  async function WireService(
+    project: string,
+    service: string,
+    definition: ServiceFunction,
+    lifecycle: TLifecycleBase,
+    internal: InternalDefinition,
+  ) {
+    const mappings = MODULE_MAPPINGS.get(project) ?? {};
+    if (!is.undefined(mappings[service])) {
+      throw new BootstrapException(
+        WIRING_CONTEXT,
+        "DUPLICATE_SERVICE_NAME",
+        `${service} is already defined for ${project}`,
+      );
+    }
+    mappings[service] = definition;
+    MODULE_MAPPINGS.set(project, mappings);
+    const context = COERCE_CONTEXT(`${project}:${service}`);
+
+    // logger gets defined first, so this really is only for the start of the start of bootstrapping
+    const boilerplate = BOILERPLATE();
+    const logger = boilerplate?.logger?.context(context);
+    const loaded = LOADED_MODULES.get(project) ?? {};
+    LOADED_MODULES.set(project, loaded);
+    try {
+      logger?.trace({ name: WireService }, `initializing`);
+      const inject = Object.fromEntries(
+        [...LOADED_MODULES.keys()].map((project) => [
+          project as keyof TServiceParams,
+          LOADED_MODULES.get(project),
+        ]),
+      );
+
+      loaded[service] = (await definition({
+        ...inject,
+        cache: boilerplate?.cache,
+        config: boilerplate?.configuration?.[INJECTED_DEFINITIONS](),
+        context,
+        event: internal?.utils?.event,
+        internal,
+        lifecycle,
+        logger,
+        scheduler: boilerplate?.scheduler?.(context),
+      })) as TServiceReturn;
+
+      return loaded[service];
+    } catch (error) {
+      // Init errors at this level are considered blocking / fatal
+      // eslint-disable-next-line no-console
+      console.error("initialization error", error);
+      exit();
+    }
+  }
+
+  // #MARK: RunStageCallbacks
+  async function RunStageCallbacks(stage: LifecycleStages): Promise<string> {
+    const start = Date.now();
+    const list = [
+      // boilerplate priority
+      internal.boot.lifecycleHooks.get("boilerplate").getCallbacks(stage),
+      // children next
+      // ...
+      ...[...internal.boot.lifecycleHooks.entries()]
+        .filter(([name]) => name !== "boilerplate")
+        .map(([, thing]) => thing.getCallbacks(stage)),
+    ];
+    await eachSeries(list, async (callbacks) => {
+      if (is.empty(callbacks)) {
         return;
       }
-      childCallbacks[stage].push([callback, priority]);
-    };
-  });
+      const sorted = callbacks.filter(([, sort]) => sort !== undefined);
+      const quick = callbacks.filter(([, sort]) => sort === undefined);
+      const positive = [] as LifecyclePrioritizedCallback[];
+      const negative = [] as LifecyclePrioritizedCallback[];
+      sorted.forEach(([callback, priority]) => {
+        if (priority >= PRE_CALLBACKS_START) {
+          positive.push([callback, priority]);
+          return;
+        }
+        negative.push([callback, priority]);
+      });
 
-  return {
-    getCallbacks: (stage: LifecycleStages) =>
-      childCallbacks[stage] as CallbackList,
-    onBootstrap,
-    onPostConfig,
-    onPreInit,
-    onPreShutdown,
-    onReady,
-    onShutdownComplete,
-    onShutdownStart,
-  };
-}
+      // * callbacks with a priority greater than 0
+      // larger number happen first
+      await eachSeries(
+        positive.sort(([, a], [, b]) => (a < b ? UP : DOWN)),
+        async ([callback]) => await callback(),
+      );
+
+      // * callbacks without a priority
+      await each(quick, async ([callback]) => await callback());
+
+      // * callbacks with a priority less than 0
+      // smaller numbers happen last
+      await eachSeries(
+        negative.sort(([, a], [, b]) => (a > b ? UP : DOWN)),
+        async ([callback]) => await callback(),
+      );
+    });
+    internal.boot.completedLifecycleEvents.add(stage);
+    return `${Date.now() - start}ms`;
+  }
+
+  let startup: Date;
+
+  // #MARK: Bootstrap
+  async function Bootstrap<
+    S extends ServiceMap,
+    C extends OptionalModuleConfiguration,
+  >(application: ApplicationDefinition<S, C>, options: BootstrapOptions = {}) {
+    if (internal) {
+      throw new BootstrapException(
+        WIRING_CONTEXT,
+        "NO_DUAL_BOOT",
+        "Another application is already active, please terminate",
+      );
+    }
+    internal = new InternalDefinition();
+    // const
+    internal.boot = {
+      application,
+      completedLifecycleEvents: new Set(),
+      lifecycleHooks: new Map(),
+      options,
+      phase: "bootstrap",
+    };
+    process.title = application.name;
+    startup = new Date();
+    try {
+      const STATS = {} as Record<string, unknown>;
+      const CONSTRUCT = {} as Record<string, unknown>;
+
+      // pre-create loaded module for boilerplate, so it can be attached to `internal`
+      // this allows it to be used as part of `internal` during boilerplate construction
+      // otherwise it'd only be there for everyone else
+      const api = {} as GetApis<ReturnType<typeof CreateBoilerplate>>;
+      internal.boilerplate = api;
+      LOADED_MODULES.set("boilerplate", api);
+
+      STATS.Construct = CONSTRUCT;
+      // * Recreate base eventemitter
+      internal.utils.event = new EventEmitter();
+      // ? Some libraries need to be aware of
+
+      // * Generate a new boilerplate module
+      LIB_BOILERPLATE = CreateBoilerplate();
+
+      // * Wire it
+      let start = Date.now();
+      await LIB_BOILERPLATE[WIRE_PROJECT](internal, WireService, logger);
+
+      CONSTRUCT.boilerplate = `${Date.now() - start}ms`;
+      // ~ configuration
+      api.configuration?.[LOAD_PROJECT](
+        LIB_BOILERPLATE.name,
+        LIB_BOILERPLATE.configuration,
+      );
+      logger = api.logger.context(WIRING_CONTEXT);
+      logger.info({ name: Bootstrap }, `[boilerplate] wiring complete`);
+
+      // * Wire in various shutdown events
+      processEvents.forEach((callback, event) => {
+        process.on(event, callback);
+        logger.trace({ event, name: Bootstrap }, "shutdown event");
+      });
+
+      // * Add in libraries
+      application.libraries ??= [];
+      const order = BuildSortOrder(application, logger);
+      await eachSeries(order, async (i) => {
+        start = Date.now();
+        logger.info({ name: Bootstrap }, `[%s] init project`, i.name);
+        await i[WIRE_PROJECT](internal, WireService, logger);
+        CONSTRUCT[i.name] = `${Date.now() - start}ms`;
+      });
+
+      logger.info({ name: Bootstrap }, `init application`);
+      // * Finally the application
+      start = Date.now();
+      await application[WIRE_PROJECT](internal, WireService, logger);
+      CONSTRUCT[application.name] = `${Date.now() - start}ms`;
+
+      // ? Configuration values provided bootstrap take priority over module level
+      if (!is.empty(options?.configuration)) {
+        api.configuration.merge(options?.configuration);
+      }
+
+      // - Kick off lifecycle
+      logger.debug(
+        { name: Bootstrap },
+        `[PreInit] running lifecycle callbacks`,
+      );
+      STATS.PreInit = await RunStageCallbacks("PreInit");
+      // - Pull in user configurations
+      logger.debug({ name: Bootstrap }, "loading configuration");
+      STATS.Configure =
+        await BOILERPLATE()?.configuration?.[INITIALIZE](application);
+      // - Run through other events in order
+      logger.debug(
+        { name: Bootstrap },
+        `[PostConfig] running lifecycle callbacks`,
+      );
+      STATS.PostConfig = await RunStageCallbacks("PostConfig");
+      logger.debug(
+        { name: Bootstrap },
+        `[Bootstrap] running lifecycle callbacks`,
+      );
+      STATS.Bootstrap = await RunStageCallbacks("Bootstrap");
+      logger.debug({ name: Bootstrap }, `[Ready] running lifecycle callbacks`);
+      STATS.Ready = await RunStageCallbacks("Ready");
+
+      STATS.Total = `${Date.now() - startup.getTime()}ms`;
+      // * App is ready!
+      logger.info(
+        options?.showExtraBootStats
+          ? { ...STATS, name: Bootstrap }
+          : { Total: STATS.Total, name: Bootstrap },
+        `🪄 [%s] application bootstrapped`,
+        application.name,
+      );
+      internal.boot.phase = "running";
+    } catch (error) {
+      if (options?.configuration?.boilerplate?.LOG_LEVEL !== "silent") {
+        // eslint-disable-next-line no-console
+        console.error("bootstrap failed", error);
+      }
+      exit();
+    }
+  }
+
+  // #MARK: Teardown
+  async function Teardown() {
+    if (!internal) {
+      return;
+    }
+    // * Announce
+    logger.warn({ name: Teardown }, `received teardown request`);
+    internal.boot.phase = "teardown";
+    try {
+      // * PreShutdown
+      logger.debug(
+        { name: Teardown },
+        `[PreShutdown] running lifecycle callbacks`,
+      );
+      await RunStageCallbacks("PreShutdown");
+
+      // * Formally shutting down
+      logger.info({ name: Teardown }, `tearing down application`);
+      logger.debug(
+        { name: Teardown },
+        `[ShutdownStart] running lifecycle callbacks`,
+      );
+      await RunStageCallbacks("ShutdownStart");
+      logger.debug(
+        { name: Teardown },
+        `[ShutdownComplete] running lifecycle callbacks`,
+      );
+      await RunStageCallbacks("ShutdownComplete");
+    } catch (error) {
+      // ! oof
+      logger.error(
+        { error, name: Teardown },
+        "error occurred during teardown, some lifecycle events may be incomplete",
+      );
+    }
+    // * Final resource cleanup, attempt to reset everything possible
+
+    logger.info(
+      { name: Teardown, started_at: internal.utils.relativeDate(startup) },
+      `application terminated`,
+    );
+    Reset();
+  }
+
+  // #MARK: Reset
+  function Reset() {
+    processEvents.forEach((callback, event) =>
+      process.removeListener(event, callback),
+    );
+    internal?.utils?.event?.removeAllListeners?.();
+
+    MODULE_MAPPINGS = new Map();
+    LOADED_MODULES = new Map();
+    internal = undefined;
+    logger = undefined;
+  }
+
+  return CreateApplication;
+})();

--- a/src/helpers/wiring.helper.ts
+++ b/src/helpers/wiring.helper.ts
@@ -1,8 +1,19 @@
 import { Dayjs } from "dayjs";
 import { EventEmitter } from "events";
 
-import { CronExpression, InternalDefinition, TBlackHole, TContext } from "..";
+import {
+  BootstrapException,
+  ConfigManager,
+  CronExpression,
+  eachSeries,
+  InternalDefinition,
+  is,
+  LOAD_PROJECT,
+  TBlackHole,
+  TContext,
+} from "..";
 import { ILogger, LIB_BOILERPLATE, TCache } from "..";
+import { CreateChildLifecycle } from "../extensions/lifecycle.extension";
 import {
   AnyConfig,
   BooleanConfig,
@@ -308,7 +319,17 @@ type Wire = {
    * - initializes lifecycle
    * - attaches event emitters
    */
-  [WIRE_PROJECT]: (internal: InternalDefinition) => Promise<TChildLifecycle>;
+  [WIRE_PROJECT]: (
+    internal: InternalDefinition,
+    WireService: (
+      project: string,
+      service: string,
+      definition: ServiceFunction,
+      lifecycle: TLifecycleBase,
+      internal: InternalDefinition,
+    ) => Promise<TServiceReturn<object>>,
+    logger: ILogger,
+  ) => Promise<TChildLifecycle>;
 };
 
 export type LibraryDefinition<
@@ -325,3 +346,176 @@ export type ApplicationDefinition<
     bootstrap: (options?: BootstrapOptions) => Promise<void>;
     teardown: () => Promise<void>;
   };
+type TLibrary = LibraryDefinition<ServiceMap, OptionalModuleConfiguration>;
+
+export function BuildSortOrder<
+  S extends ServiceMap,
+  C extends OptionalModuleConfiguration,
+>(app: ApplicationDefinition<S, C>, logger: ILogger) {
+  if (is.empty(app.libraries)) {
+    return [];
+  }
+  const libraryMap = new Map<string, TLibrary>(
+    app.libraries.map((i) => [i.name, i]),
+  );
+
+  // Recursive function to check for missing dependencies at any depth
+  function checkDependencies(library: TLibrary) {
+    if (!is.empty(library.depends)) {
+      library.depends.forEach((item) => {
+        const loaded = libraryMap.get(item.name);
+        if (!loaded) {
+          throw new BootstrapException(
+            WIRING_CONTEXT,
+            "MISSING_DEPENDENCY",
+            `${item.name} is required by ${library.name}, but was not provided`,
+          );
+        }
+        // just "are they the same object reference?" as the test
+        // you get a warning, and the one the app asks for
+        // hopefully there is no breaking changes
+        if (loaded !== item) {
+          logger.warn(
+            { name: BuildSortOrder },
+            "[%s] depends different version {%s}",
+            library.name,
+            item.name,
+          );
+        }
+      });
+    }
+    return library;
+  }
+
+  let starting = app.libraries.map((i) => checkDependencies(i));
+  const out = [] as TLibrary[];
+  while (!is.empty(starting)) {
+    const next = starting.find((library) => {
+      if (is.empty(library.depends)) {
+        return true;
+      }
+      return library.depends?.every((depend) =>
+        out.some((i) => i.name === depend.name),
+      );
+    });
+    if (!next) {
+      logger.fatal({ current: out.map((i) => i.name), name: BuildSortOrder });
+      throw new BootstrapException(
+        WIRING_CONTEXT,
+        "BAD_SORT",
+        `Cannot find a next lib to load`,
+      );
+    }
+    starting = starting.filter((i) => next.name !== i.name);
+    out.push(next);
+  }
+
+  const order = out.map((i) => i.name);
+  logger.trace({ name: BuildSortOrder, order }, ``);
+  return out;
+}
+
+export const COERCE_CONTEXT = (context: string): TContext =>
+  context as TContext;
+export const WIRING_CONTEXT = COERCE_CONTEXT("boilerplate:wiring");
+
+export function ValidateLibrary<S extends ServiceMap>(
+  project: string,
+  serviceList: S,
+): void | never {
+  if (is.empty(project)) {
+    throw new BootstrapException(
+      COERCE_CONTEXT("CreateLibrary"),
+      "MISSING_LIBRARY_NAME",
+      "Library name is required",
+    );
+  }
+  const services = Object.entries(serviceList);
+
+  // Find the first invalid service
+  const invalidService = services.find(
+    ([, definition]) => typeof definition !== "function",
+  );
+  if (invalidService) {
+    const [invalidServiceName, service] = invalidService;
+    throw new BootstrapException(
+      COERCE_CONTEXT("CreateLibrary"),
+      "INVALID_SERVICE_DEFINITION",
+      `Invalid service definition for '${invalidServiceName}' in library '${project}' (${typeof service}})`,
+    );
+  }
+}
+
+export function WireOrder<T extends string>(priority: T[], list: T[]): T[] {
+  const out = [...(priority || [])];
+  if (!is.empty(priority)) {
+    const check = is.unique(priority);
+    if (check.length !== out.length) {
+      throw new BootstrapException(
+        WIRING_CONTEXT,
+        "DOUBLE_PRIORITY",
+        "There are duplicate items in the priority load list",
+      );
+    }
+  }
+  return [...out, ...list.filter((i) => !out.includes(i))];
+}
+
+export function CreateLibrary<
+  S extends ServiceMap,
+  C extends OptionalModuleConfiguration,
+>({
+  name: libraryName,
+  configuration = {} as C,
+  priorityInit,
+  services,
+  depends,
+}: LibraryConfigurationOptions<S, C>): LibraryDefinition<S, C> {
+  ValidateLibrary(libraryName, services);
+
+  const serviceApis = {} as GetApisResult<ServiceMap>;
+
+  const library = {
+    [WIRE_PROJECT]: async (
+      internal: InternalDefinition,
+      WireService: (
+        project: string,
+        service: string,
+        definition: ServiceFunction,
+        lifecycle: TLifecycleBase,
+        internal: InternalDefinition,
+      ) => Promise<TServiceReturn<object>>,
+      logger: ILogger,
+    ) => {
+      const lifecycle = CreateChildLifecycle(internal, logger);
+      // This one hasn't been loaded yet, generate an object with all the correct properties
+      internal.boot.lifecycleHooks.set(libraryName, lifecycle);
+      // not defined for boilerplate (chicken & egg)
+      // manually added inside the bootstrap process
+      const config = internal?.boilerplate.configuration as ConfigManager;
+      config?.[LOAD_PROJECT](libraryName as keyof LoadedModules, configuration);
+      await eachSeries(
+        WireOrder(priorityInit, Object.keys(services)),
+        async (service) => {
+          serviceApis[service] = await WireService(
+            libraryName,
+            service,
+            services[service],
+            lifecycle,
+            internal,
+          );
+        },
+      );
+      // mental note: people should probably do all their lifecycle attachments at the base level function
+      // otherwise, it'll happen after this wire() call, and go into a black hole (worst case) or fatal error ("best" case)
+      return lifecycle;
+    },
+    configuration,
+    depends,
+    name: libraryName,
+    priorityInit,
+    serviceApis,
+    services,
+  } as LibraryDefinition<S, C>;
+  return library;
+}

--- a/src/helpers/wiring.helper.ts
+++ b/src/helpers/wiring.helper.ts
@@ -342,6 +342,7 @@ export type ApplicationDefinition<
   C extends OptionalModuleConfiguration,
 > = ApplicationConfigurationOptions<S, C> &
   Wire & {
+    logger: ILogger;
     booted: boolean;
     bootstrap: (options?: BootstrapOptions) => Promise<void>;
     teardown: () => Promise<void>;

--- a/src/testing/cache.spec.ts
+++ b/src/testing/cache.spec.ts
@@ -1,3 +1,352 @@
-describe("Cache", () => {
-  //
+import {
+  CACHE_DELETE_OPERATIONS_TOTAL,
+  CACHE_GET_OPERATIONS_TOTAL,
+  CACHE_SET_OPERATIONS_TOTAL,
+  CreateApplication,
+} from "..";
+import { BASIC_BOOT, ServiceTest } from "./testing.helper";
+
+describe("Cache Extension", () => {
+  // * DO NOT REMOVE THIS BLOCK
+  beforeAll(async () => {
+    // It does nothing, but somehow magically prevents jest from exploding for no reason
+    // @ts-expect-error asdf
+    const preload = CreateApplication({ name: "testing" });
+    await preload.bootstrap(BASIC_BOOT);
+    await preload.teardown();
+  });
+  afterEach(async () => {
+    jest.restoreAllMocks();
+  });
+
+  describe("set Method", () => {
+    it("should successfully set a value in the cache", async () => {
+      expect.assertions(1);
+
+      await ServiceTest(({ cache, lifecycle }) => {
+        lifecycle.onReady(async () => {
+          const key = "testKey";
+          const value = "testValue";
+          await cache.set(key, value);
+          const result = await cache.get(key);
+          expect(result).toEqual(value);
+        });
+      });
+    });
+
+    it("should overwrite existing value with the same key", async () => {
+      expect.assertions(1);
+
+      await ServiceTest(({ cache, lifecycle }) => {
+        lifecycle.onReady(async () => {
+          const key = "testKey";
+          const value1 = "value1";
+          const value2 = "value2";
+          await cache.set(key, value1);
+          await cache.set(key, value2);
+          const result = await cache.get(key);
+          expect(result).toEqual(value2);
+        });
+      });
+    });
+
+    it("should respect the TTL for a cached item", async () => {
+      expect.assertions(1);
+
+      await ServiceTest(({ cache, lifecycle }) => {
+        lifecycle.onReady(async () => {
+          const key = "tempKey";
+          const value = "tempValue";
+          const ttl = 1; // Time-to-live in seconds
+          await cache.set(key, value, ttl);
+          // Wait for the TTL to expire
+          await new Promise((resolve) => setTimeout(resolve, 1100));
+          const result = await cache.get(key);
+          expect(result).toBeUndefined();
+        });
+      });
+    });
+  });
+
+  describe("get Method", () => {
+    it("should retrieve the correct value for an existing key", async () => {
+      expect.assertions(1);
+
+      await ServiceTest(({ cache, lifecycle }) => {
+        lifecycle.onReady(async () => {
+          const key = "existingKey";
+          const expectedValue = "storedValue";
+          await cache.set(key, expectedValue);
+          const result = await cache.get(key);
+          expect(result).toEqual(expectedValue);
+        });
+      });
+    });
+
+    it("should return the default value for a non-existing key", async () => {
+      expect.assertions(1);
+
+      await ServiceTest(({ cache, lifecycle }) => {
+        lifecycle.onReady(async () => {
+          const defaultValue = "default";
+          const result = await cache.get("nonExistingKey", defaultValue);
+          expect(result).toEqual(defaultValue);
+        });
+      });
+    });
+
+    it("should return undefined for a non-existing key when no default value is provided", async () => {
+      expect.assertions(1);
+
+      await ServiceTest(({ cache, lifecycle }) => {
+        lifecycle.onReady(async () => {
+          const result = await cache.get("nonExistingKey");
+          expect(result).toBeUndefined();
+        });
+      });
+    });
+
+    it("should handle different types for the default value", async () => {
+      expect.assertions(1);
+      await ServiceTest(({ cache, lifecycle }) => {
+        lifecycle.onReady(async () => {
+          const key = "nonExistingKey";
+          const defaultValue = 123;
+          const result = await cache.get(key, defaultValue);
+          expect(result).toBe(defaultValue);
+        });
+      });
+    });
+    const defaultValue = "defaultValue";
+
+    it("should return the actual value when it is false", async () => {
+      expect.assertions(1);
+      await ServiceTest(({ cache, lifecycle }) => {
+        lifecycle.onReady(async () => {
+          const key = "keyWithFalse";
+          const falseValue = false;
+          await cache.set(key, falseValue);
+          const result = await cache.get(key, defaultValue);
+          expect(result).toBe(falseValue);
+        });
+      });
+    });
+
+    it("should return the actual value when it is 0", async () => {
+      expect.assertions(1);
+      await ServiceTest(({ cache, lifecycle }) => {
+        lifecycle.onReady(async () => {
+          const key = "keyWithZero";
+          const zeroValue = 0;
+          await cache.set(key, zeroValue);
+          const result = await cache.get(key, defaultValue);
+          expect(result).toBe(zeroValue);
+        });
+      });
+    });
+
+    it("should return the actual value when it is an empty string", async () => {
+      expect.assertions(1);
+      await ServiceTest(({ cache, lifecycle }) => {
+        lifecycle.onReady(async () => {
+          const key = "keyWithEmptyString";
+          const emptyStringValue = "";
+          await cache.set(key, emptyStringValue);
+          const result = await cache.get(key, defaultValue);
+          expect(result).toBe(emptyStringValue);
+        });
+      });
+    });
+
+    it("should return the actual value when it is null", async () => {
+      expect.assertions(1);
+      await ServiceTest(({ cache, lifecycle }) => {
+        lifecycle.onReady(async () => {
+          const key = "keyWithNull";
+          const nullValue = null as null;
+          await cache.set(key, nullValue);
+          const result = await cache.get(key, defaultValue);
+          expect(result).toBe(nullValue);
+        });
+      });
+    });
+
+    it("should return the default value for a key that is not set in the cache (undefined)", async () => {
+      expect.assertions(1);
+      await ServiceTest(({ cache, lifecycle }) => {
+        lifecycle.onReady(async () => {
+          const key = "keyNotSet";
+          const defaultValue = "defaultValue";
+          // No value is set for 'keyNotSet'
+          const result = await cache.get(key, defaultValue);
+          expect(result).toEqual(defaultValue); // Expecting the default value as the key is not set in the cache});
+        });
+      });
+    });
+
+    it.skip("should return the default value for a non-existing key, regardless of its type", async () => {
+      expect.assertions(1);
+      await ServiceTest(({ cache, lifecycle }) => {
+        lifecycle.onReady(async () => {
+          const defaultStringValue = "defaultString";
+          const defaultNumberValue = 42;
+          const defaultObjectValue = { default: "object" };
+
+          const resultString = await cache.get(
+            "nonExistingStringKey",
+            defaultStringValue,
+          );
+          const resultNumber = await cache.get(
+            "nonExistingNumberKey",
+            defaultNumberValue,
+          );
+          const resultObject = await cache.get(
+            "nonExistingObjectKey",
+            defaultObjectValue,
+          );
+
+          expect(resultString).toEqual(defaultStringValue);
+          expect(resultNumber).toEqual(defaultNumberValue);
+          expect(resultObject).toEqual(defaultObjectValue);
+        });
+      });
+    });
+  });
+
+  describe("del Method", () => {
+    it("should successfully delete an existing key from the cache", async () => {
+      expect.assertions(1);
+      await ServiceTest(({ cache, lifecycle }) => {
+        lifecycle.onReady(async () => {
+          const key = "keyToDelete";
+          await cache.set(key, "value");
+          await cache.del(key);
+          const result = await cache.get(key);
+          expect(result).toBeUndefined();
+        });
+      });
+    });
+
+    it.skip("should confirm that a non-existing key is not in the cache after a delete operation", async () => {
+      expect.assertions(1);
+      await ServiceTest(({ cache, lifecycle }) => {
+        lifecycle.onReady(async () => {
+          const nonExistingKey = "nonExistingKey";
+          // Initial check to confirm the key is not already in the cache
+          const initialResult = await cache.get(nonExistingKey);
+          expect(initialResult).toBeUndefined();
+
+          await cache.del(nonExistingKey);
+          // Recheck to confirm the key is still not in the cache
+          const finalResult = await cache.get(nonExistingKey);
+          expect(finalResult).toBeUndefined();
+        });
+      });
+    });
+
+    it("should handle deletion of a key with a falsey value correctly", async () => {
+      expect.assertions(1);
+      await ServiceTest(({ cache, lifecycle }) => {
+        lifecycle.onReady(async () => {
+          const falseyKey = "falseyKey";
+          await cache.set(falseyKey, 0); // Or other falsey values like '', false, null
+          await cache.del(falseyKey);
+          const result = await cache.get(falseyKey);
+          expect(result).toBeUndefined();
+        });
+      });
+    });
+  });
+
+  describe.skip("keys Method", () => {
+    it("should return all keys in the cache when no pattern is provided", async () => {
+      expect.assertions(1);
+      await ServiceTest(({ cache, lifecycle }) => {
+        lifecycle.onReady(async () => {
+          // Setting up multiple keys in the cache
+          await cache.set("key1", "value1");
+          await cache.set("key2", "value2");
+          await cache.set("key3", "value3");
+
+          const allKeys = await cache.keys();
+          expect(allKeys).toContain("key1");
+          expect(allKeys).toContain("key2");
+          expect(allKeys).toContain("key3");
+        });
+      });
+    });
+
+    it("should return keys matching a specific pattern", async () => {
+      expect.assertions(1);
+      await ServiceTest(({ cache, lifecycle }) => {
+        lifecycle.onReady(async () => {
+          // Setting up keys, some of which match a pattern
+          await cache.set("match1", "value1");
+          await cache.set("match2", "value2");
+          await cache.set("noMatch", "value3");
+
+          const matchedKeys = await cache.keys("match*");
+          expect(matchedKeys).toContain("match1");
+          expect(matchedKeys).toContain("match2");
+          expect(matchedKeys).not.toContain("noMatch");
+        });
+      });
+    });
+
+    it("should return an empty array if no keys match the pattern", async () => {
+      expect.assertions(1);
+      await ServiceTest(({ cache, lifecycle }) => {
+        lifecycle.onReady(async () => {
+          // Assuming the cache is clear or the pattern is very unique
+          const noMatchKeys = await cache.keys("nonExistentPattern*");
+          expect(noMatchKeys).toEqual([]);
+        });
+      });
+    });
+  });
+
+  describe("Cache Operation Metrics", () => {
+    beforeEach(async () => {
+      // Resetting metrics before each test
+      await CACHE_DELETE_OPERATIONS_TOTAL.reset();
+      await CACHE_GET_OPERATIONS_TOTAL.reset();
+      await CACHE_SET_OPERATIONS_TOTAL.reset();
+    });
+
+    it("should increment CACHE_SET_OPERATIONS_TOTAL on set operations", async () => {
+      expect.assertions(1);
+      await ServiceTest(({ cache, lifecycle }) => {
+        lifecycle.onReady(async () => {
+          await cache.set("testKey", "testValue");
+          const newCount = (await CACHE_SET_OPERATIONS_TOTAL.get()).values[0]
+            .value;
+          expect(newCount).toBe(1);
+        });
+      });
+    });
+
+    it("should increment CACHE_GET_OPERATIONS_TOTAL on get operations", async () => {
+      expect.assertions(1);
+      await ServiceTest(({ cache, lifecycle }) => {
+        lifecycle.onReady(async () => {
+          await cache.get("testKey");
+          const newCount = (await CACHE_GET_OPERATIONS_TOTAL.get()).values[0]
+            .value;
+          expect(newCount).toBe(1);
+        });
+      });
+    });
+
+    it("should increment CACHE_DELETE_OPERATIONS_TOTAL on delete operations", async () => {
+      expect.assertions(1);
+      await ServiceTest(({ cache, lifecycle }) => {
+        lifecycle.onReady(async () => {
+          await cache.del("testKey");
+          const newCount = (await CACHE_DELETE_OPERATIONS_TOTAL.get()).values[0]
+            .value;
+          expect(newCount).toBe(1);
+        });
+      });
+    });
+  });
 });

--- a/src/testing/cache.spec.ts
+++ b/src/testing/cache.spec.ts
@@ -1,0 +1,3 @@
+describe("Cache", () => {
+  //
+});

--- a/src/testing/testing.helper.ts
+++ b/src/testing/testing.helper.ts
@@ -1,0 +1,25 @@
+import { CreateApplication } from "../extensions";
+import { BootstrapOptions, TBlackHole, TServiceParams } from "../helpers";
+
+export const BASIC_BOOT = {
+  configuration: { boilerplate: { LOG_LEVEL: "silent" } },
+  hideLogLevel: true,
+} as BootstrapOptions;
+
+export async function ServiceTest(
+  callback: (params: TServiceParams) => TBlackHole,
+  options: BootstrapOptions = BASIC_BOOT,
+) {
+  const application = CreateApplication({
+    configurationLoaders: [],
+    // @ts-expect-error testing
+    name: "testing",
+    services: {
+      async Testing(params: TServiceParams) {
+        await callback(params);
+      },
+    },
+  });
+  await application.bootstrap(options);
+  await application.teardown();
+}

--- a/src/testing/wiring.spec.ts
+++ b/src/testing/wiring.spec.ts
@@ -7,14 +7,9 @@ import {
   InternalDefinition,
   LIB_BOILERPLATE,
   LifecycleStages,
-  LOADED_LIFECYCLES,
-  LOADED_MODULES,
-  MODULE_MAPPINGS,
   OptionalModuleConfiguration,
-  REVERSE_MODULE_MAPPING,
   ServiceMap,
   TServiceParams,
-  WIRE_PROJECT,
 } from "..";
 
 const FAKE_EXIT = (() => {}) as () => never;
@@ -57,17 +52,6 @@ describe("Wiring", () => {
       expect(library.services).toEqual({});
     });
 
-    it("properly wires services when creating a library", async () => {
-      const testService = jest.fn();
-      const library = CreateLibrary({
-        // @ts-expect-error For unit testing
-        name: "testing",
-        services: { testService },
-      });
-      await library[WIRE_PROJECT](undefined);
-      // Check that the service is wired correctly
-      expect(testService).toHaveBeenCalled();
-    });
     it("throws an error with invalid service definition", () => {
       expect(() => {
         CreateLibrary({
@@ -686,17 +670,19 @@ describe("Wiring", () => {
   // #region Internal
   describe("Internal", () => {
     it("populates maps during bootstrap", async () => {
+      let i: InternalDefinition;
       application = CreateApplication({
         configurationLoaders: [],
         // @ts-expect-error Testing
         name: "testing",
-        services: {},
+        services: {
+          Test({ internal }: TServiceParams) {
+            i = internal;
+          },
+        },
       });
       await application.bootstrap(BASIC_BOOT);
-      expect(MODULE_MAPPINGS.size).not.toEqual(0);
-      expect(LOADED_MODULES.size).not.toEqual(0);
-      expect(REVERSE_MODULE_MAPPING.size).not.toEqual(0);
-      expect(LOADED_LIFECYCLES.size).not.toEqual(0);
+      expect(i.boot.lifecycleHooks.size).not.toEqual(0);
       expect(LIB_BOILERPLATE).toBeDefined();
     });
   });

--- a/src/testing/wiring.spec.ts
+++ b/src/testing/wiring.spec.ts
@@ -690,6 +690,28 @@ describe("Wiring", () => {
 
   // #region Wiring
   describe("Wiring", () => {
+    it("should allow 2 separate apps to boot", async () => {
+      application = CreateApplication({
+        configurationLoaders: [],
+        // @ts-expect-error Testing
+        name: "testing",
+        services: {
+          Test() {},
+        },
+      });
+      await application.bootstrap(BASIC_BOOT);
+      const secondary = CreateApplication({
+        configurationLoaders: [],
+        // @ts-expect-error Testing
+        name: "testing_second",
+        services: {
+          Test() {},
+        },
+      });
+      await secondary.bootstrap(BASIC_BOOT);
+      await secondary.teardown();
+    });
+
     it("should add library to TServiceParams", async () => {
       let observed: unknown;
       application = CreateApplication({


### PR DESCRIPTION
#### Changes

This PR alters the way "multiboot" is defined. Previously, it meant any 2 applications inside of the process was not allowed. With this PR, the definition is redefined as the return of a `CreateApplication` may not be booted twice, without having performed a teardown first

This enables 2 different applications to live within the same process, interacting with each other

This was primarily accomplished through moving some local variables to live on `internal` instead, and breaking down the `wiring` extension a bit 

All external apis remain consistent

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the
  [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme and [docs](https://docs.digital-alchemy.app/) (updated or not needed)
- [x] Tests (added, updated or not needed)
