### PR TITLE
Throttle command

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -38,6 +38,7 @@
         "unicorn/prefer-module": "off",
         "@typescript-eslint/no-magic-numbers": "warn",
         "unicorn/no-object-as-default-parameter": "off",
+        "@cspell/spellchecker": ["warn", { "checkComments": false, "autoFix": true }],
         "unicorn/no-null": "off",
         "unicorn/no-empty-file": "off",
         "sonarjs/prefer-single-boolean-return": "off",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "repository": {
     "url": "git+https://github.com/Digital-Alchemy-TS/core"
   },
-  "version": "24.6.6",
+  "version": "24.7.1",
   "author": {
     "url": "https://github.com/zoe-codez",
     "name": "Zoe Codez"

--- a/src/helpers/utilities.helper.ts
+++ b/src/helpers/utilities.helper.ts
@@ -90,6 +90,21 @@ export function sleep(target: number | Date = SECOND): SleepReturn {
   return out;
 }
 
+export const ACTIVE_THROTTLE = new Map<string, SleepReturn>();
+export async function throttle(
+  identifier: string,
+  timeout: number,
+): Promise<void> {
+  const current = ACTIVE_THROTTLE.get(identifier);
+  if (current) {
+    current.kill("stop");
+  }
+  const delay = sleep(timeout);
+  ACTIVE_THROTTLE.set(identifier, delay);
+  await delay;
+  ACTIVE_THROTTLE.delete(identifier);
+}
+
 export const asyncNoop = async () => await sleep(NONE);
 export const noop = () => {};
 

--- a/src/testing/utilities.spec.ts
+++ b/src/testing/utilities.spec.ts
@@ -1,0 +1,104 @@
+import { ACTIVE_THROTTLE, sleep, throttle } from "../helpers";
+
+describe("utilities", () => {
+  describe("sleep", () => {
+    it("should delay execution by the specified timeout", async () => {
+      const timeout = 100;
+      const start = Date.now();
+
+      await sleep(timeout);
+
+      const end = Date.now();
+      expect(end - start).toBeGreaterThanOrEqual(timeout);
+    });
+
+    it('should stop early when kill("continue") is called', async () => {
+      const timeout = 200;
+      const start = Date.now();
+
+      const timer = sleep(timeout);
+      setTimeout(() => timer.kill("continue"), 50);
+      await timer;
+
+      const end = Date.now();
+      expect(end - start).toBeGreaterThanOrEqual(50);
+      expect(end - start).toBeLessThan(timeout);
+    });
+
+    it('should not resolve if kill("stop") is called before timeout', async () => {
+      const timeout = 200;
+      const start = Date.now();
+
+      const timer = sleep(timeout);
+      setTimeout(() => timer.kill("stop"), 50);
+      await new Promise((resolve) => setTimeout(resolve, 100)); // Wait for 100 milliseconds to ensure the stop has taken effect
+
+      const end = Date.now();
+      expect(end - start).toBeGreaterThanOrEqual(100);
+      expect(end - start).toBeLessThan(timeout);
+    });
+
+    it("should handle date object correctly", async () => {
+      const targetDate = new Date(Date.now() + 100);
+      const start = Date.now();
+
+      await sleep(targetDate);
+
+      const end = Date.now();
+      expect(end - start).toBeGreaterThanOrEqual(100);
+    });
+  });
+
+  describe("throttle", () => {
+    it("should delay execution by the specified timeout", async () => {
+      const identifier = "test-id";
+      const timeout = 10;
+      const start = Date.now();
+
+      await throttle(identifier, timeout);
+
+      const end = Date.now();
+      expect(end - start).toBeGreaterThanOrEqual(timeout);
+    });
+
+    it("should cancel the previous throttle if called with the same identifier", async () => {
+      const identifier = "test-id";
+      const timeout1 = 20;
+      const timeout2 = 10;
+
+      const start = Date.now();
+      throttle(identifier, timeout1);
+      await throttle(identifier, timeout2);
+
+      const end = Date.now();
+      expect(end - start).toBeLessThan(timeout1);
+      expect(end - start).toBeGreaterThanOrEqual(timeout2);
+    });
+
+    it("should allow multiple identifiers to be throttled independently", async () => {
+      const identifier1 = "test-id-1";
+      const identifier2 = "test-id-2";
+      const timeout1 = 10;
+      const timeout2 = 10;
+
+      const start1 = Date.now();
+      throttle(identifier1, timeout1);
+
+      const start2 = Date.now();
+      await throttle(identifier2, timeout2);
+
+      const end1 = Date.now();
+      expect(end1 - start1).toBeGreaterThanOrEqual(timeout1);
+      expect(end1 - start2).toBeGreaterThanOrEqual(timeout2);
+    });
+
+    it("should clear the throttle once the timeout has passed", async () => {
+      const identifier = "test-id";
+      const timeout = 100;
+
+      await throttle(identifier, timeout);
+
+      expect(ACTIVE_THROTTLE.has(identifier)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
#### Changes

- add new helper function `throttle`

```typescript
async function doTheThing() {
	await throttle("throttle_based_on", 100 /* within ms */);
}
```

Throttle will wait for ms, like `sleep`, then returns void
If it gets called multiple times within the time window, the previous call will not resolve, but the time window will be pushed out.

This can be particularly helpful for event callbacks where it may receive many calls in a short burst, but it it only really needs to run once 

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the
  [code](../CODE_OF_CONDUCT.md) of conduct
- [ ] Readme and [docs](https://docs.digital-alchemy.app/) (updated or not needed)
- [x] Tests (added, updated or not needed)
