### PR TITLE
Deferred initial sliding date calculation 

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "repository": {
     "url": "git+https://github.com/Digital-Alchemy-TS/core"
   },
-  "version": "0.3.15",
+  "version": "0.3.16",
   "author": {
     "url": "https://github.com/zoe-codez",
     "name": "Zoe Codez"

--- a/src/extensions/scheduler.extension.ts
+++ b/src/extensions/scheduler.extension.ts
@@ -171,7 +171,7 @@ export function Scheduler({ logger, lifecycle, internal }: TServiceParams) {
       });
       // find value for now (boot)
       // assumption: function should always return the same value inside of reset window
-      waitForNext();
+      lifecycle.onReady(() => waitForNext());
 
       return () => {
         scheduleStop();

--- a/src/extensions/scheduler.extension.ts
+++ b/src/extensions/scheduler.extension.ts
@@ -170,7 +170,6 @@ export function Scheduler({ logger, lifecycle, internal }: TServiceParams) {
         schedule: reset,
       });
       // find value for now (boot)
-      // assumption: function should always return the same value inside of reset window
       lifecycle.onReady(() => waitForNext());
 
       return () => {


### PR DESCRIPTION
#### Changes

`scheduler.sliding` waits for `onReady` before performing initial time calculation, ensuring all resources are available to do that operation

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the
  [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme and [docs](https://docs.digital-alchemy.app/) (updated or not needed)
- [x] Tests (added, updated or not needed)
