### PR TITLE
Enable optional depends

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "repository": {
     "url": "git+https://github.com/Digital-Alchemy-TS/core"
   },
-  "version": "24.6.4",
+  "version": "24.6.5",
   "author": {
     "url": "https://github.com/zoe-codez",
     "name": "Zoe Codez"

--- a/src/testing/wiring.spec.ts
+++ b/src/testing/wiring.spec.ts
@@ -1116,6 +1116,17 @@ describe("Wiring", () => {
       },
     });
 
+    const LIBRARY_D = CreateLibrary({
+      depends: [LIBRARY_A],
+      // @ts-expect-error testing
+      name: "D",
+
+      optionalDepends: [LIBRARY_B],
+      services: {
+        AddToList: () => list.push("C"),
+      },
+    });
+
     beforeEach(() => {
       list = [];
     });
@@ -1148,6 +1159,22 @@ describe("Wiring", () => {
       expect.assertions(1);
       await application.bootstrap(BASIC_BOOT);
       expect(failFastSpy).toHaveBeenCalled();
+    });
+
+    it("should not throw errors if a optional dependency is missing from the app", async () => {
+      application = CreateApplication({
+        configurationLoaders: [],
+        libraries: [LIBRARY_A, LIBRARY_D],
+        // @ts-expect-error testing
+        name: "testing",
+        services: {},
+      });
+      const failFastSpy = jest
+        .spyOn(process, "exit")
+        .mockImplementation(FAKE_EXIT);
+      expect.assertions(1);
+      await application.bootstrap(BASIC_BOOT);
+      expect(failFastSpy).not.toHaveBeenCalled();
     });
 
     it("should allow name compatible library substitutions", async () => {


### PR DESCRIPTION
#### Changes

- add the ability to provide optional library dependencies

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the
  [code](../CODE_OF_CONDUCT.md) of conduct
- [ ] Readme and [docs](https://docs.digital-alchemy.app/) (updated or not needed)
- [ ] Tests (added, updated or not needed)
