### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: read
 jobs:
   lint-and-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Digital-Alchemy-TS/core/security/code-scanning/12](https://github.com/Digital-Alchemy-TS/core/security/code-scanning/12)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Based on the provided steps, the workflow primarily performs read operations (e.g., checking out the repository, setting up Node.js, running tests, and uploading coverage reports). Therefore, we will set `contents: read` as the minimal permission. Additionally, since the workflow uploads coverage reports to Codecov, it does not appear to require any write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
