### PR TITLE
Remove jest testing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": {
     "url": "git+https://github.com/Digital-Alchemy-TS/core"
   },
-  "version": "24.10.3",
+  "version": "24.10.4",
   "author": {
     "url": "https://github.com/zoe-codez",
     "name": "Zoe Codez"

--- a/src/services/logger.extension.ts
+++ b/src/services/logger.extension.ts
@@ -185,12 +185,24 @@ export async function Logger({
               .slice(SYMBOL_START, SYMBOL_END)
               .join("\n");
         }
-        if (["warn", "error", "fatal"].includes(key)) {
-          global.console.error(message);
-          return;
+        switch (key) {
+          case "warn": {
+            global.console.warn(message);
+            return;
+          }
+          case "debug": {
+            global.console.debug(message);
+            return;
+          }
+          case "error":
+          case "fatal": {
+            global.console.error(message);
+            return;
+          }
+          default: {
+            global.console.log(message);
+          }
         }
-
-        global.console.log(message);
       };
     });
   } else {

--- a/src/testing/mock-logger.ts
+++ b/src/testing/mock-logger.ts
@@ -2,11 +2,11 @@ import { ILogger } from "../helpers";
 
 export function createMockLogger(): ILogger {
   return {
-    debug: jest.fn(),
-    error: jest.fn(),
-    fatal: jest.fn(),
-    info: jest.fn(),
-    trace: jest.fn(),
-    warn: jest.fn(),
+    debug: () => {},
+    error: () => {},
+    fatal: () => {},
+    info: () => {},
+    trace: () => {},
+    warn: () => {},
   };
 }

--- a/src/testing/test-module.ts
+++ b/src/testing/test-module.ts
@@ -276,12 +276,12 @@ export function TestRunner<S extends ServiceMap, C extends OptionalModuleConfigu
         customLogger: bootOptions?.emitLogs
           ? undefined
           : (bootOptions?.customLogger ?? {
-              debug: jest.fn(),
-              error: jest.fn(),
-              fatal: jest.fn(),
-              info: jest.fn(),
-              trace: jest.fn(),
-              warn: jest.fn(),
+              debug: () => {},
+              error: () => {},
+              fatal: () => {},
+              info: () => {},
+              trace: () => {},
+              warn: () => {},
             }),
         loggerOptions: bootOptions?.loggerOptions,
       });

