### PR TITLE
Configurable timestamps

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "repository": {
     "url": "git+https://github.com/Digital-Alchemy-TS/core"
   },
-  "version": "24.8.4",
+  "version": "24.9.1",
   "author": {
     "url": "https://github.com/zoe-codez",
     "name": "Zoe Codez"

--- a/src/extensions/logger.extension.ts
+++ b/src/extensions/logger.extension.ts
@@ -72,6 +72,8 @@ const LEVEL_MAX = 7;
 // #region Service definition
 export async function Logger({ lifecycle, config, internal }: TServiceParams) {
   const chalk = (await import("chalk")).default;
+  const timestampFormat =
+    internal.boot.options.loggerOptions?.timestamp_format ?? "ddd HH:mm:ss.SSS";
 
   const YELLOW_DASH = chalk.yellowBright(frontDash);
   const BLUE_TICK = chalk.blue(`>`);
@@ -132,9 +134,7 @@ export async function Logger({ lifecycle, config, internal }: TServiceParams) {
         delete data.context;
         delete data.name;
 
-        const timestamp = chalk.white(
-          `[${dayjs().format("ddd hh:mm:ss.SSS")}]`,
-        );
+        const timestamp = chalk.white(`[${dayjs().format(timestampFormat)}]`);
         let logMessage: string;
         if (!is.empty(parameters)) {
           const text = parameters.shift() as string;

--- a/src/extensions/wiring.extension.ts
+++ b/src/extensions/wiring.extension.ts
@@ -508,8 +508,9 @@ async function Teardown(internal: InternalDefinition, logger: ILogger) {
     internal.boot.completedLifecycleEvents.add("ShutdownComplete");
   } catch (error) {
     // ! oof
-    logger.error(
-      { error, name: Teardown },
+    // eslint-disable-next-line no-console
+    console.error(
+      { error },
       "error occurred during teardown, some lifecycle events may be incomplete",
     );
   }

--- a/src/helpers/wiring.helper.ts
+++ b/src/helpers/wiring.helper.ts
@@ -338,6 +338,16 @@ export type BootstrapOptions = {
   customLogger?: ILogger;
 
   /**
+   * fine tine the built in logger
+   */
+  loggerOptions?: {
+    /**
+     * > default: ddd HH:mm:ss.SSS
+     */
+    timestamp_format?: string;
+  };
+
+  /**
    * Show detailed boot time statistics
    */
   showExtraBootStats?: boolean;

--- a/src/testing/logger.spec.ts
+++ b/src/testing/logger.spec.ts
@@ -3,6 +3,8 @@
 // magic import, do not remove / put anything above
 import "..";
 
+import dayjs from "dayjs";
+
 import { CreateApplication, is } from "../extensions";
 import {
   ApplicationDefinition,
@@ -163,6 +165,32 @@ describe("Logger", () => {
       expect(
         params.internal.boilerplate.logger.prettyFormatMessage(message),
       ).toBe(expected);
+    });
+  });
+
+  describe("Fine Tuning", () => {
+    it("allows timestamp format to be configured", async () => {
+      const format = "ddd HH:mm:ss.SSS";
+      application = CreateApplication({
+        configurationLoaders: [],
+        // @ts-expect-error For unit testing
+        name: "testing",
+        services: {
+          Test({ logger }: TServiceParams) {
+            jest.spyOn(console, "error").mockImplementation(() => {});
+            jest.spyOn(console, "log").mockImplementation(() => {});
+            const spy = jest
+              .spyOn(dayjs.prototype, "format")
+              .mockImplementation(() => "timestamp");
+            logger.info(`test`);
+            expect(spy).toHaveBeenCalledWith(format);
+          },
+        },
+      });
+      await application.bootstrap({
+        // ...BASIC_BOOT,
+        loggerOptions: { timestamp_format: format },
+      });
     });
   });
 });

--- a/src/testing/logger.spec.ts
+++ b/src/testing/logger.spec.ts
@@ -170,7 +170,7 @@ describe("Logger", () => {
 
   describe("Fine Tuning", () => {
     it("allows timestamp format to be configured", async () => {
-      const format = "ddd HH:mm:ss.SSS";
+      const format = "ddd HH:mm:ss";
       application = CreateApplication({
         configurationLoaders: [],
         // @ts-expect-error For unit testing


### PR DESCRIPTION
## 📬 Changes

<!-- short description of what's going on, help the changelog be useful -->

> addresses #63 

- Made timestamps configurable
- Updated default format to be 24h

## 🗒️ Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the
  [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme and [docs](https://docs.digital-alchemy.app/) (updated or not needed)
- [x] Tests (added, updated or not needed)
