### PR TITLE
Lifecycle event sorting

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "repository": {
     "url": "git+https://github.com/Digital-Alchemy-TS/core"
   },
-  "version": "0.3.13",
+  "version": "0.3.14",
   "author": {
     "url": "https://github.com/zoe-codez",
     "name": "Zoe Codez"

--- a/src/testing/wiring.spec.ts
+++ b/src/testing/wiring.spec.ts
@@ -297,11 +297,11 @@ describe("Wiring", () => {
           spy({ lifecycle }: TServiceParams) {
             lifecycle.onBootstrap(
               () => executionOrder.push("LowPriorityBootstrap"),
-              -1,
+              -10,
             );
             lifecycle.onBootstrap(
               () => executionOrder.push("HighPriorityBootstrap"),
-              -10,
+              -1,
             );
           },
         },


### PR DESCRIPTION
#### Changes

1. Fixed lifecycle events so the all sources have their events merged together into a flat list before running. Previously, each library would have it's own events run as a block, then the next library. This could cause some weird race conditions

2. Inverted sort order of low priorty lifecycle events to properly align with the description

Event priority properly follows this priority:

- (series) high to low / `1000` -> `0`
- (parallel) no priority given
- (series) negative values high to low / `-1` -> `-1000`

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the
  [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme and [docs](https://docs.digital-alchemy.app/) (updated or not needed)
- [x] Tests (added, updated or not needed)