--- a/testing/configuration.spec.ts
+++ b/testing/configuration.spec.ts
@@ -579,6 +579,7 @@ describe("Configuration", () => {
         let testFiles: ReturnType<typeof ConfigTesting> = undefined;
 
         jest.spyOn(global.console, "error").mockImplementation(() => {});
+        jest.spyOn(global.console, "warn").mockImplementation(() => {});
         jest.spyOn(global.console, "log").mockImplementation(() => {});
         const helper = CreateApplication({
           configurationLoaders: [],

--- a/testing/internal.spec.ts
+++ b/testing/internal.spec.ts
@@ -12,6 +12,8 @@ export const BASIC_BOOT = {
 describe("Fetch Extension", () => {
   beforeAll(async () => {
     jest.spyOn(global.console, "error").mockImplementation(() => {});
+    jest.spyOn(global.console, "warn").mockImplementation(() => {});
+    jest.spyOn(global.console, "debug").mockImplementation(() => {});
     jest.spyOn(global.console, "log").mockImplementation(() => {});
     const preload = CreateApplication({
       // @ts-expect-error testing

--- a/testing/logger.spec.ts
+++ b/testing/logger.spec.ts
@@ -27,12 +27,13 @@ describe("Logger", () => {
       expect.assertions(1);
 
       const customLogger = createMockLogger();
+      const spy = jest.spyOn(customLogger, "fatal");
       await TestRunner()
         .setOptions({ customLogger })
         .run(({ internal, logger }) => {
           internal.boilerplate.configuration.set("boilerplate", "LOG_LEVEL", "warn");
           logger.fatal("HIT");
-          expect(customLogger.fatal).toHaveBeenCalled();
+          expect(spy).toHaveBeenCalled();
         });
     });
 
@@ -262,6 +263,7 @@ describe("Logger", () => {
     it("allows timestamp format to be configured", async () => {
       const format = "ddd HH:mm:ss";
       jest.spyOn(global.console, "error").mockImplementation(() => {});
+      jest.spyOn(global.console, "debug").mockImplementation(() => {});
       jest.spyOn(global.console, "log").mockImplementation(() => {});
 
       await TestRunner()
@@ -279,8 +281,10 @@ describe("Logger", () => {
     // #MARK: level matching
     describe("level matching", () => {
       it("warn uses error", async () => {
-        const spy = jest.spyOn(global.console, "error").mockImplementation(() => {});
+        const spy = jest.spyOn(global.console, "warn").mockImplementation(() => {});
         jest.spyOn(global.console, "log").mockImplementation(() => {});
+        jest.spyOn(global.console, "debug").mockImplementation(() => {});
+        jest.spyOn(global.console, "error").mockImplementation(() => {});
         await TestRunner()
           .emitLogs()
           .run(({ logger }) => {
@@ -292,6 +296,7 @@ describe("Logger", () => {
 
       it("error uses error", async () => {
         const spy = jest.spyOn(global.console, "error").mockImplementation(() => {});
+        jest.spyOn(global.console, "debug").mockImplementation(() => {});
         jest.spyOn(global.console, "log").mockImplementation(() => {});
         await TestRunner()
           .emitLogs()
@@ -304,6 +309,7 @@ describe("Logger", () => {
 
       it("fatal uses error", async () => {
         const spy = jest.spyOn(global.console, "error").mockImplementation(() => {});
+        jest.spyOn(global.console, "debug").mockImplementation(() => {});
         jest.spyOn(global.console, "log").mockImplementation(() => {});
         await TestRunner()
           .emitLogs()
@@ -316,6 +322,7 @@ describe("Logger", () => {
 
       it("trace uses log", async () => {
         jest.spyOn(global.console, "error").mockImplementation(() => {});
+        jest.spyOn(global.console, "debug").mockImplementation(() => {});
         const spy = jest.spyOn(global.console, "log").mockImplementation(() => {});
         await TestRunner()
           .emitLogs()
@@ -328,7 +335,8 @@ describe("Logger", () => {
 
       it("trace uses debug", async () => {
         jest.spyOn(global.console, "error").mockImplementation(() => {});
-        const spy = jest.spyOn(global.console, "log").mockImplementation(() => {});
+        jest.spyOn(global.console, "log").mockImplementation(() => {});
+        const spy = jest.spyOn(global.console, "debug").mockImplementation(() => {});
         await TestRunner()
           .emitLogs()
           .run(({ logger }) => {
@@ -340,6 +348,7 @@ describe("Logger", () => {
 
       it("trace uses info", async () => {
         jest.spyOn(global.console, "error").mockImplementation(() => {});
+        jest.spyOn(global.console, "debug").mockImplementation(() => {});
         const spy = jest.spyOn(global.console, "log").mockImplementation(() => {});
         await TestRunner()
           .emitLogs()
@@ -365,6 +374,7 @@ describe("Logger", () => {
       it("emits http logs when url is set", async () => {
         expect.assertions(1);
         jest.spyOn(console, "error").mockImplementation(() => undefined);
+        jest.spyOn(global.console, "debug").mockImplementation(() => {});
         jest.spyOn(console, "log").mockImplementation(() => undefined);
         await TestRunner()
           .emitLogs("info")
@@ -386,6 +396,7 @@ describe("Logger", () => {
       it("can emit logIdx", async () => {
         expect.assertions(1);
         jest.spyOn(console, "error").mockImplementation(() => undefined);
+        jest.spyOn(global.console, "debug").mockImplementation(() => {});
         jest.spyOn(console, "log").mockImplementation(() => undefined);
         const spy = jest.fn();
         await TestRunner()
@@ -411,6 +422,7 @@ describe("Logger", () => {
       it("does not emit logIdx by default", async () => {
         expect.assertions(1);
         jest.spyOn(console, "error").mockImplementation(() => undefined);
+        jest.spyOn(global.console, "debug").mockImplementation(() => {});
         jest.spyOn(console, "log").mockImplementation(() => undefined);
         const spy = jest.fn();
         await TestRunner()
@@ -438,6 +450,7 @@ describe("Logger", () => {
       it("can emit ms", async () => {
         expect.assertions(1);
         jest.spyOn(console, "error").mockImplementation(() => undefined);
+        jest.spyOn(global.console, "debug").mockImplementation(() => {});
         jest.spyOn(console, "log").mockImplementation(() => undefined);
         const spy = jest.fn();
         await TestRunner()
@@ -463,6 +476,7 @@ describe("Logger", () => {
       it("can emit ms in green", async () => {
         expect.assertions(1);
         jest.spyOn(console, "error").mockImplementation(() => undefined);
+        jest.spyOn(global.console, "debug").mockImplementation(() => {});
         jest.spyOn(console, "log").mockImplementation(() => undefined);
         const spy = jest.fn();
         await TestRunner()
@@ -488,6 +502,7 @@ describe("Logger", () => {
       it("prepends ms number", async () => {
         expect.assertions(1);
         jest.spyOn(console, "error").mockImplementation(() => undefined);
+        jest.spyOn(global.console, "debug").mockImplementation(() => {});
         const spy = jest.spyOn(console, "log").mockImplementation(() => undefined);
         await TestRunner()
           .emitLogs("info")
@@ -502,6 +517,7 @@ describe("Logger", () => {
       it("does not emit ms by default", async () => {
         expect.assertions(1);
         jest.spyOn(console, "error").mockImplementation(() => undefined);
+        jest.spyOn(global.console, "debug").mockImplementation(() => {});
         jest.spyOn(console, "log").mockImplementation(() => undefined);
         const spy = jest.fn();
         await TestRunner()
@@ -529,6 +545,7 @@ describe("Logger", () => {
       it("will merge als data if enabled", async () => {
         expect.assertions(1);
         jest.spyOn(console, "error").mockImplementation(() => undefined);
+        jest.spyOn(global.console, "debug").mockImplementation(() => {});
         jest.spyOn(console, "log").mockImplementation(() => undefined);
         const spy = jest.fn();
         await TestRunner()
@@ -559,6 +576,7 @@ describe("Logger", () => {
       it("does not merge als data if disabled", async () => {
         expect.assertions(1);
         jest.spyOn(console, "error").mockImplementation(() => undefined);
+        jest.spyOn(global.console, "debug").mockImplementation(() => {});
         jest.spyOn(console, "log").mockImplementation(() => undefined);
         const spy = jest.fn();
         await TestRunner()

--- a/testing/wiring.spec.ts
+++ b/testing/wiring.spec.ts
@@ -515,6 +515,7 @@ describe("Wiring", () => {
 
     it("includes extended stats with switch", async () => {
       const mockLogger = createMockLogger();
+      const spy = jest.spyOn(mockLogger, "info");
       expect.assertions(1);
       const app = CreateApplication({
         // @ts-expect-error testing
@@ -525,7 +526,7 @@ describe("Wiring", () => {
         customLogger: mockLogger,
         showExtraBootStats: true,
       });
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(spy).toHaveBeenCalledWith(
         "boilerplate:wiring",
         expect.objectContaining({
           Bootstrap: expect.any(String),
@@ -542,6 +543,7 @@ describe("Wiring", () => {
 
     it("does not log extended boot stats by default", async () => {
       const mockLogger = createMockLogger();
+      const spy = jest.spyOn(mockLogger, "info");
       expect.assertions(2);
       const app = CreateApplication({
         // @ts-expect-error testing
@@ -551,7 +553,7 @@ describe("Wiring", () => {
       await app.bootstrap({
         customLogger: mockLogger,
       });
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(spy).toHaveBeenCalledWith(
         "boilerplate:wiring",
         expect.objectContaining({
           Total: expect.any(String),
@@ -559,7 +561,7 @@ describe("Wiring", () => {
         "[%s] application bootstrapped",
         "app",
       );
-      expect(mockLogger.info).not.toHaveBeenCalledWith(
+      expect(spy).not.toHaveBeenCalledWith(
         "boilerplate:wiring",
         expect.objectContaining({
           Ready: expect.any(String),
@@ -1081,7 +1083,9 @@ describe("Wiring", () => {
 
       let hit = false;
       jest.spyOn(global.console, "log").mockImplementation(() => {});
-      jest.spyOn(global.console, "error").mockImplementation((text: string) => {
+      jest.spyOn(global.console, "error").mockImplementation(() => {});
+      jest.spyOn(global.console, "debug").mockImplementation(() => {});
+      jest.spyOn(global.console, "warn").mockImplementation((text: string) => {
         hit ||= text?.includes("depends different version");
       });
       const customLogger = createMockLogger();


### PR DESCRIPTION
## 📬 Changes

- stopped mock logger from implying jest (bun test compat)
- change `logger.debug` to use `console.debug`
- change `logger.warn` to use `console.warn`

## 🗒️ Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the
  [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme and [docs](https://docs.digital-alchemy.app/) (updated or not needed)
- [x] Tests (added, updated or not needed)
