### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Digital-Alchemy-TS/core/security/code-scanning/11](https://github.com/Digital-Alchemy-TS/core/security/code-scanning/11)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Since the workflow does not appear to require write access to repository contents, we will set `contents: read`. This ensures the workflow has only the permissions it needs, reducing the risk of misuse.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
