### PR TITLE
sliding scheduler checks at boot

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "repository": {
     "url": "git+https://github.com/Digital-Alchemy-TS/core"
   },
-  "version": "0.3.14",
+  "version": "0.3.15",
   "author": {
     "url": "https://github.com/zoe-codez",
     "name": "Zoe Codez"


### PR DESCRIPTION
#### Changes

1. The method `scheduler.sliding` will now query for next run time as part of init process
2. Warnings no longer be emitted if next time is in the past (will be silently ignored)

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the
  [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme and [docs](https://docs.digital-alchemy.app/) (updated or not needed)
- [😢] Tests (added, updated or not needed)
