### PR TITLE
Add is to internal.utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": {
     "url": "git+https://github.com/Digital-Alchemy-TS/core"
   },
-  "version": "25.1.3",
+  "version": "25.2.1",
   "author": {
     "url": "https://github.com/zoe-codez",
     "name": "Zoe Codez"

--- a/src/services/configuration.service.mts
+++ b/src/services/configuration.service.mts
@@ -20,7 +20,6 @@ import {
   TServiceParams,
   TSetConfig,
 } from "../index.mts";
-import { is } from "./is.service.mts";
 
 export const INITIALIZE = Symbol.for("initialize");
 export const LOAD_PROJECT = Symbol.for("load-project");
@@ -36,6 +35,8 @@ export function Configuration({
   lifecycle,
   internal,
 }: TServiceParams): DigitalAlchemyConfiguration {
+  const { is } = internal.utils;
+
   // modern problems require modern solutions
   let logger: ILogger;
   lifecycle.onPreInit(() => (logger = internal.boilerplate.logger.context(context)));

--- a/src/services/internal.service.mts
+++ b/src/services/internal.service.mts
@@ -24,7 +24,7 @@ import {
   TResolvedModuleMappings,
   YEAR,
 } from "../index.mts";
-import { is } from "./is.service.mts";
+import { is, IsIt } from "./is.service.mts";
 import { CreateLifecycle } from "./lifecycle.service.mts";
 import { LIB_BOILERPLATE } from "./wiring.service.mts";
 
@@ -49,6 +49,12 @@ export class InternalUtils {
    * Making listener changes should only be done from within the context of service functions
    */
   public event: EventEmitter;
+
+  /**
+   * reference to `is` instance that's importable from `core`
+   */
+  public is: IsIt;
+
   constructor() {
     this.event = new EventEmitter();
     this.event.setMaxListeners(NONE);

--- a/src/services/logger.service.mts
+++ b/src/services/logger.service.mts
@@ -19,7 +19,6 @@ import {
   TLoggerFunction,
   TServiceParams,
 } from "../index.mts";
-import { is } from "./is.service.mts";
 
 const LOG_LEVEL_PRIORITY = {
   debug: 20,
@@ -51,6 +50,7 @@ export async function Logger({
   internal,
   als,
 }: TServiceParams): Promise<DigitalAlchemyLogger> {
+  const { is } = internal.utils;
   let lastMessage = performance.now();
   let logCounter = START;
   const extraTargets = new Set<GetLogger | LogStreamTarget>();

--- a/src/services/scheduler.service.mts
+++ b/src/services/scheduler.service.mts
@@ -13,9 +13,9 @@ import {
   TContext,
   TServiceParams,
 } from "../index.mts";
-import { is } from "./is.service.mts";
 
 export function Scheduler({ logger, lifecycle, internal }: TServiceParams): SchedulerBuilder {
+  const { is } = internal.utils;
   const stop = new Set<ScheduleRemove>();
 
   // #MARK: lifecycle events

--- a/src/services/wiring.service.mts
+++ b/src/services/wiring.service.mts
@@ -277,6 +277,7 @@ export function CreateApplication<S extends ServiceMap, C extends OptionalModule
         );
       }
       internal = new InternalDefinition();
+      internal.utils.is = is;
       const out = await bootstrap(application, options, internal);
       application.booted = true;
       RUNNING_APPLICATIONS.set(name, application);
@@ -414,7 +415,6 @@ async function bootstrap<S extends ServiceMap, C extends OptionalModuleConfigura
     // * Recreate base eventemitter
     internal.utils.event = new EventEmitter();
     internal.utils.event.setMaxListeners(NONE);
-    internal.utils.is = is;
 
     // * Generate a new boilerplate module
     LIB_BOILERPLATE = createBoilerplate();

--- a/src/services/wiring.service.mts
+++ b/src/services/wiring.service.mts
@@ -414,7 +414,7 @@ async function bootstrap<S extends ServiceMap, C extends OptionalModuleConfigura
     // * Recreate base eventemitter
     internal.utils.event = new EventEmitter();
     internal.utils.event.setMaxListeners(NONE);
-    // ? Some libraries need to be aware of
+    internal.utils.is = is;
 
     // * Generate a new boilerplate module
     LIB_BOILERPLATE = createBoilerplate();

--- a/testing/als.spec.mts
+++ b/testing/als.spec.mts
@@ -37,6 +37,7 @@ describe("ALS", () => {
 
   it("getLogData", async () => {
     await TestRunner().run(({ als }) => {
+      // @ts-expect-error testing
       als.enterWith({ logs: { test: true } });
       const data = als.getLogData();
       expect(data).toEqual({ test: true });


### PR DESCRIPTION
## 📬 Changes

- Attach `is` to `internal.utils` 

Still importable as standalone, libraries should prefer the `internal` version going forward. Fixes some edge cases when using `yarn link` against different libraries

## 🗒️ Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the
  [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme and [docs](https://docs.digital-alchemy.app/) (updated or not needed)
- [x] Tests (added, updated or not needed)
