### PR TITLE
Service injection

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "repository": {
     "url": "git+https://github.com/Digital-Alchemy-TS/core"
   },
-  "version": "0.3.12",
+  "version": "0.3.13",
   "author": {
     "url": "https://github.com/zoe-codez",
     "name": "Zoe Codez"

--- a/src/helpers/wiring.helper.ts
+++ b/src/helpers/wiring.helper.ts
@@ -287,21 +287,37 @@ export type PartialConfiguration = Partial<{
 // #MARK: BootstrapOptions
 export type BootstrapOptions = {
   /**
+   * An extra library to load after the application is constructed.
+   * Can be used to provide testing specific logic
+   */
+  appendLibrary?: TLibrary;
+
+  /**
+   * An services to be appended to the application.
+   * Wired as if they were declared with the application, but doesn't come with any related type support
+   */
+  appendService?: ServiceMap;
+
+  /**
    * default: true
    */
   handleGlobalErrors?: boolean;
+
   /**
    * default values to use for configurations, before user values come in
    */
   configuration?: PartialConfiguration;
+
   /**
    * use this logger, instead of the baked in one. Maybe you want some custom transports or something? Put your customized thing here
    */
   customLogger?: ILogger;
+
   /**
    * Show detailed boot time statistics
    */
   showExtraBootStats?: boolean;
+
   /**
    * default false
    *


### PR DESCRIPTION
#### Changes

This PR adds the ability to inject libraries & services via the `.bootstrap` call. This allows for injecting additional logic related to unit testing, and running tests against an imported application definition

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the
  [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme and [docs](https://docs.digital-alchemy.app/) (updated or not needed)
- [ ] Tests (added, updated or not needed)
