### PR TITLE
feat: env var double underscore separator support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,302 @@
+# CLAUDE.md — @digital-alchemy/core
+
+## 1. What core is
+
+`@digital-alchemy/core` is a zero-magic dependency-injection framework for TypeScript. There is no reflection, no decorators, no class hierarchy. Every service is a plain function that receives its dependencies through a single destructured parameter — `TServiceParams`.
+
+```typescript
+export function MyService({ logger, lifecycle, config }: TServiceParams) {
+  lifecycle.onReady(() => {
+    logger.info("ready");
+  });
+  return { doThing };
+}
+```
+
+The framework wires up all declared services at bootstrap time, building a dependency graph from the `libraries` and `services` fields of each `CreateApplication` / `CreateLibrary` call. Once wired, every service receives its full `TServiceParams` synchronously (with async factories awaited).
+
+This repo is the foundation every other `@digital-alchemy` library depends on. Changes to exports, lifecycle semantics, or `TServiceParams` shape ripple downstream into every consumer. Treat public API surface changes as breaking.
+
+---
+
+## 2. Repo orientation
+
+### `src/services/*.mts` — stateful service factories
+
+| File | Owns / responsibility | Read by |
+|---|---|---|
+| `als.service.mts` | `AsyncLocalStorage` wrapper; `enterWith`, `run`, `getStore`, `getLogData` | Logger (ALS log merging), any code needing per-request context |
+| `configuration.service.mts` | Config state map, loader orchestration, proxy for `config.*`, `setConfig`, `mergeConfig`, `validateConfig`, `onUpdate` | `wiring.service.mts` at bootstrap; every service via `config` injection |
+| `internal.service.mts` | `InternalDefinition` class (boot state, module maps, lifecycle ref); `InternalUtils` (object path get/set/del, `is`, `relativeDate`, `titleCase`); `safeExec` | All services — injected as `internal` |
+| `is.service.mts` | `IsIt` class — type guards and small utilities (`array`, `boolean`, `empty`, `equal`, `function`, `object`, `string`, etc.); exports singleton `is` | Imported directly by `lifecycle.service.mts` and `wiring.service.mts` to break circular deps; everywhere else reached as `internal.utils.is` |
+| `lifecycle.service.mts` | `CreateLifecycle` — per-bootstrap lifecycle event registry; priority-sorted callback execution across all seven stages | `wiring.service.mts` owns the lifecycle instance; services attach via `lifecycle.*` injection |
+| `logger.service.mts` | `Logger` factory — chalk/stdout formatter, `context(ctx)` builder, level filtering, `addTarget`, `updateShouldLog`, ALS integration, `systemLogger` | Every service via `logger` injection; `internal.boilerplate.logger` |
+| `scheduler.service.mts` | `Scheduler` factory — cron, interval, sliding, `setTimeout`, `setInterval`, `sleep`; registers stop callbacks for clean shutdown; returns a builder called with `(context: TContext)` | Every service via `scheduler` injection |
+| `wiring.service.mts` | Bootstrap orchestration — `CreateApplication`, `wireService`, `CreateBoilerplate`, `teardown`, SIGINT/SIGTERM handling; owns `LIB_BOILERPLATE` | Entry point for all apps; do not call `wireService` directly |
+| `index.mts` | Re-exports all service exports | Everything in `src/` imports from `../index.mts` |
+
+### `src/helpers/*.mts` — pure logic, types, and utilities
+
+**What distinguishes helpers from services:** helpers are side-effect-free modules containing types, utility functions, constants, and small classes. They do not receive `TServiceParams`. Services are factories that receive DI params and return an API object.
+
+| File | Owns |
+|---|---|
+| `async.mts` | `each`, `eachSeries`, `eachLimit` — async iteration helpers that replace inconsistent `async` library behavior |
+| `config-environment-loader.mts` | `ConfigLoaderEnvironment` — reads env vars and CLI switches; search order is `MODULE__KEY` (double-underscore) → `MODULE_KEY` (single-underscore) → `KEY` |
+| `config-file-loader.mts` | `configLoaderFile`, `configFilePaths`, `loadConfigFromFile`, `withExtensions` — file-based config loading (JSON, YAML, INI, auto-detect) |
+| `config.mts` | All config types (`AnyConfig`, `StringConfig`, `BooleanConfig`, etc.), `ConfigLoaderParams`, `ConfigLoaderReturn`, `findKey`, `iSearchKey`, `loadDotenv`, `parseConfig`, `KnownConfigs` |
+| `context.mts` | `TContext` branded string type; `IContextBrand` |
+| `cron.mts` | `CronExpression` enum, `TOffset`, `SchedulerCronOptions`, `SchedulerIntervalOptions`, `SchedulerSlidingOptions`, `DigitalAlchemyScheduler`, `SchedulerBuilder` |
+| `errors.mts` | `BootstrapException` (wiring-time errors), `InternalError` (runtime errors) — both carry `context`, `cause`, `timestamp` |
+| `events.mts` | Global error event name constants (`DIGITAL_ALCHEMY_NODE_GLOBAL_ERROR`, etc.) |
+| `extend.mts` | `deepExtend`, `deepCloneArray`, `cloneSpecificValue` — deep merge utilities |
+| `index.mts` | Re-exports all helper exports; new public helpers thread through here |
+| `lifecycle.mts` | `TLifecycleBase`, `TLifeCycleRegister`, `LIFECYCLE_STAGES` array, `LifecycleStages` type, `LifecycleCallback` |
+| `logger.mts` | `ILogger`, `TLoggerFunction`, `DigitalAlchemyLogger`, `GetLogger`, `METHOD_COLORS`, `fatalLog`, `EVENT_UPDATE_LOG_LEVELS` |
+| `module.mts` | `createModule`, `DigitalAlchemyModule`, `ModuleExtension` — chainable module builder that can export to application, library, or test runner |
+| `service-runner.mts` | `ServiceRunner` — minimal one-service bootstrap helper for scripts |
+| `utilities.mts` | Numeric constants (`START`, `NONE`, `EMPTY`, `FIRST`, `ARRAY_OFFSET`, `SINGLE`, `UP`, `DOWN`, `MINUTE`, `HOUR`, `DAY`, `SECOND`, `YEAR`, etc.); `sleep`, `debounce`, `toOffsetMs`, `toOffsetDuration`, `SleepReturn`, `TBlackHole` |
+| `wiring.mts` | `TServiceParams`, `ServiceFunction`, `ServiceMap`, `ApplicationDefinition`, `LibraryDefinition`, `BootstrapOptions`, `TInjectedConfig`, `LoadedModules`, `buildSortOrder`, `CreateLibrary`, `wireOrder`, `COERCE_CONTEXT`, `WIRE_PROJECT` |
+
+### `src/testing/*.mts` — test infrastructure (not test cases)
+
+| File | Owns |
+|---|---|
+| `mock-logger.mts` | `createMockLogger()` — returns a no-op `ILogger`; import in specs to suppress output |
+| `test-module.mts` | `TestRunner` factory + `iTestRunner` interface — boots a real DI graph scoped to a test; chainable API: `.configure`, `.setOptions`, `.run`, `.serviceParams`, `.setup`, `.appendLibrary`, `.appendService`, `.replaceLibrary`, `.teardown` |
+| `index.mts` | Re-exports `mock-logger` and `test-module` |
+
+### `testing/` (sibling of `src/`, not inside it)
+
+All `.spec.mts` files live here. Each spec file maps to a service or helper:
+`als.spec.mts`, `configuration.spec.mts`, `internal.spec.mts`, `is.spec.mts`, `logger.spec.mts`, `scheduler.spec.mts`, `testing.spec.mts`, `utilities.spec.mts`, `wiring.spec.mts`. A `setup.mts` file and `pipelines/` subdirectory handle vitest global setup.
+
+---
+
+## 3. The TServiceParams pattern in core specifically
+
+### Reaching `is`
+
+**Inside core services and helpers**, use `internal.utils.is` — do not `import { is }` from the index:
+
+```typescript
+// correct inside a service factory
+export function MyService({ internal }: TServiceParams) {
+  const { is } = internal.utils;
+  if (is.empty(value)) { ... }
+}
+```
+
+**The one exception:** `is.service.mts` is imported directly in `lifecycle.service.mts` and `wiring.service.mts` to break a circular dependency that would form if they went through `../index.mts`. This is intentional — leave it.
+
+### Dual-arity logger with `{ name: fnRef }` tagging
+
+Every function entry logs with its own function reference as the `name` field. This appears in the rendered output as the function name, enabling precise call-site identification without string literals.
+
+```typescript
+function loadThing(id: string) {
+  logger.trace({ name: loadThing, id }, "loading");
+  // ...
+  logger.debug({ name: loadThing }, "loaded");
+}
+```
+
+Pass the function reference directly (not `loadThing.name`). The logger extracts `.name` from the object or function automatically.
+
+### Lifecycle hook order
+
+Hooks are attached in service constructors but executed by the wiring engine in strict order:
+
+```
+onPreInit → onPostConfig → onBootstrap → onReady
+→ onPreShutdown → onShutdownStart → onShutdownComplete
+```
+
+- `onPreInit`: safe for attaching state; config is not yet loaded — do not read `config.*`
+- `onPostConfig`: config values are available from this point forward
+- `onBootstrap`: all modules are wired; safe to call other services
+- `onReady`: app is fully running; schedulers start here
+- `onPreShutdown` / `onShutdownStart` / `onShutdownComplete`: teardown in order
+
+Each hook accepts an optional `priority` number. Positive priorities run first (high → low), un-prioritized callbacks run in parallel, negative priorities run last.
+
+### No `metrics` injection
+
+`TServiceParams` in this repo does not include `metrics`. Do not write `metrics.perf()`, `metrics.histogram(...)`, or any metrics-instrumentation patterns. Those patterns exist in sibling repos (e.g., vault-ts) that build on top of core. Core itself has no metrics service.
+
+### `context: TContext` for builder-style services
+
+`scheduler` is a builder: it returns a function that accepts `context: TContext` and returns the actual scheduler API. This is the pattern for any service that needs to bind per-caller context at use time:
+
+```typescript
+// wiring.service.mts — how scheduler is injected
+scheduler: boilerplate?.scheduler?.(context),
+```
+
+Services that need to pass context down into callbacks capture the context injected into their own factory:
+
+```typescript
+export function MyService({ context, scheduler }: TServiceParams) {
+  scheduler.cron({ exec: doWork, schedule: CronExpression.EVERY_MINUTE });
+}
+```
+
+---
+
+## 4. Style rules
+
+### TSDoc
+
+- Every exported factory function gets a TSDoc comment with at minimum a one-line summary.
+- Every method on the returned object gets a one-line summary.
+- Use `@remarks` for non-obvious behavior (e.g., "only valid after `onPostConfig`").
+- Use `@throws` when the function throws a documented exception.
+- `@internal` on symbols not intended for downstream consumers.
+
+### Inline comments
+
+Write `// why`, never `// what`. The code describes what. The comment explains the reason:
+
+```typescript
+// only read config after PostConfig fires; value is undefined before that
+lifecycle.onPostConfig(() => {
+  CURRENT_LOG_LEVEL = config.boilerplate.LOG_LEVEL;
+});
+```
+
+### Logging conventions
+
+```typescript
+// entry — always trace with name + relevant inputs
+logger.trace({ name: fnRef, ...inputs }, "brief description");
+
+// decision points — trace
+logger.trace({ name: fnRef, chosen }, "selected path");
+
+// successful completion — debug
+logger.debug({ name: fnRef }, "operation complete");
+
+// expected-but-notable — info
+// unexpected non-fatal — warn
+// errors — error or fatal
+```
+
+### Error types
+
+- `BootstrapException(context, "SCREAMING_SNAKE_CODE", "human message")` — for wiring failures, misconfiguration, or anything that should prevent boot.
+- `InternalError(context, "CODE", "message")` — for runtime logic errors after boot.
+- No bare `new Error(...)` in service or helper code.
+
+### Hard prohibitions
+
+- No `console.*` — use `logger.*` or `fatalLog` for last-resort stderr writes.
+- No `process.stdout` writes.
+- No `process.env.*` access outside of `config-environment-loader.mts` and `wiring.service.mts` (where `IS_TEST` / `NODE_ENV` defaults are set).
+- No module-level side effects beyond constant declarations and `dayjs.extend(...)`.
+- No `.catch()` — use `internal.safeExec` for wrapped async execution, or handle errors explicitly.
+- No classic `for` / `for...of` loops — use `each`, `eachSeries`, `eachLimit`, `.forEach`, `.map`, `.filter`, `.some`, `.find`.
+- No `ts-ignore` on new code; `ts-expect-error` is acceptable only with a comment explaining why.
+
+### Cast restrictions
+
+Follow the existing eslint config. In particular: `@typescript-eslint/no-magic-numbers` is enforced — declare named constants for non-obvious numeric literals.
+
+---
+
+## 5. Validation
+
+All commands run from the repo root (`/home/zoe/Repos/DigitalAlchemyTS/core`).
+
+### `yarn lint`
+
+Runs eslint over `src/` and `testing/`. Must pass with zero errors and zero warnings. A clean run exits 0 with no output.
+
+```bash
+yarn lint
+```
+
+### `yarn test`
+
+Runs vitest. All specs in `testing/` must pass. A clean run shows all tests green with no skipped specs (unless the test is explicitly marked `.skip` for a documented reason).
+
+```bash
+yarn test
+```
+
+### Type check the publish surface
+
+```bash
+tsc -p tsconfig.lib.json --noEmit
+```
+
+This checks only the files that end up in `dist/`. Errors here are publish-blocking.
+
+### `yarn build`
+
+Produces `dist/` cleanly. Use to verify the publish output compiles.
+
+```bash
+yarn build
+```
+
+### Do not touch
+
+- `coverage/` — generated artifact, gitignored
+- `node_modules/` — managed by yarn
+- `yarn.lock` — only update deliberately with `yarn add` / `yarn remove`
+- `dist/` — gitignored; never commit it
+
+---
+
+## 6. Footguns specific to core
+
+### `wiring.mts` and `wiring.service.mts` — the engine was deliberately split
+
+`helpers/wiring.mts` contains all the types and pure functions (`CreateLibrary`, `buildSortOrder`, `TServiceParams`, etc.). `services/wiring.service.mts` contains the runtime bootstrap logic (`CreateApplication`, `bootstrap`, `wireService`, `teardown`).
+
+This split exists to break a circular reference that would form if types and the bootstrap runtime lived in the same file. **Do not merge them.** Read both before touching either. Changes to `TServiceParams` shape in `helpers/wiring.mts` affect every downstream library.
+
+### `index.mts` is the re-export hub
+
+`src/index.mts` re-exports everything. New public symbols thread through either `src/helpers/index.mts` or `src/services/index.mts` (whichever is appropriate), not directly into `src/index.mts`.
+
+### Services import from `../index.mts`, not from siblings
+
+Services import from `../index.mts` rather than directly from sibling files:
+
+```typescript
+// correct
+import { deepExtend, eachSeries } from "../index.mts";
+
+// wrong — breaks the circular-ref mitigation
+import { deepExtend } from "./extend.mts";
+```
+
+The only exceptions are the deliberate direct imports in `lifecycle.service.mts` and `wiring.service.mts` of `is.service.mts`.
+
+### `lifecycle.service.mts` imports `is` directly
+
+`lifecycle.service.mts` and `wiring.service.mts` both `import { is } from "./is.service.mts"` instead of going through `../index.mts`. This breaks the circular dep that would form at module init time. Leave this pattern intact.
+
+### `TestRunner` boots a real DI graph
+
+`TestRunner` in `src/testing/test-module.mts` bootstraps a full application with real lifecycle execution. It is not a mock framework. This means:
+
+- Lifecycle hooks fire in real order.
+- Assertions inside `lifecycle.onPostConfig(...)` only see post-config values.
+- Services passed to `.appendLibrary` / `.appendService` execute normally.
+- Always call `.teardown()` in `afterEach` — open handles will keep vitest hanging.
+
+Mocking depth matters: spying on a method only replaces that method, not the service it belongs to. When in doubt, use `.replaceLibrary` or inject a stub via `.appendService`.
+
+### `configSources` controls loader activation
+
+By default, `TestRunner` does not load env vars or config files (this is the safe default for tests). To test env-var resolution, pass `loadConfigs: true` or `setOptions({ configSources: { env: true } })`. To assert that env loading is disabled, pass `configSources: { env: false }`.
+
+---
+
+## 7. Where to find more
+
+Long-form learning material — architecture overviews, declaration merging docs, advanced recipes — exists in a sibling documentation repository. Refer to that repo abstractly; its path and URL are out of scope here.
+
+This `CLAUDE.md` is the canonical working reference for the `core` repo itself. When this file and external docs disagree about what to do *in this repo*, this file wins.

--- a/README.md
+++ b/README.md
@@ -17,11 +17,27 @@ yarn add @digital-alchemy/core
 
 ## Introduction
 
-The Digital Alchemy core utilities are a set of dependency-light tools for building backend applications with **TypeScript**. It targets the latest **ESModule** syntax and language standards, and it's compatible with Bun, Deno, and modern versions of NodeJS.
+`@digital-alchemy/core` is a dependency-injection framework for TypeScript — no decorators, no reflection, no class hierarchy. Services are plain functions that receive their dependencies through a single typed parameter. The framework wires everything at boot time, with full type safety across your entire service graph.
 
-Modules leverage advanced TypeScript features to easily combine services and configurations into type-safe applications. This makes it friendly to a variety of use cases, from complex functional programming logic to usage as a smaller utility in an existing codebase.
+Targets the latest ESModule syntax and runs on Bun, Deno, and modern Node.
 
-The framework adds minimal overhead to boot times, making it well-suited for a wide range of applications, such as web servers, serverless functions, automation tools, and long-running background scripts.
+## At a glance
+
+```typescript
+import { CreateApplication, TServiceParams } from "@digital-alchemy/core";
+
+function HelloService({ logger, lifecycle }: TServiceParams) {
+  lifecycle.onReady(() => logger.info("hello world"));
+}
+
+const app = CreateApplication({
+  name: "hello",
+  services: { hello: HelloService },
+});
+
+await app.bootstrap();
+```
+
 ## What it does
 
 - **Service wiring** - Automatic dependency injection with full type safety

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,7 +2,6 @@ import importPlugin from "eslint-plugin-import";
 import jsonc from "eslint-plugin-jsonc";
 import noUnsanitized from "eslint-plugin-no-unsanitized";
 import simpleImportSort from "eslint-plugin-simple-import-sort";
-import sortKeysFix from "eslint-plugin-sort-keys-fix";
 import unicorn from "eslint-plugin-unicorn";
 import prettier from "eslint-plugin-prettier";
 import { fixupPluginRules } from "@eslint/compat";
@@ -30,7 +29,6 @@ export default [
       jsonc,
       "no-unsanitized": noUnsanitized,
       "simple-import-sort": simpleImportSort,
-      "sort-keys-fix": sortKeysFix,
       unicorn,
       prettier,
     },
@@ -41,7 +39,6 @@ export default [
   ...compat
     .extends(
       "plugin:@typescript-eslint/recommended",
-      "plugin:jsonc/recommended-with-jsonc",
       "plugin:prettier/recommended",
       "plugin:@cspell/recommended",
     )
@@ -88,10 +85,11 @@ export default [
       "unicorn/prefer-node-protocol": "error",
       "unicorn/no-array-for-each": "off",
       "unicorn/import-style": "off",
-      "sort-keys-fix/sort-keys-fix": "warn",
+      // "sort-keys-fix/sort-keys-fix": "warn",
       "unicorn/prefer-event-target": "off",
       "simple-import-sort/imports": "warn",
       "sonarjs/no-misused-promises": "off",
+      "@typescript-eslint/no-duplicate-enum-values": "off",
       "sonarjs/no-commented-code": "off",
       "sonarjs/todo-tag": "off",
       "simple-import-sort/exports": "warn",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": {
     "url": "git+https://github.com/Digital-Alchemy-TS/core"
   },
-  "version": "26.2.17",
+  "version": "26.5.1",
   "author": {
     "url": "https://github.com/zoe-codez",
     "name": "Zoe Codez"
@@ -16,7 +16,7 @@
     "build": "rm -rf dist/; tsc -p tsconfig.lib.json",
     "lint": "eslint src",
     "test": "vitest",
-    "upgrade": "yarn up '@digital-alchemy/*'"
+    "upgrade": "ncu --upgrade && truncate -s 0 yarn.lock && yarn install"
   },
   "bugs": {
     "email": "bugs@digital-alchemy.app",
@@ -47,54 +47,55 @@
     "node": ">=20"
   },
   "dependencies": {
-    "@dotenvx/dotenvx": "^1.51.4",
+    "@dotenvx/dotenvx": "^1.64.0",
     "chalk": "^5.6.2",
     "cron": "^4.4.0",
-    "dayjs": "^1.11.19",
+    "dayjs": "^1.11.20",
     "ini": "^6.0.0",
     "js-yaml": "^4.1.1",
     "minimist": "^1.2.8",
-    "uuid": "^13.0.0"
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "@cspell/eslint-plugin": "^10.0.0",
-    "@eslint/compat": "^2.0.0",
-    "@eslint/eslintrc": "^3.3.3",
-    "@eslint/js": "^9.39.2",
-    "@faker-js/faker": "^10.2.0",
+    "@eslint/compat": "^2.0.5",
+    "@eslint/eslintrc": "^3.3.5",
+    "@eslint/js": "^10.0.1",
+    "@faker-js/faker": "^10.4.0",
     "@types/ini": "^4.1.1",
     "@types/js-yaml": "^4.0.9",
     "@types/minimist": "^1.2.5",
-    "@types/node": "^25.0.3",
+    "@types/node": "^25.6.0",
     "@types/sinonjs__fake-timers": "^15.0.1",
-    "@typescript-eslint/eslint-plugin": "8.58.2",
-    "@typescript-eslint/parser": "8.58.2",
-    "@vitest/coverage-v8": "^4.0.16",
+    "@typescript-eslint/eslint-plugin": "8.59.1",
+    "@typescript-eslint/parser": "8.59.1",
+    "@vitest/coverage-v8": "^4.1.5",
     "chalk": "^5.6.2",
-    "dayjs": "^1.11.19",
+    "dayjs": "^1.11.20",
     "eslint": "10.2.1",
     "eslint-config-prettier": "10.1.8",
     "eslint-plugin-import": "^2.32.0",
-    "eslint-plugin-jsonc": "^2.21.0",
-    "eslint-plugin-no-unsanitized": "^4.1.4",
-    "eslint-plugin-prettier": "^5.5.4",
+    "eslint-plugin-jsonc": "^3.1.2",
+    "eslint-plugin-no-unsanitized": "^4.1.5",
+    "eslint-plugin-prettier": "^5.5.5",
     "eslint-plugin-security": "^4.0.0",
-    "eslint-plugin-simple-import-sort": "^12.1.1",
-    "eslint-plugin-sonarjs": "^4.0.0",
+    "eslint-plugin-simple-import-sort": "^13.0.0",
+    "eslint-plugin-sonarjs": "^4.0.3",
     "eslint-plugin-sort-keys-fix": "^1.1.2",
-    "eslint-plugin-unicorn": "^63.0.0",
+    "eslint-plugin-unicorn": "^64.0.0",
     "ini": "^6.0.0",
     "js-yaml": "^4.1.1",
     "minimist": "^1.2.8",
-    "pino": "^10.1.0",
+    "npm-check-updates": "^22.0.1",
+    "pino": "^10.3.1",
     "pino-pretty": "^13.1.3",
-    "prettier": "^3.7.4",
+    "prettier": "^3.8.3",
     "tslib": "^2.8.1",
     "tsx": "^4.21.0",
-    "type-fest": "^5.3.1",
-    "typescript": "^5.9.3",
-    "uuid": "^13.0.0",
-    "vitest": "^4.0.16"
+    "type-fest": "^5.6.0",
+    "typescript": "^6.0.3",
+    "uuid": "^14.0.0",
+    "vitest": "^4.1.5"
   },
-  "packageManager": "yarn@4.12.0"
+  "packageManager": "yarn@4.14.1"
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "./testing": "./dist/testing/helpers/index.mjs"
   },
   "files": [
-    "dist/**/*"
+    "dist/**/*",
+    "CLAUDE.md"
   ],
   "engines": {
     "node": ">=20"

--- a/src/helpers/async.mts
+++ b/src/helpers/async.mts
@@ -1,30 +1,55 @@
+/**
+ * Async iteration helpers — drop-in replacements for the `async` library with
+ * more predictable behavior.
+ *
+ * @remarks
+ * Provides `each`, `eachSeries`, and `eachLimit` functions that mirror common
+ * async iteration patterns but with consistent semantics. All functions accept
+ * either an array or a Set as input and execute a callback on each item,
+ * returning a promise that resolves when all iterations complete.
+ */
+
 import { is } from "../index.mts";
 import { ARRAY_OFFSET, SINGLE, START } from "./utilities.mts";
 
-// ? Functions written to be similar to the offerings from the async library
-// That library gave me oddly inconsistent results,
-//     so these exist to replace those doing exactly what I expect
-//
-
-// #MARK: each
+/**
+ * Execute an async callback in parallel on each item in a collection.
+ *
+ * @remarks
+ * Invokes all callbacks concurrently using `Promise.all`. Accepts either an
+ * array or a Set; Sets are converted to arrays before processing. If `callback`
+ * throws or rejects, the entire operation fails with that error.
+ */
 export async function each<T = unknown>(
   item: T[] | Set<T>,
   callback: (item: T) => Promise<void | unknown>,
 ): Promise<void> {
+  // convert Set to array for uniform handling
   if (item instanceof Set) {
     item = [...item.values()];
   }
   await Promise.all(item.map(async i => await callback(i)));
 }
 
-// #MARK: eachSeries
+/**
+ * Execute an async callback serially on each item in a collection.
+ *
+ * @remarks
+ * Invokes callbacks one after the other, waiting for each to complete before
+ * starting the next. Accepts either an array or a Set; Sets are converted to
+ * arrays. Throws if the input is not a Set or array after conversion.
+ *
+ * @throws {TypeError} when the input is neither an array nor a Set.
+ */
 export async function eachSeries<T = void>(
   item: T[] | Set<T>,
   callback: (item: T) => Promise<void | unknown>,
 ): Promise<void> {
+  // convert Set to array for uniform handling
   if (item instanceof Set) {
     item = [...item.values()];
   }
+  // ensure we have an array; failing fast helps catch misuse early
   if (!is.array(item)) {
     throw new TypeError(`not provided an array`);
   }
@@ -33,37 +58,47 @@ export async function eachSeries<T = void>(
   }
 }
 
-// #MARK: eachLimit
+/**
+ * Execute an async callback on each item in an array while limiting concurrency.
+ *
+ * @remarks
+ * Respects a maximum number of concurrent callbacks by tracking active promises
+ * and awaiting one to resolve before starting a new one. Processes the first
+ * `limit` items immediately, then maintains the limit as remaining items are
+ * queued. Resolves only when all callbacks complete.
+ */
 export async function eachLimit<T = unknown>(
   items: T[],
   limit: number,
   callback: (item: T) => Promise<void | unknown>,
 ): Promise<void> {
-  // Track active promises to ensure we don't exceed the limit
+  // track promises to enforce the concurrency limit
   const activePromises: Set<Promise<void | unknown>> = new Set();
 
-  // A helper function to add a new task
+  // queue a new callback and manage the promise lifecycle
   async function addTask(item: T) {
     const promise = callback(item).then(() => {
-      activePromises.delete(promise); // Remove the promise from the set once it's resolved
+      // clean up completed promise so we can detect when to start new ones
+      activePromises.delete(promise);
     });
     activePromises.add(promise);
+    // if at or over limit, block until at least one promise resolves
     if (activePromises.size >= limit) {
-      await Promise.race(activePromises); // Wait for one of the active promises to resolve
+      await Promise.race(activePromises);
     }
   }
 
-  // Add initial tasks up to the limit
+  // seed the concurrency pool with the first `limit` items
   const initialTasks = items.slice(SINGLE, limit).map(item => addTask(item));
 
-  // Wait for the initial set of tasks to start processing
+  // wait for all initial tasks to be queued (not necessarily complete)
   await Promise.all(initialTasks);
 
-  // Process the remaining items, ensuring the limit is respected
+  // process remaining items while respecting the limit
   for (let i = limit - ARRAY_OFFSET; i < items.length; i++) {
     await addTask(items[i]);
   }
 
-  // Wait for all remaining tasks to complete
+  // wait for all in-flight operations to finish
   await Promise.all(activePromises);
 }

--- a/src/helpers/config-environment-loader.mts
+++ b/src/helpers/config-environment-loader.mts
@@ -1,3 +1,15 @@
+/**
+ * Environment variable and CLI switch config loader.
+ *
+ * @remarks
+ * Reads config from Node.js env vars and command-line arguments. For each config
+ * key, searches using a three-tier precedence: CLI switches (highest), then env
+ * vars (middle), then defaults (lowest). Both argv and env sources support a
+ * double-underscore variant (`MODULE__KEY`) in addition to single-underscore,
+ * enabling env vars with embedded dots/slashes that would be shell-escaped.
+ * Timing information is captured and returned for observability.
+ */
+
 import { env } from "node:process";
 
 import minimist from "minimist";
@@ -13,6 +25,34 @@ import type {
 import { findKey, iSearchKey, loadDotenv, parseConfig } from "./config.mts";
 import type { ServiceMap } from "./wiring.mts";
 
+/**
+ * Load configuration from environment variables and CLI switches.
+ *
+ * @remarks
+ * Merges CLI arguments and environment variables into the config tree, respecting
+ * the configured sources (argv, env) and individual config key source restrictions.
+ * Searches for each key in three forms (in order):
+ * 1. `MODULE__KEY` (double underscore) — preferred, allows shell-escaped env vars
+ * 2. `MODULE_KEY` (single underscore) — classic format
+ * 3. `KEY` (bare key) — fallback for globals
+ *
+ * CLI arguments are checked first (highest precedence); env vars are checked second.
+ * Both are optional and controlled by `internal.boot.options.configSources`.
+ *
+ * Timing data is collected for argv and env separately and returned if the
+ * optional `timings` object is provided.
+ *
+ * @example
+ * ```
+ * // Search order for app.NODE_ENV config key:
+ * // 1. --app__NODE_ENV cli switch
+ * // 2. APP__NODE_ENV env var
+ * // 3. --app_NODE_ENV cli switch
+ * // 4. APP_NODE_ENV env var
+ * // 5. --NODE_ENV cli switch
+ * // 6. NODE_ENV env var
+ * ```
+ */
 export async function ConfigLoaderEnvironment<
   S extends ServiceMap = ServiceMap,
   C extends ModuleConfiguration = ModuleConfiguration,
@@ -34,31 +74,30 @@ export async function ConfigLoaderEnvironment<
   const shouldEnv = (source: DataTypes[]) =>
     canEnvironment && (!is.array(source) || source.includes("env"));
 
-  // * merge dotenv into local vars
-  // accounts for `--env-file` switches, and whatever is passed in via bootstrap
+  // merge dotenv files and env-file switches into process.env
   loadDotenv(internal, CLI_SWITCHES, logger);
   const environmentKeys = Object.keys(env);
 
-  // Track timing for argv and env separately
+  // track timing for argv and env separately
   let argvTime = NONE;
   let envTime = NONE;
 
-  // * go through all module
+  // iterate through all module configurations
   configs.forEach((configuration, project) => {
     const cleanedProject = project.replaceAll("-", "_");
 
-    // * run through each config for module
+    // iterate through each config key within the module
     Object.keys(configuration).forEach(key => {
       const { source } = configs.get(project)[key];
-      // > things to search for
-      // - MODULE_NAME_CONFIG_KEY (module + key, ex: app_NODE_ENV)
-      // - CONFIG_KEY (only key, ex: NODE_ENV)
+      // search keys in order: double-underscore (preferred), single-underscore, bare key
+      // double-underscore allows env var names with embedded special chars (dots, slashes)
       const noAppPath = `${cleanedProject}_${key}`;
-      const search = [noAppPath, key];
+      const noAppPathDouble = `${cleanedProject}__${key}`;
+      const search = [noAppPathDouble, noAppPath, key];
       const configPath = `${project}.${key}`;
 
       if (canArgv) {
-        // * (preferred) Find an applicable cli switch
+        // CLI switches take precedence; find a matching flag in the argv
         const argvStart = performance.now();
         const flag = findKey(search, switchKeys);
         if (flag && shouldArgv(source)) {
@@ -82,12 +121,13 @@ export async function ConfigLoaderEnvironment<
         argvTime += performance.now() - argvStart;
       }
 
-      // * (fallback) Find an environment variable
+      // fallback to environment variable if no CLI switch was found
       if (canEnvironment) {
         const envStart = performance.now();
         const environment = findKey(search, environmentKeys);
         if (!is.empty(environment) && shouldEnv(source)) {
           const environmentName = iSearchKey(environment, environmentKeys);
+          // only set if the env var is defined and non-empty
           if (!is.string(env[environmentName]) || !is.empty(env[environmentName])) {
             internal.utils.object.set(
               out,
@@ -111,6 +151,7 @@ export async function ConfigLoaderEnvironment<
     });
   });
 
+  // record timing if provided
   if (timings) {
     if (argvTime) {
       timings.argv = `${argvTime.toFixed(DECIMALS)}ms`;

--- a/src/helpers/config-file-loader.mts
+++ b/src/helpers/config-file-loader.mts
@@ -1,3 +1,15 @@
+/**
+ * File-based configuration loader — reads JSON, YAML, and INI config files.
+ *
+ * @remarks
+ * Supports four formats (JSON, YAML, INI, and auto-detect) and searches standard
+ * config paths: `/etc/{app}`, `./{app}` (walking up the directory tree),
+ * `~/.config/{app}`, and explicit `--config` flag overrides. Files are detected
+ * by extension and parsed accordingly; if extension is ambiguous, format detection
+ * occurs in order: JSON-like start, YAML parse, INI fallback. Multiple files are
+ * merged using `deepExtend`, with earlier files providing defaults.
+ */
+
 import fs from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -15,7 +27,26 @@ import type { PartialConfiguration, ServiceMap } from "./wiring.mts";
 
 const isWindows = platform === "win32";
 
+/**
+ * Supported config file extensions.
+ */
 export const SUPPORTED_CONFIG_EXTENSIONS = ["json", "ini", "yaml", "yml"];
+
+/**
+ * Generate potential file paths for a given base path.
+ *
+ * @remarks
+ * Returns an array of paths including the base, a "config" subdirectory variant,
+ * and all supported extensions of each. This is used to generate candidates
+ * without checking filesystem; callers filter to existing files.
+ *
+ * @example
+ * ```
+ * withExtensions("myapp") returns:
+ * ["myapp", "myapp.json", "myapp.ini", "myapp.yaml", "myapp.yml",
+ *  "myapp/config", "myapp/config.json", ...]
+ * ```
+ */
 export function withExtensions(path: string): string[] {
   return [path, join(path, "config")].flatMap(path => [
     path,
@@ -23,25 +54,51 @@ export function withExtensions(path: string): string[] {
   ]);
 }
 
+/**
+ * Resolve all existing config files for an application.
+ *
+ * @remarks
+ * Searches in order: `/etc/{name}` (Unix only), `./.{name}` (walking up the
+ * directory tree), and `~/.config/{name}` (home directory). Returns only paths
+ * that exist and are regular files. Used as the default search order when no
+ * explicit `--config` flag is provided.
+ */
 export function configFilePaths(name: string): string[] {
   const out: string[] = [];
+  // system-wide config (Unix only)
   if (!isWindows) {
     out.push(...withExtensions(join(`/etc`, `${name}`)));
   }
+  // search up the directory tree from cwd
   let current = cwd();
   let next: string;
   while (!is.empty(current)) {
     out.push(...withExtensions(join(current, `.${name}`)));
     next = join(current, "..");
+    // stop at filesystem root
     if (next === current) {
       break;
     }
     current = next;
   }
+  // user-local config
   out.push(...withExtensions(join(homedir(), ".config", name)));
+  // filter to existing regular files
   return out.filter(filePath => fs.existsSync(filePath) && fs.statSync(filePath).isFile());
 }
 
+/**
+ * Load configuration from file(s).
+ *
+ * @remarks
+ * Checks for an explicit `--config` CLI flag or `CONFIG` config value; if
+ * provided and the file does not exist, exits fatally. Otherwise, searches
+ * standard paths using `configFilePaths`. Merges all found files using
+ * `deepExtend`, with earlier files as defaults.
+ *
+ * @throws {Error} (via process.exit) when `--config` points to a non-existent file
+ * or when argv parsing fails.
+ */
 export async function configLoaderFile<
   S extends ServiceMap = ServiceMap,
   C extends ModuleConfiguration = ModuleConfiguration,
@@ -50,13 +107,16 @@ export async function configLoaderFile<
   const configFile =
     CLI_SWITCHES.config ?? internal?.boot?.options?.configuration?.boilerplate?.CONFIG;
   let files: string[];
+  // argv parsing errors result in a boolean instead of a string
   if (is.boolean(configFile)) {
     logger.fatal({ argv: process.argv }, "system failed to parse argv");
     process.exit();
   } else if (is.empty(configFile)) {
+    // no explicit config; search standard paths
     files = configFilePaths(application.name);
     logger.trace({ files, name: configLoaderFile }, `identified config files`);
   } else {
+    // explicit config file provided; must exist
     if (!fs.existsSync(configFile)) {
       logger.fatal(
         { configFile, name: configLoaderFile },
@@ -80,8 +140,24 @@ export async function configLoaderFile<
   return out;
 }
 
+/**
+ * Parse and merge a single config file into the output object.
+ *
+ * @remarks
+ * Detects format by extension first; if ambiguous or no extension matches,
+ * uses heuristics: if content starts with `{`, tries JSON; then YAML; finally
+ * falls back to INI. File is merged into `out` using `deepExtend`.
+ *
+ * @example
+ * ```
+ * const config: PartialConfiguration = {};
+ * loadConfigFromFile(config, "/etc/myapp.yaml");
+ * // config is now merged with the file contents
+ * ```
+ */
 export function loadConfigFromFile(out: PartialConfiguration, filePath: string) {
   const fileContent = fs.readFileSync(filePath, "utf8").trim();
+  // check if filename has a recognized extension and parse accordingly
   const hasExtension = SUPPORTED_CONFIG_EXTENSIONS.some(extension => {
     if (filePath.slice(extension.length * INVERT_VALUE).toLowerCase() === extension) {
       switch (extension) {
@@ -99,15 +175,17 @@ export function loadConfigFromFile(out: PartialConfiguration, filePath: string) 
     }
     return false;
   });
+  // extension was recognized and parsed
   if (hasExtension) {
     return;
   }
-  // Guessing JSON
+  // no extension; try to detect format heuristically
+  // JSON objects start with `{`
   if (fileContent[START] === "{") {
     deepExtend(out, JSON.parse(fileContent) as PartialConfiguration);
     return;
   }
-  // Guessing yaml
+  // try YAML (will throw if malformed)
   try {
     const content = yaml.load(fileContent);
     if (is.object(content)) {
@@ -115,8 +193,8 @@ export function loadConfigFromFile(out: PartialConfiguration, filePath: string) 
       return;
     }
   } catch {
-    // Is not a yaml file
+    // not valid YAML; continue to INI fallback
   }
-  // Final fallback: INI
+  // final fallback: treat as INI
   deepExtend(out, ini.decode(fileContent) as PartialConfiguration);
 }

--- a/src/helpers/config.mts
+++ b/src/helpers/config.mts
@@ -21,6 +21,16 @@ import type {
   TInjectedConfig,
 } from "./wiring.mts";
 
+// --- Loader source types ------------------------------------------------------
+
+/**
+ * Describes the three built-in configuration source channels.
+ *
+ * @remarks
+ * Used as the key set for {@link DataTypes} and for the `source` field on
+ * individual config definitions. Each channel can be opted in/out independently
+ * via `BootstrapOptions.configSources`.
+ */
 export interface ConfigLoaderSource {
   /**
    * will be checked for values unless `sources` is defined without argv
@@ -36,7 +46,19 @@ export interface ConfigLoaderSource {
   file: true;
 }
 
+// --- Config shape types -------------------------------------------------------
+
+/** A record of config-key → config-definition for a single module. */
 export type CodeConfigDefinition = Record<string, AnyConfig>;
+
+/**
+ * All supported primitive config types.
+ *
+ * @remarks
+ * Each value maps to a concrete config interface (`StringConfig`,
+ * `BooleanConfig`, etc.) and determines how the raw string from env/argv/file
+ * is coerced before injection.
+ */
 export type ProjectConfigTypes =
   | "string"
   | "boolean"
@@ -44,6 +66,14 @@ export type ProjectConfigTypes =
   | "number"
   | "record"
   | "string[]";
+
+/**
+ * Union of all supported config definition shapes.
+ *
+ * @remarks
+ * Narrowing on the `type` discriminant gives access to the specific fields
+ * (e.g., `enum` for `StringConfig`, `default` for every typed config).
+ */
 export type AnyConfig =
   | StringConfig<string>
   | BooleanConfig
@@ -52,6 +82,14 @@ export type AnyConfig =
   | RecordConfig
   | StringArrayConfig;
 
+/**
+ * Fields shared by every config definition.
+ *
+ * @remarks
+ * The `type` discriminant drives coercion in {@link parseConfig}.
+ * `source` narrows which loaders are allowed to supply this key — omit it to
+ * allow all loaders.
+ */
 export interface BaseConfig {
   /**
    * If no other values are provided, what value should be injected?
@@ -74,7 +112,34 @@ export interface BaseConfig {
    */
   source?: (keyof ConfigLoaderSource)[];
 }
+
+/**
+ * Map of module-name → config-definition record for all known modules.
+ *
+ * @remarks
+ * Populated incrementally during bootstrap as each library calls
+ * `configuration.[LOAD_PROJECT]`. Used by all config loaders to know which
+ * keys to look up.
+ */
 export type KnownConfigs = Map<string, CodeConfigDefinition>;
+
+/**
+ * Config definition for a typed string value.
+ *
+ * @remarks
+ * The generic parameter `STRING` lets callers constrain the injected value to a
+ * specific string literal union. When `enum` is provided the framework refuses
+ * to boot if the resolved value is not in the list.
+ *
+ * @example Enum-constrained string
+ * ```typescript
+ * const LOG_LEVEL: StringConfig<"debug" | "info" | "warn"> = {
+ *   default: "info",
+ *   enum: ["debug", "info", "warn"],
+ *   type: "string",
+ * };
+ * ```
+ */
 export interface StringConfig<STRING extends string> extends BaseConfig {
   default?: STRING;
   /**
@@ -84,43 +149,65 @@ export interface StringConfig<STRING extends string> extends BaseConfig {
   type: "string";
 }
 
+/** Config definition for a boolean value. */
 export interface BooleanConfig extends BaseConfig {
   default?: boolean;
   type: "boolean";
 }
 
 /**
- * For configurations that just can't be expressed any other way.
- * Make sure to add a helpful description on how to format the value,
- * because `config-builder` won't be able to help.
+ * Escape hatch for configurations that can't be expressed as a primitive.
+ *
+ * @remarks
+ * Accepts a JSON-serialisable object as its default; at runtime the raw string
+ * value from env/file is passed through `JSON.parse`. Use the `description`
+ * field to explain the expected structure, because `config-builder` cannot
+ * introspect complex shapes.
  *
  * This can be used to take in a complex json object, and forward the information to another library.
  *
  * TODO: JSON schema magic for validation / maybe config builder help
+ *
+ * For configurations that just can't be expressed any other way.
+ * Make sure to add a helpful description on how to format the value,
+ * because `config-builder` won't be able to help.
  */
 export type InternalConfig<VALUE extends object> = BaseConfig & {
   default: VALUE;
   type: "internal";
 };
 
+/** Config definition for a numeric value. */
 export interface NumberConfig extends BaseConfig {
   default?: number;
   type: "number";
 }
 
 /**
+ * Config definition for an arbitrary key/value record.
+ *
+ * @remarks
+ * Injected as a plain object; the raw value is parsed via `JSON.parse` when it
+ * arrives as a string.
+ *
  * key/value pairs
  */
 export interface RecordConfig extends BaseConfig {
   type: "record";
 }
 
+/** Config definition for a string-array value. */
 export interface StringArrayConfig extends BaseConfig {
   default?: string[];
   type: "string[]";
 }
 
+// --- DTO types used by external config tooling --------------------------------
+
 /**
+ * Serialisable representation of a module's full config for use by external
+ * tooling (e.g. the `config-builder` CLI scanner).
+ *
  * Used with config scanner
  */
 export interface ConfigDefinitionDTO {
@@ -129,6 +216,7 @@ export interface ConfigDefinitionDTO {
   config: ConfigTypeDTO[];
 }
 
+/** Single config-item descriptor emitted by the scanner. */
 export interface ConfigTypeDTO<METADATA extends AnyConfig = AnyConfig> {
   /**
    * Name of project
@@ -145,15 +233,33 @@ export interface ConfigTypeDTO<METADATA extends AnyConfig = AnyConfig> {
 }
 
 /**
- * Top level configuration object
+ * Top level configuration object.
+ *
+ * @remarks
+ * Downstream libraries extend this interface via declaration merging to add
+ * their own config sections. See the architecture docs for the merging pattern.
  *
  * Extends the global common config, adding a section for the top level application to chuck in data without affecting things
  * Also provides dedicated sections for libraries to store their own configuration options
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface AbstractConfig {}
+
+/**
+ * Return type of a config loader — a partial snapshot of the global config
+ * hierarchy.
+ */
 export type ConfigLoaderReturn = Promise<Partial<AbstractConfig>>;
 
+/**
+ * Parameters passed to every config loader at bootstrap time.
+ *
+ * @remarks
+ * Loaders receive the full application definition, the accumulated
+ * `KnownConfigs` map, the internal definition for accessing boot state, and a
+ * logger for diagnostics. Loaders must not throw; they should return an empty
+ * object when they find nothing.
+ */
 export type ConfigLoaderParams<
   S extends ServiceMap = ServiceMap,
   C extends OptionalModuleConfiguration = OptionalModuleConfiguration,
@@ -164,10 +270,28 @@ export type ConfigLoaderParams<
   logger: ILogger;
 };
 
+/**
+ * Contract that all config loaders must satisfy.
+ *
+ * @remarks
+ * Each loader is registered for a specific {@link DataTypes} channel via
+ * `DigitalAlchemyConfiguration.registerLoader`. The framework calls all
+ * registered loaders during `onPostConfig` and deep-merges their results.
+ */
 export type ConfigLoader = <S extends ServiceMap, C extends OptionalModuleConfiguration>(
   params: ConfigLoaderParams<S, C>,
 ) => ConfigLoaderReturn;
 
+/**
+ * Coerce a raw string (or boolean/array from argv parsing) to the target type.
+ *
+ * @remarks
+ * Called by env/argv loaders after key lookup to normalise the raw value before
+ * it is stored in the config map. `boolean` coercion is intentionally lenient:
+ * `"true"`, `"y"`, and `"1"` all produce `true`. `string[]` handles the
+ * minimist edge case where a single flag value arrives as a plain string rather
+ * than a one-element array.
+ */
 export function cast<T = unknown>(data: boolean | number[] | string | string[], type: string): T {
   switch (type) {
     case "boolean": {
@@ -195,11 +319,27 @@ export function cast<T = unknown>(data: boolean | number[] | string | string[], 
   return data as T;
 }
 
+/** A record that maps config-key names to their config definitions. */
 export type ModuleConfiguration = {
   [key: string]: AnyConfig;
 };
+
+/** A module's config block, or `undefined` when the module declares none. */
 export type OptionalModuleConfiguration = ModuleConfiguration | undefined;
 
+/**
+ * Find the first key in `source` that also appears in `find`, using a
+ * case-insensitive fuzzy match that treats `-` and `_` as interchangeable.
+ *
+ * @remarks
+ * The search runs in two passes:
+ * 1. Exact match — fast path for the common case where cases and separators align.
+ * 2. Regex match — builds a pattern from `source[i]` that allows `-` or `_`
+ *    between each word boundary, then tests every element of `find`.
+ *
+ * This is the canonical key-resolution routine called by the env and argv
+ * loaders before falling back to unqualified key search.
+ */
 export function findKey<T extends string>(source: T[], find: T[]) {
   return (
     // Find an exact match (if available) first
@@ -212,6 +352,16 @@ export function findKey<T extends string>(source: T[], find: T[]) {
   );
 }
 
+/**
+ * Search `source` for the first key that case-insensitively matches `target`,
+ * treating `-` and `_` as interchangeable separators.
+ *
+ * @remarks
+ * Builds a single regex from `target` and tests it against every element of
+ * `source`. Unlike {@link findKey}, this function operates in one direction
+ * only (target → source) and is used for direct key lookups rather than
+ * cross-set intersection.
+ */
 export function iSearchKey(target: string, source: string[]) {
   const regex = new RegExp(`^${target.replaceAll(new RegExp("[-_]", "gi"), "[-_]?")}$`, "gi");
 
@@ -219,6 +369,19 @@ export function iSearchKey(target: string, source: string[]) {
 }
 
 /**
+ * Load a `.env` file into `process.env`, respecting the configured priority
+ * order.
+ *
+ * @remarks
+ * Priority (highest to lowest):
+ * 1. `--env-file` CLI switch
+ * 2. `BootstrapOptions.envFile`
+ * 3. `.env` in the current working directory (silent fallback)
+ *
+ * If the resolved path does not exist, a warning is emitted and loading is
+ * skipped rather than throwing. This keeps the application bootable in
+ * environments that intentionally have no `.env` file.
+ *
  * priorities:
  * - --env-file
  * - bootstrap envFile
@@ -249,6 +412,7 @@ export function loadDotenv(
     if (fs.existsSync(checkFile)) {
       file = checkFile;
     } else {
+      // path was explicitly provided but does not exist; warn so operators notice the misconfiguration
       logger.warn({ checkFile, envFile, name: loadDotenv }, "invalid target for dotenv file");
     }
   }
@@ -270,6 +434,18 @@ export function loadDotenv(
   }
 }
 
+/**
+ * Coerce `value` to the concrete type described by `config`.
+ *
+ * @remarks
+ * Called after a raw value has been retrieved from a loader to normalise it
+ * before storage. Each branch matches a `ProjectConfigTypes` discriminant:
+ * - `"string"` — `String(value)`
+ * - `"number"` — `Number(value)`
+ * - `"string[]"` — splits on commas, or parses JSON arrays starting with `[`
+ * - `"record"` / `"internal"` — passes objects through; parses strings as JSON
+ * - `"boolean"` — accepts boolean literals and the strings `"y"` / `"true"`
+ */
 export function parseConfig(config: AnyConfig, value: unknown) {
   switch (config.type) {
     case "string": {
@@ -283,6 +459,7 @@ export function parseConfig(config: AnyConfig, value: unknown) {
         return value;
       }
       if (is.string(value)) {
+        // leading "[" signals a JSON-serialised array; otherwise treat as CSV
         return value.startsWith("[") ? JSON.parse(value) : value.split(",");
       }
       return [];
@@ -305,6 +482,18 @@ export function parseConfig(config: AnyConfig, value: unknown) {
   }
 }
 
+/**
+ * Internal shape of the configuration service — the object attached to
+ * `internal.boilerplate.configuration`.
+ *
+ * @remarks
+ * Symbol-keyed methods (`[INITIALIZE]`, `[INJECTED_DEFINITIONS]`,
+ * `[LOAD_PROJECT]`) are bootstrap-internal surface and should not be called by
+ * application code. Use the named methods (`getDefinitions`, `registerLoader`,
+ * `merge`, `onUpdate`, `set`) for runtime configuration interaction.
+ *
+ * @internal
+ */
 export type DigitalAlchemyConfiguration = {
   [INITIALIZE]: <S extends ServiceMap, C extends OptionalModuleConfiguration>(
     application: ApplicationDefinition<S, C>,
@@ -315,9 +504,13 @@ export type DigitalAlchemyConfiguration = {
   registerLoader: (loader: ConfigLoader, type: DataTypes) => void;
   merge: (incoming: Partial<PartialConfiguration>) => PartialConfiguration;
   /**
+   * Subscribe to runtime config changes made via `config.set`.
+   *
+   * @remarks
    * Not a replacement for `onPostConfig`
    *
-   * Only receives updates from `config.set` calls
+   * Only receives updates from `config.set` calls — initial load values do not
+   * trigger this callback.
    */
   onUpdate: <
     Project extends keyof TInjectedConfig,
@@ -335,6 +528,14 @@ export type DigitalAlchemyConfiguration = {
   set: TSetConfig;
 };
 
+/**
+ * Type-safe setter for a single config value.
+ *
+ * @remarks
+ * The generic parameters are inferred from the call site — TypeScript enforces
+ * that `property` is a valid key of the chosen `project` section and that
+ * `value` matches the declared type.
+ */
 export type TSetConfig = <
   Project extends keyof TInjectedConfig,
   Property extends keyof TInjectedConfig[Project],
@@ -344,8 +545,19 @@ export type TSetConfig = <
   value: TInjectedConfig[Project][Property],
 ) => void;
 
+/**
+ * Callback signature for config-update subscriptions.
+ *
+ * @remarks
+ * Receives the `project` and `property` names that changed; callers read the
+ * new value directly from `config[project][property]` rather than receiving it
+ * as a parameter, which keeps the callback signature stable regardless of the
+ * value type.
+ */
 export type OnConfigUpdateCallback<
   Project extends keyof TInjectedConfig,
   Property extends keyof TInjectedConfig[Project],
 > = (project: Project, property: Property) => TBlackHole;
+
+/** Union of the three supported config source channel names. */
 export type DataTypes = keyof ConfigLoaderSource;

--- a/src/helpers/context.mts
+++ b/src/helpers/context.mts
@@ -1,9 +1,19 @@
 /**
- * Simple branded type
+ * Request context — a branded string type that enables per-request logging and state isolation.
+ *
+ * @remarks
+ * `TContext` is used throughout the framework to tag operations with a unique request
+ * identifier, enabling AsyncLocalStorage to associate logs and state changes with the
+ * calling context. It is passed to error constructors and used as a key in per-request
+ * data structures.
  */
 export type TContext = string & IContextBrand;
 
-// Might make the situation more complicated later, it's mostly to keep track of things right now
+/**
+ * Phantom brand to enforce type safety on context identifiers.
+ *
+ * @internal
+ */
 export interface IContextBrand {
   _context: symbol;
 }

--- a/src/helpers/cron.mts
+++ b/src/helpers/cron.mts
@@ -1,3 +1,13 @@
+/**
+ * Scheduler types and cron expression constants.
+ *
+ * @remarks
+ * Provides a comprehensive set of cron expressions for common scheduling patterns
+ * (second, minute, hour, day, week, month, year), three scheduler options types
+ * (cron, interval, sliding), and type definitions for time offsets and the
+ * scheduler service interface.
+ */
+
 import type { Dayjs } from "dayjs";
 import dayjs from "dayjs";
 import type { Duration, DurationUnitsObjectType, DurationUnitType } from "dayjs/plugin/duration.js";
@@ -9,17 +19,37 @@ import type { SleepReturn, TBlackHole } from "./utilities.mts";
 import type { Schedule, SchedulerOptions } from "./wiring.mts";
 dayjs.extend(duration);
 
+/**
+ * Predefined cron expressions for common scheduling patterns.
+ *
+ * @remarks
+ * Each constant is a cron expression string (6-field format: second minute hour
+ * dayOfMonth month dayOfWeek) that can be passed to `scheduler.cron(...)`.
+ * Expressions range from sub-second (EVERY_SECOND) to yearly (EVERY_YEAR),
+ * with specific business hours and weekday patterns included.
+ *
+ * @example
+ * ```typescript
+ * scheduler.cron({ exec: dailyTask, schedule: CronExpression.EVERY_DAY_AT_NOON });
+ * scheduler.cron({ exec: weeklyTask, schedule: CronExpression.EVERY_WEEKDAY });
+ * ```
+ */
 export enum CronExpression {
+  // sub-minute
   EVERY_SECOND = "* * * * * *",
   EVERY_5_SECONDS = "*/5 * * * * *",
   EVERY_10_SECONDS = "*/10 * * * * *",
   EVERY_30_SECONDS = "*/30 * * * * *",
+  // minute
   EVERY_MINUTE = "*/1 * * * *",
   EVERY_5_MINUTES = "0 */5 * * * *",
   EVERY_10_MINUTES = "0 */10 * * * *",
   EVERY_30_MINUTES = "0 */30 * * * *",
+  // hour
   EVERY_HOUR = "0 0-23/1 * * *",
-  EVERY_2_HOURS = "0 0-23/2 * * *",
+  EVERY_2_HOURS = "0 */2 * * *",
+  EVERY_2ND_HOUR = "0 */2 * * *",
+  EVERY_2ND_HOUR_FROM_1AM_THROUGH_11PM = "0 1-23/2 * * *",
   EVERY_3_HOURS = "0 0-23/3 * * *",
   EVERY_4_HOURS = "0 0-23/4 * * *",
   EVERY_5_HOURS = "0 0-23/5 * * *",
@@ -30,6 +60,7 @@ export enum CronExpression {
   EVERY_10_HOURS = "0 0-23/10 * * *",
   EVERY_11_HOURS = "0 0-23/11 * * *",
   EVERY_12_HOURS = "0 0-23/12 * * *",
+  // day (specific times)
   EVERY_DAY_AT_1AM = "0 01 * * *",
   EVERY_DAY_AT_2AM = "0 02 * * *",
   EVERY_DAY_AT_3AM = "0 03 * * *",
@@ -54,20 +85,21 @@ export enum CronExpression {
   EVERY_DAY_AT_10PM = "0 22 * * *",
   EVERY_DAY_AT_11PM = "0 23 * * *",
   EVERY_DAY_AT_MIDNIGHT = "0 0 * * *",
+  // week
   EVERY_WEEK = "0 0 * * 0",
   EVERY_WEEKDAY = "0 0 * * 1-5",
   EVERY_WEEKEND = "0 0 * * 6,0",
+  // month
   EVERY_1ST_DAY_OF_MONTH_AT_MIDNIGHT = "0 0 1 * *",
   EVERY_1ST_DAY_OF_MONTH_AT_NOON = "0 12 1 * *",
-  EVERY_2ND_HOUR = "0 */2 * * *",
-  EVERY_2ND_HOUR_FROM_1AM_THROUGH_11PM = "0 1-23/2 * * *",
   EVERY_2ND_MONTH = "0 0 1 */2 *",
   EVERY_QUARTER = "0 0 1 */3 *",
   EVERY_6_MONTHS = "0 0 1 */6 *",
-  EVERY_YEAR = "0 0 1 1 *",
+  // business hours
   EVERY_30_MINUTES_BETWEEN_9AM_AND_5PM = "0 */30 9-17 * * *",
   EVERY_30_MINUTES_BETWEEN_9AM_AND_6PM = "0 */30 9-18 * * *",
   EVERY_30_MINUTES_BETWEEN_10AM_AND_7PM = "0 */30 10-19 * * *",
+  // weekday-specific times
   MONDAY_TO_FRIDAY_AT_1AM = "0 0 01 * * 1-5",
   MONDAY_TO_FRIDAY_AT_2AM = "0 0 02 * * 1-5",
   MONDAY_TO_FRIDAY_AT_3AM = "0 0 03 * * 1-5",
@@ -93,43 +125,179 @@ export enum CronExpression {
   MONDAY_TO_FRIDAY_AT_9PM = "0 0 21 * * 1-5",
   MONDAY_TO_FRIDAY_AT_10PM = "0 0 22 * * 1-5",
   MONDAY_TO_FRIDAY_AT_11PM = "0 0 23 * * 1-5",
+  // year
+  EVERY_YEAR = "0 0 1 1 *",
 }
+
+/**
+ * Schedule type identifier for cron-based schedules.
+ *
+ * @internal
+ */
 export const CRON_SCHEDULE = "CRON_SCHEDULE";
+
+/**
+ * Schedule type identifier for interval-based schedules.
+ *
+ * @internal
+ */
 export const INTERVAL_SCHEDULE = "INTERVAL_SCHEDULE";
 
+/**
+ * Options for a cron-based scheduled task.
+ *
+ * @remarks
+ * Extends `SchedulerOptions` with a `schedule` field that accepts one or more
+ * cron expressions (or `CronExpression` enum values). Multiple schedules will
+ * trigger the callback at the union of all specified times.
+ */
 export type SchedulerCronOptions = SchedulerOptions & {
+  /** Cron expression(s) — single or array — determining execution times. */
   schedule: Schedule | Schedule[];
 };
+
+/**
+ * Options for an interval-based scheduled task.
+ *
+ * @remarks
+ * Extends `SchedulerOptions` with an `interval` field specifying the time
+ * between executions (in milliseconds or a `TOffset` specification).
+ */
 export type SchedulerIntervalOptions = SchedulerOptions & {
+  /** Time between executions, in milliseconds. */
   interval: number;
 };
+
+/**
+ * Options for a sliding-window scheduled task.
+ *
+ * @remarks
+ * Executes on a computed schedule: the `reset` cron determines how often to
+ * call the `next()` function to retrieve the next execution time. If `next()`
+ * returns a valid time (Dayjs, Date, number, or string), a timeout is set for
+ * that time; undefined means skip this iteration. Useful for event-driven or
+ * data-dependent scheduling.
+ */
 export type SchedulerSlidingOptions = SchedulerOptions & {
   /**
-   * How often to run the `next` method, to retrieve the next scheduled execution time
+   * Cron expression determining how often to recompute the next execution time.
+   *
+   * @remarks
+   * The `next()` callback is invoked on this schedule; its return value is
+   * used to compute the actual execution time.
    */
   reset: Schedule;
+
   /**
-   * Return something time like. undefined = skip next
+   * Compute the next execution time.
+   *
+   * @remarks
+   * Called on the `reset` schedule; return a time-like value to execute,
+   * or undefined to skip this iteration.
    */
   next: () => Dayjs | string | number | Date | undefined;
 };
 
+/**
+ * Scheduler service interface — methods to schedule and execute tasks.
+ *
+ * @remarks
+ * Returned by the scheduler service factory after context binding. Provides
+ * four primary scheduling methods (cron, interval, sliding, setTimeout/setInterval)
+ * and a sleep utility. All methods return a `RemoveCallback` to cancel the
+ * scheduled task.
+ */
 export type DigitalAlchemyScheduler = {
+  /**
+   * Schedule a task on a cron expression.
+   *
+   * @remarks
+   * Accepts one or more cron schedules (or `CronExpression` constants) and
+   * executes the callback at matching times. Returns a function to remove
+   * the scheduled task.
+   */
   cron: (options: SchedulerCronOptions) => RemoveCallback;
+
+  /**
+   * Schedule a task with a dynamically computed execution time.
+   *
+   * @remarks
+   * On the `reset` schedule, calls the `next()` function to determine the next
+   * execution time. If `next()` returns a valid time, schedules execution; if
+   * undefined, skips. Useful for event-triggered or data-dependent scheduling.
+   */
   sliding: (options: SchedulerSlidingOptions) => RemoveCallback;
+
+  /**
+   * Schedule a task to run repeatedly at a fixed interval.
+   *
+   * @remarks
+   * Executes the callback after the first interval, then repeats. Useful for
+   * background polling or periodic maintenance tasks.
+   */
   setInterval: (callback: () => TBlackHole, target: TOffset) => RemoveCallback;
+
+  /**
+   * Schedule a task to run once after a delay.
+   *
+   * @remarks
+   * Executes the callback once after the specified time offset has elapsed.
+   * Useful for deferred operations or delayed initialization.
+   */
   setTimeout: (callback: () => TBlackHole, target: TOffset) => RemoveCallback;
+
+  /**
+   * Create a promise that resolves after a delay.
+   *
+   * @remarks
+   * Useful for awaiting a time offset in async code, or for testing. The
+   * returned promise is cancellable via its `cancel()` method.
+   */
   sleep: (target: TOffset | Date | Dayjs) => SleepReturn;
 };
 
+/**
+ * Scheduler factory function — binds context and returns the scheduler API.
+ *
+ * @remarks
+ * Called by the wiring engine with the request context; returns an object
+ * with all scheduling methods. This pattern allows per-request context
+ * binding without polluting the DI injection signature.
+ */
 export type SchedulerBuilder = (context: TContext) => DigitalAlchemyScheduler;
 
+/**
+ * ISO 8601 partial duration string type for flexible time offset specification.
+ *
+ * @remarks
+ * Examples: "1h", "30m", "45s", "1h30m45s". Used alongside `DurationUnitsObjectType`
+ * and numeric offsets to specify time values in scheduler methods.
+ *
+ * @internal
+ */
 type Part<CHAR extends string> = `${number}${CHAR}` | "";
 type ISO_8601_PARTIAL = Exclude<`${Part<"H" | "h">}${Part<"M" | "m">}${Part<"S" | "s">}`, "">;
+
+/**
+ * Union of supported time offset representations.
+ *
+ * @remarks
+ * Can be a dayjs Duration, milliseconds (number), an object with duration units,
+ * an ISO 8601 partial string, or a tuple of [quantity, unit]. Scheduler methods
+ * accept any of these formats and normalize them internally.
+ */
 export type OffsetTypes =
   | Duration
   | number
   | DurationUnitsObjectType
   | ISO_8601_PARTIAL
   | [quantity: number, unit: DurationUnitType];
+
+/**
+ * Time offset — either a static value or a function that returns one.
+ *
+ * @remarks
+ * Allows dynamic offset computation at execution time. Useful for tests or
+ * when the delay depends on runtime state.
+ */
 export type TOffset = OffsetTypes | (() => OffsetTypes);

--- a/src/helpers/errors.mts
+++ b/src/helpers/errors.mts
@@ -1,8 +1,38 @@
+/**
+ * Framework exception types for structured error handling and lifecycle management.
+ *
+ * @remarks
+ * The framework uses two canonical exception classes: `BootstrapException` for
+ * wiring-time errors (configuration, module loading, dependency resolution) and
+ * `InternalError` for runtime logic errors after bootstrap. Both carry `context`,
+ * `cause` (error code), and `timestamp` to support observability and debugging.
+ */
+
 import type { TContext } from "./context.mts";
 
+/**
+ * Exception thrown during application bootstrap or module wiring.
+ *
+ * @remarks
+ * Indicates failures during dependency graph construction, configuration parsing,
+ * or module initialization. These errors should prevent the application from
+ * starting. The `cause` field carries a `SCREAMING_SNAKE_CODE` for programmatic
+ * handling; the `message` field is the human-readable description.
+ */
 export class BootstrapException extends Error {
+  /** Request context under which the exception occurred. */
   context: TContext;
+
+  /**
+   * Machine-readable error code (e.g., `MISSING_CONFIG`, `UNKNOWN_MODULE`).
+   *
+   * @remarks
+   * Overrides the inherited `Error.cause` to ensure consistency with the
+   * framework's error classification scheme.
+   */
   override cause: string;
+
+  /** Timestamp when the exception was created. */
   timestamp: Date;
 
   constructor(context: TContext, cause: string, message: string) {
@@ -15,9 +45,29 @@ export class BootstrapException extends Error {
   }
 }
 
+/**
+ * Exception thrown during runtime operation after bootstrap.
+ *
+ * @remarks
+ * Indicates logic errors, invalid state transitions, or failed assertions that
+ * occur after the application is fully initialized and running. These are
+ * typically unexpected but non-fatal; the `cause` field carries an error code
+ * for observability and alerting.
+ */
 export class InternalError extends Error {
+  /** Request context under which the error occurred. */
   context: TContext;
+
+  /**
+   * Machine-readable error code (e.g., `NOT_FOUND`, `INVALID_STATE`).
+   *
+   * @remarks
+   * Overrides the inherited `Error.cause` to ensure consistency with the
+   * framework's error classification scheme.
+   */
   override cause: string;
+
+  /** Timestamp when the error was created. */
   timestamp: Date;
 
   constructor(context: TContext, cause: string, message: string) {

--- a/src/helpers/events.mts
+++ b/src/helpers/events.mts
@@ -1,6 +1,32 @@
+/**
+ * Global error event names and factory functions for event bus routing.
+ *
+ * @remarks
+ * These constants are emitted as Node.js uncaught exception events and allow
+ * applications to attach listeners that distinguish framework-level errors
+ * (global, application, or library-scoped) from other process events.
+ */
+
 import { is } from "../index.mts";
 
+/**
+ * Event name for uncaught errors at the Node.js process level.
+ */
 export const DIGITAL_ALCHEMY_NODE_GLOBAL_ERROR = "DIGITAL_ALCHEMY_NODE_GLOBAL_ERROR";
+
+/**
+ * Event name for errors thrown during application bootstrap or operation.
+ */
 export const DIGITAL_ALCHEMY_APPLICATION_ERROR = "DIGITAL_ALCHEMY_APPLICATION_ERROR";
+
+/**
+ * Factory for library-scoped error event names.
+ *
+ * @remarks
+ * When `library` is provided, returns a namespaced event name
+ * (`DIGITAL_ALCHEMY_LIBRARY_ERROR:${library}`) to allow listening for errors
+ * from a specific library. When not provided or empty, returns the base
+ * `DIGITAL_ALCHEMY_LIBRARY_ERROR` constant.
+ */
 export const DIGITAL_ALCHEMY_LIBRARY_ERROR = (library?: string) =>
   is.empty(library) ? "DIGITAL_ALCHEMY_LIBRARY_ERROR" : `DIGITAL_ALCHEMY_LIBRARY_ERROR:${library}`;

--- a/src/helpers/extend.mts
+++ b/src/helpers/extend.mts
@@ -1,9 +1,36 @@
+/**
+ * Deep object merging and cloning utilities — recursive extend and array clone
+ * functions that preserve Date and RegExp instances.
+ *
+ * @remarks
+ * These utilities support the configuration system by enabling deep merging of
+ * config objects from multiple sources while preserving special value types.
+ * `deepExtend` mutates the target in place and returns it; `deepCloneArray`
+ * creates a new array with recursively cloned items.
+ */
+
 import { is } from "../index.mts";
 
+/**
+ * Check whether a value is a Date or RegExp instance.
+ *
+ * @internal
+ */
 function isSpecificValue(value: unknown) {
   return value instanceof Date || value instanceof RegExp;
 }
 
+/**
+ * Clone a Date or RegExp instance.
+ *
+ * @remarks
+ * Creates a new Date or RegExp with the same value as the input. Throws
+ * TypeError if the input is neither a Date nor a RegExp.
+ *
+ * @throws {TypeError} when the value is not a Date or RegExp.
+ *
+ * @internal
+ */
 export function cloneSpecificValue(value: unknown) {
   if (value instanceof Date) {
     return new Date(value.getTime());
@@ -14,6 +41,14 @@ export function cloneSpecificValue(value: unknown) {
   throw new TypeError("Unexpected situation");
 }
 
+/**
+ * Recursively clone an array, preserving nested objects, arrays, Dates, and RegExps.
+ *
+ * @remarks
+ * Walks the array and clones each item: arrays are cloned recursively, Dates and
+ * RegExps are cloned using `cloneSpecificValue`, plain objects are merged with
+ * an empty target using `deepExtend`, and primitives are returned as-is.
+ */
 export function deepCloneArray<TYPE = unknown>(array: Array<TYPE>): Array<TYPE> {
   // eslint-disable-next-line sonarjs/function-return-type
   return array.map(item => {
@@ -30,36 +65,65 @@ export function deepCloneArray<TYPE = unknown>(array: Array<TYPE>): Array<TYPE> 
   }) as Array<TYPE>;
 }
 
+/**
+ * Safely read a property from an object, blocking access to `__proto__`.
+ *
+ * @remarks
+ * Returns `undefined` if the key is `__proto__`, otherwise returns the value at
+ * `object[key]`. This prevents prototype pollution vulnerabilities during deep
+ * merges.
+ *
+ * @internal
+ */
 export function safeGetProperty(object: unknown, key: string) {
+  // guard against prototype pollution
   return key === "__proto__" ? undefined : (object as Record<string, unknown>)[key];
 }
 
+/**
+ * Merge all own properties from `object` into `target`, recursively.
+ *
+ * @remarks
+ * Mutates `target` in place and returns the merged result. Primitive values
+ * overwrite target properties outright. Arrays from `object` are cloned into
+ * the target. Objects are recursively merged if both target and source values
+ * are plain objects; otherwise, a new deep clone is created. Dates and RegExps
+ * are cloned. Circular references (where `value === target`) are skipped to
+ * prevent infinite recursion.
+ */
 export function deepExtend<A, B>(target: A, object: B): A & B {
+  // early exit if not merging an object
   if (!is.object(object)) {
     return target as A & B;
   }
   Object.keys(object).forEach(key => {
     const source = safeGetProperty(target, key);
     const value = safeGetProperty(object, key);
+    // skip circular references
     if (value === target) {
       return;
     }
+    // scalars and nulls overwrite directly
     if (typeof value !== "object" || value === null) {
       (target as Record<string, unknown>)[key] = value;
       return;
     }
+    // arrays are cloned into the target
     if (is.array(value)) {
       (target as Record<string, unknown>)[key] = deepCloneArray(value);
       return;
     }
+    // special values (Date, RegExp) are cloned
     if (isSpecificValue(value)) {
       (target as Record<string, unknown>)[key] = cloneSpecificValue(value);
       return;
     }
+    // if source is not an object or is an array, create a new clone of value
     if (typeof source !== "object" || source === null || is.array(source)) {
       (target as Record<string, unknown>)[key] = deepExtend({}, value);
       return;
     }
+    // both are plain objects — recurse
     (target as Record<string, unknown>)[key] = deepExtend(source, value);
   });
   return target as A & B;

--- a/src/helpers/index.mts
+++ b/src/helpers/index.mts
@@ -1,3 +1,13 @@
+/**
+ * Public helpers — pure-function modules and type definitions.
+ *
+ * @remarks
+ * This module re-exports all helper modules (async utilities, config loaders,
+ * lifecycle types, logging interfaces, cron schedules, etc.). Helpers are
+ * side-effect-free and differ from services in that they do not receive
+ * `TServiceParams` or participate in the DI graph.
+ */
+
 export * from "./async.mts";
 export * from "./config.mts";
 export * from "./config-environment-loader.mts";

--- a/src/helpers/lifecycle.mts
+++ b/src/helpers/lifecycle.mts
@@ -1,67 +1,152 @@
+/**
+ * Lifecycle types and stage definitions — the ordered callback hooks that
+ * frame application startup and shutdown.
+ *
+ * @remarks
+ * Services register callbacks at specific lifecycle stages; the wiring engine
+ * executes them in strict order. Callbacks can be prioritized (positive = early,
+ * negative = late, unspecified = parallel). Each stage represents a well-defined
+ * point where certain actions are safe: `onPreInit` before config,
+ * `onPostConfig` after, `onBootstrap` after all modules are wired, `onReady`
+ * when the app is running, and three shutdown stages for graceful termination.
+ */
+
 import type { TBlackHole } from "./utilities.mts";
 
+/**
+ * Function signature for a lifecycle callback — takes no arguments, returns nothing.
+ */
 export type LifecycleCallback = () => TBlackHole;
+
+/**
+ * Prioritized callback — a tuple of callback function and numeric priority.
+ *
+ * @remarks
+ * Used internally by the lifecycle engine to sort callbacks before execution.
+ * Higher priorities run first; unspecified (default) callbacks run in parallel;
+ * negative priorities run last.
+ *
+ * @internal
+ */
 export type LifecyclePrioritizedCallback = [callback: LifecycleCallback, priority: number];
+
+/**
+ * Ordered collection of prioritized callbacks.
+ *
+ * @internal
+ */
 export type CallbackList = LifecyclePrioritizedCallback[];
 
+/**
+ * Function signature for registering a lifecycle callback.
+ *
+ * @remarks
+ * Services call these methods to attach callbacks at specific lifecycle stages.
+ * The optional `priority` argument controls execution order:
+ * positive = early (high to low), undefined = parallel, negative = late.
+ */
 export type TLifeCycleRegister = (callback: LifecycleCallback, priority?: number) => void;
 
+/**
+ * Core lifecycle interface — seven stages with callback registration methods.
+ *
+ * @remarks
+ * Each method (`onPreInit`, `onPostConfig`, etc.) accepts a callback and optional
+ * priority. Callbacks are invoked by the bootstrap engine in strict stage order,
+ * with priorities controlling execution within each stage.
+ */
 export type TLifecycleBase = {
   /**
-   * Registers a callback for the bootstrap phase, executed during the initial startup process.
+   * Registers a callback for the pre-initialization phase, executed before config is loaded.
    *
-   * Optional priority arg: negative values -> no value -> positive value
-   */
-  onBootstrap: TLifeCycleRegister;
-
-  /**
-   * Registers a callback for immediately after the configuration phase, allowing post-configuration adjustments.
+   * @remarks
+   * Safe for basic state setup; do not read config values at this stage.
    *
-   * Optional priority arg: negative values -> no value -> positive value
-   */
-  onPostConfig: TLifeCycleRegister;
-
-  /**
-   * Registers a callback for the pre-initialization phase, executed before the main initialization starts.
-   *
-   * Optional priority arg: negative values -> no value -> positive value
+   * Priority: positive = early, undefined = parallel, negative = late.
    */
   onPreInit: TLifeCycleRegister;
 
   /**
-   * Registers a callback for when the system is fully initialized and ready.
+   * Registers a callback for the post-configuration phase, executed after config is ready.
    *
-   * Optional priority arg: negative values -> no value -> positive value
+   * @remarks
+   * Safe to read and validate config values; all modules are not yet wired.
+   *
+   * Priority: positive = early, undefined = parallel, negative = late.
+   */
+  onPostConfig: TLifeCycleRegister;
+
+  /**
+   * Registers a callback for the bootstrap phase, executed when all modules are wired.
+   *
+   * @remarks
+   * Safe to call other services and set up inter-service dependencies.
+   *
+   * Priority: positive = early, undefined = parallel, negative = late.
+   */
+  onBootstrap: TLifeCycleRegister;
+
+  /**
+   * Registers a callback for the ready phase, executed when the app is fully running.
+   *
+   * @remarks
+   * Safe to start schedulers, timers, and external integrations.
+   *
+   * Priority: positive = early, undefined = parallel, negative = late.
    */
   onReady: TLifeCycleRegister;
 
   /**
-   * Notification that the application intends to shut down.
+   * Registers a callback for the pre-shutdown phase, notification of intended shutdown.
    *
-   * Optional priority arg: negative values -> no value -> positive value
+   * @remarks
+   * First shutdown hook; used for graceful degradation or cleanup signaling.
+   *
+   * Priority: positive = early, undefined = parallel, negative = late.
    */
   onPreShutdown: TLifeCycleRegister;
 
   /**
-   * Begins the shutdown process, typically invoked when the system is about to shut down.
+   * Registers a callback for the shutdown-start phase, begins active teardown.
    *
-   * Optional priority arg: negative values -> no value -> positive value
+   * @remarks
+   * Close connections, stop schedulers, and drain in-flight operations.
+   *
+   * Priority: positive = early, undefined = parallel, negative = late.
    */
   onShutdownStart: TLifeCycleRegister;
 
   /**
-   * Completes the shutdown process, executed after all shutdown procedures are complete.
+   * Registers a callback for the shutdown-complete phase, final cleanup.
    *
-   * Optional priority arg: negative values -> no value -> positive value
+   * @remarks
+   * Last-resort cleanup after all other teardown is done.
+   *
+   * Priority: positive = early, undefined = parallel, negative = late.
    */
   onShutdownComplete: TLifeCycleRegister;
 };
 
+/**
+ * Extended lifecycle interface with child lifecycle factory.
+ *
+ * @remarks
+ * Used by scoped contexts (e.g., per-request) to create child lifecycle instances
+ * that fire callbacks within their own scope.
+ *
+ * @internal
+ */
 export type TParentLifecycle = TLifecycleBase & {
   child: () => TLifecycleBase;
 };
 
-// ! This is a sorted array! Don't change the order
+/**
+ * Ordered lifecycle stages — the canonical sequence of bootstrap and shutdown phases.
+ *
+ * @remarks
+ * This array defines the execution order. Do not change the order; it is relied
+ * upon by the wiring engine to route callbacks and ensure safe state transitions.
+ */
 export const LIFECYCLE_STAGES = [
   "PreInit",
   "PostConfig",
@@ -72,4 +157,7 @@ export const LIFECYCLE_STAGES = [
   "ShutdownComplete",
 ] as const;
 
+/**
+ * Union type of all lifecycle stage names.
+ */
 export type LifecycleStages = (typeof LIFECYCLE_STAGES)[number];

--- a/src/helpers/logger.mts
+++ b/src/helpers/logger.mts
@@ -1,3 +1,15 @@
+/**
+ * Logger interface and configuration — dual-arity log methods, color schemes,
+ * and a last-resort stderr writer.
+ *
+ * @remarks
+ * The logger supports six severity levels (trace, debug, info, warn, error, fatal)
+ * and dual-arity calls: `logger.info("message")` or `logger.info({ context, id }, "message")`.
+ * The logger service wraps this interface with chalk/stdout formatting, ALS
+ * integration, and LOG_LEVEL filtering. `fatalLog` is the last-resort writer for
+ * fatal conditions that cannot use the logger (e.g., during bootstrap failure).
+ */
+
 import fs from "node:fs";
 
 import type { Get } from "type-fest";
@@ -6,100 +18,268 @@ import { is, SINGLE } from "../index.mts";
 import type { TContext } from "./context.mts";
 import type { TBlackHole } from "./utilities.mts";
 
+/**
+ * Extension hook for logger replacement via declaration merging.
+ *
+ * @remarks
+ * Downstream libraries can extend this interface to substitute their own logger
+ * type into `GetLogger`, allowing alternative logging implementations.
+ *
+ * @internal
+ */
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface ReplacementLogger {
   // intentionally left empty
   // for use with declaration merging
 }
 
+/**
+ * Resolved logger type — either a merged replacement logger or the default `ILogger`.
+ *
+ * @remarks
+ * When `ReplacementLogger` is extended with a `logger` property, that type is
+ * used; otherwise, `ILogger` is the default.
+ */
 export type GetLogger =
   Get<ReplacementLogger, "logger"> extends object ? Get<ReplacementLogger, "logger"> : ILogger;
 
+/**
+ * Streaming log target — a function that receives formatted message and context data.
+ *
+ * @remarks
+ * Implementing libraries can add custom targets to send logs to external services
+ * (e.g., Datadog, CloudWatch) via the `logger.addTarget(...)` method.
+ */
 export type LogStreamTarget = (message: string, data: object) => TBlackHole;
 
+/**
+ * Logger service interface — methods to emit logs, create scoped loggers, and
+ * configure targets and output formatting.
+ *
+ * @remarks
+ * Each method operates on a base logger (which can be replaced for testing or
+ * integration) and filters based on the current LOG_LEVEL configuration.
+ * The `systemLogger` is a pre-created instance for use in bootstrap and
+ * low-level operations.
+ */
 export type DigitalAlchemyLogger = {
-  addTarget: (logger: GetLogger | LogStreamTarget) => void;
   /**
-   * Create a new logger instance for a given context
+   * Register an additional log target.
+   *
+   * @remarks
+   * Targets receive all logged messages and context data after filtering.
+   * Can be a logger instance (like `ILogger`) or a stream function that writes
+   * directly to an external service.
+   */
+  addTarget: (logger: GetLogger | LogStreamTarget) => void;
+
+  /**
+   * Create a new logger instance scoped to a specific context.
+   *
+   * @remarks
+   * Returns an `ILogger` where all calls are implicitly tagged with the given context,
+   * enabling per-request log correlation and filtering.
    */
   context: (context: string | TContext) => ILogger;
+
   /**
-   * Retrieve a reference to the base logger used to emit from
+   * Retrieve the underlying base logger implementation.
+   *
+   * @remarks
+   * Exposed for testing and low-level integrations; most code should use the logger
+   * returned by the injection, not this method.
+   *
+   * @internal
    */
   getBaseLogger: () => Record<
     keyof GetLogger,
     (context: TContext, ...data: Parameters<TLoggerFunction>) => void
   >;
-  getPrettyFormat: () => boolean;
+
   /**
-   * exposed for testing
+   * Check whether pretty formatting is enabled.
+   *
+   * @remarks
+   * Exposed for testing.
+   *
+   * @internal
+   */
+  getPrettyFormat: () => boolean;
+
+  /**
+   * Format a message string for display.
+   *
+   * @remarks
+   * Applies syntax highlighting or other transformations based on the current
+   * pretty-format setting. Exposed for testing.
+   *
+   * @internal
    */
   prettyFormatMessage: (message: string) => string;
+
   /**
-   * Modify the base logger
+   * Replace the base logger implementation.
    *
-   * Note: Extension still handles LOG_LEVEL logic
+   * @remarks
+   * Allows testing and framework integration by substituting a mock or wrapper logger.
+   * The service still enforces LOG_LEVEL filtering on top of the replacement.
    */
   setBaseLogger: (base: GetLogger) => GetLogger;
+
   /**
-   * Set the enabled/disabled state of the message pretty formatting logic
+   * Enable or disable pretty formatting of log messages.
+   *
+   * @remarks
+   * When disabled, output is minimal (no colors, no extra formatting).
+   * Returns the new state.
    */
   setPrettyFormat: (state: boolean) => boolean;
+
   /**
-   * Logger instance of last resort
+   * System logger instance — ready-to-use logger for bootstrap and low-level code.
+   *
+   * @remarks
+   * Pre-created for convenience in places where context is unavailable or
+   * not yet initialized.
    */
   systemLogger: GetLogger;
+
   /**
-   * exposed for testing
+   * Recompute log filtering based on current LOG_LEVEL config.
+   *
+   * @remarks
+   * Call after changing the LOG_LEVEL configuration to update filter state.
+   * Exposed for testing.
+   *
+   * @internal
    */
   updateShouldLog: () => void;
 };
 
+/**
+ * Dual-arity logger function signature — message-only or object+message forms.
+ *
+ * @remarks
+ * Enables flexible calling styles:
+ * - `logger.info("message")`
+ * - `logger.info({data}, "message")`
+ * The logger extracts `name` from objects for call-site identification.
+ */
 export type TLoggerFunction =
   | ((message: string, ...arguments_: unknown[]) => void)
   | ((object: object, message?: string, ...arguments_: unknown[]) => void);
 
+/**
+ * Logger interface — six severity levels with dual-arity overloads.
+ *
+ * @remarks
+ * Each level (`trace`, `debug`, `info`, `warn`, `error`, `fatal`) accepts either
+ * a message string or an object with metadata plus an optional message. The
+ * object form typically includes a `name` field (function reference) for
+ * call-site identification.
+ */
 export interface ILogger {
-  debug(...arguments_: Parameters<TLoggerFunction>): void;
-  debug(message: string, ...arguments_: unknown[]): void;
-  debug(object: object, message?: string, ...arguments_: unknown[]): void;
-  error(...arguments_: Parameters<TLoggerFunction>): void;
-  error(message: string, ...arguments_: unknown[]): void;
-  error(object: object, message?: string, ...arguments_: unknown[]): void;
-  fatal(...arguments_: Parameters<TLoggerFunction>): void;
-  fatal(message: string, ...arguments_: unknown[]): void;
-  fatal(object: object, message?: string, ...arguments_: unknown[]): void;
-  info(...arguments_: Parameters<TLoggerFunction>): void;
-  info(message: string, ...arguments_: unknown[]): void;
-  info(object: object, message?: string, ...arguments_: unknown[]): void;
+  /**
+   * Log at TRACE level — lowest severity, highest volume; decision points, entry/exit.
+   */
   trace(...arguments_: Parameters<TLoggerFunction>): void;
   trace(message: string, ...arguments_: unknown[]): void;
   trace(object: object, message?: string, ...arguments_: unknown[]): void;
+
+  /**
+   * Log at DEBUG level — low severity; detailed operation flow.
+   */
+  debug(...arguments_: Parameters<TLoggerFunction>): void;
+  debug(message: string, ...arguments_: unknown[]): void;
+  debug(object: object, message?: string, ...arguments_: unknown[]): void;
+
+  /**
+   * Log at INFO level — notable events; startup, shutdown, config changes.
+   */
+  info(...arguments_: Parameters<TLoggerFunction>): void;
+  info(message: string, ...arguments_: unknown[]): void;
+  info(object: object, message?: string, ...arguments_: unknown[]): void;
+
+  /**
+   * Log at WARN level — unexpected but non-fatal; potential issues worth investigating.
+   */
   warn(...arguments_: Parameters<TLoggerFunction>): void;
   warn(message: string, ...arguments_: unknown[]): void;
   warn(object: object, message?: string, ...arguments_: unknown[]): void;
+
+  /**
+   * Log at ERROR level — error conditions; failed operations, exceptions.
+   */
+  error(...arguments_: Parameters<TLoggerFunction>): void;
+  error(message: string, ...arguments_: unknown[]): void;
+  error(object: object, message?: string, ...arguments_: unknown[]): void;
+
+  /**
+   * Log at FATAL level — unrecoverable errors; application must shut down.
+   */
+  fatal(...arguments_: Parameters<TLoggerFunction>): void;
+  fatal(message: string, ...arguments_: unknown[]): void;
+  fatal(object: object, message?: string, ...arguments_: unknown[]): void;
 }
+
+/**
+ * Configuration value type — log level or the special "silent" value.
+ */
 export type TConfigLogLevel = keyof ILogger | "silent";
 
+/**
+ * Mapping from log level to console color for pretty-printed output.
+ */
 export const METHOD_COLORS = new Map<keyof ILogger, CONTEXT_COLORS>([
   ["trace", "grey"],
   ["debug", "blue"],
+  ["info", "green"],
   ["warn", "yellow"],
   ["error", "red"],
-  ["info", "green"],
   ["fatal", "magenta"],
 ]);
+
+/**
+ * Supported console color names for log output.
+ */
 export type CONTEXT_COLORS = "grey" | "blue" | "yellow" | "red" | "green" | "magenta";
+
+/**
+ * Event name for log level configuration updates.
+ *
+ * @internal
+ */
 export const EVENT_UPDATE_LOG_LEVELS = "EVENT_UPDATE_LOG_LEVELS";
 
+/**
+ * Last-resort logger for fatal conditions that cannot use the normal logger.
+ *
+ * @remarks
+ * Writes directly to `stderr` bypassing the logger service. Use only when the
+ * logger is not available (e.g., during bootstrap failure before services are
+ * wired). If `data` is an Error, extracts and formats `name`, `cause`, `message`,
+ * and stack trace; otherwise, JSON-stringifies it. Always adds a trailing newline.
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   await bootstrap();
+ * } catch (error) {
+ *   fatalLog("bootstrap failed", error);
+ *   process.exit(1);
+ * }
+ * ```
+ */
 export function fatalLog(message: string, data?: unknown) {
   if (data) {
     if (data instanceof Error) {
+      // extract structured error fields with fallback defaults
       const cause = is.string(data?.cause) && !is.empty(data?.cause) ? ` - ${data.cause}` : "";
       const stack = data.stack ? `\n` + data.stack.split("\n").slice(SINGLE).join("\n") : ``;
       const errorOutput = `${data.name || "Error"}${cause}: ${data.message || "Unknown error"}${stack}`;
       message = [message, errorOutput].join("\n");
     } else {
+      // pretty-print non-error data
       message = [message, JSON.stringify(data, undefined, "  ")].join("\n");
     }
   }

--- a/src/helpers/module.mts
+++ b/src/helpers/module.mts
@@ -3,6 +3,8 @@ import type { Except, Merge } from "type-fest";
 import type { iTestRunner } from "../index.mts";
 import { CreateApplication, TestRunner } from "../index.mts";
 import type { OptionalModuleConfiguration } from "./config.mts";
+import type { TContext } from "./context.mts";
+import { BootstrapException } from "./errors.mts";
 import { deepExtend } from "./extend.mts";
 import type {
   ApplicationDefinition,
@@ -13,7 +15,18 @@ import type {
 } from "./wiring.mts";
 import { CreateLibrary } from "./wiring.mts";
 
+// pure-helper file has no TServiceParams; tag bootstrap errors with a stable
+// module-scoped context so consumers can identify the origin in stack traces
+const MODULE_CONTEXT = "digital-alchemy:module" as TContext;
+
+// --- Option types -------------------------------------------------------------
+
+/**
+ * Options that control how {@link DigitalAlchemyModule.extend} behaves when
+ * forking a module into a modified copy.
+ */
 export type ExtendOptions = {
+  /** Override the name given to the extended module. */
   name?: string;
   /**
    * default: true
@@ -21,7 +34,21 @@ export type ExtendOptions = {
   keepConfiguration?: boolean;
 };
 
-// #MARK: DigitalAlchemyModule
+// --- Core module types --------------------------------------------------------
+
+/**
+ * Intermediate representation of a Digital Alchemy module before it is
+ * committed to a concrete form (library, application, or test runner).
+ *
+ * @remarks
+ * A `DigitalAlchemyModule` holds the full set of services and configuration
+ * that would be passed to `CreateLibrary` or `CreateApplication`, but defers
+ * that commitment so callers can compose and mutate before export.
+ *
+ * Call `.extend()` to obtain a {@link ModuleExtension} builder, then chain
+ * mutations before finalising with `.toLibrary()`, `.toApplication()`, or
+ * `.toTest()`.
+ */
 export type DigitalAlchemyModule<S extends ServiceMap, C extends OptionalModuleConfiguration> = {
   services: S;
   configuration: C;
@@ -32,7 +59,14 @@ export type DigitalAlchemyModule<S extends ServiceMap, C extends OptionalModuleC
   extend: (options?: ExtendOptions) => ModuleExtension<S, C>;
 };
 
-// #MARK: CreateModuleOptions
+/**
+ * Input shape required to construct a {@link DigitalAlchemyModule}.
+ *
+ * @remarks
+ * Mirrors `LibraryConfigurationOptions` but without the `type` discriminant or
+ * the runtime wiring symbol — those are added by `CreateLibrary` /
+ * `CreateApplication` at export time.
+ */
 export type CreateModuleOptions<S extends ServiceMap, C extends OptionalModuleConfiguration> = {
   services: S;
   configuration: C;
@@ -43,19 +77,56 @@ export type CreateModuleOptions<S extends ServiceMap, C extends OptionalModuleCo
 };
 
 /**
+ * Chainable builder returned by {@link DigitalAlchemyModule.extend}.
+ *
+ * @remarks
+ * Each mutation method returns the same `ModuleExtension` instance (or a
+ * narrowed variant of it), enabling fluent composition. The builder holds
+ * mutable references to the service map and dependency list; calling any
+ * terminal method (`.toLibrary()`, `.toApplication()`, `.toTest()`) reads the
+ * current state and produces an immutable definition.
+ *
+ * **Method categories:**
+ * - *Dependency mutations:* `appendLibrary`, `replaceLibrary`
+ * - *Service mutations:* `appendService`, `replaceService`, `pickService`,
+ *   `omitService`, `rebuild`
+ * - *Terminal exports:* `toApplication`, `toLibrary`, `toTest`
+ *
  * commands mutate module
  */
-// #MARK: ModuleExtension
 export type ModuleExtension<S extends ServiceMap, C extends OptionalModuleConfiguration> = {
+  /**
+   * Add a new library dependency not present in the base module.
+   *
+   * @remarks
+   * Throws if the library name is already appended or exists in the base
+   * `depends` list — use `replaceLibrary` in that case.
+   */
   appendLibrary: (library: TLibrary) => ModuleExtension<S, C>;
+
+  /**
+   * Inject an additional service that is not declared in the base module.
+   *
+   * @remarks
+   * Throws if a service with the same name already exists — use
+   * `replaceService` in that case.
+   */
   appendService: (name: string, target: ServiceFunction) => ModuleExtension<S, C>;
 
   /**
+   * Swap a library dependency by name.
+   *
    * name must match existing library
    */
   replaceLibrary: (library: TLibrary) => ModuleExtension<S, C>;
 
   /**
+   * Swap an existing service implementation while keeping the same key.
+   *
+   * @remarks
+   * The return type is narrowed to reflect the new function's signature.
+   * Throws if `name` does not exist in the current service map.
+   *
    * name must match existing service
    */
   replaceService: <TARGET extends keyof S, FN extends ServiceFunction>(
@@ -64,16 +135,32 @@ export type ModuleExtension<S extends ServiceMap, C extends OptionalModuleConfig
   ) => ModuleExtension<Merge<S, { [key in TARGET]: FN }>, C>;
 
   /**
+   * Reduce the service map to only the named services.
+   *
+   * @remarks
+   * Throws if any supplied name does not exist in the current service map.
+   *
    * throws if any service does not exist
    */
   pickService: <PICK extends keyof S>(...services: PICK[]) => ModuleExtension<Pick<S, PICK>, C>;
 
   /**
+   * Remove specific services from the service map.
+   *
+   * @remarks
+   * Throws if any supplied name does not exist in the current service map.
+   *
    * throws if any service does not exist
    */
   omitService: <OMIT extends keyof S>(...services: OMIT[]) => ModuleExtension<Except<S, OMIT>, C>;
 
   /**
+   * Replace the entire service map with a new set.
+   *
+   * @remarks
+   * `services` must extend `S` (i.e., it must be API-compatible with the
+   * original map). Use when rebuilding several services at once.
+   *
    * build api compatible replacement (potentially adding)
    */
   rebuild: <REPLACEMENTS extends S>(
@@ -81,22 +168,54 @@ export type ModuleExtension<S extends ServiceMap, C extends OptionalModuleConfig
   ) => ModuleExtension<REPLACEMENTS, C>;
 
   /**
+   * Finalise as an {@link ApplicationDefinition} for use with `bootstrap`.
+   *
    * export as application
    */
   toApplication: () => ApplicationDefinition<S, C>;
 
   /**
+   * Finalise as a {@link LibraryDefinition} for use as a dependency.
+   *
    * export as library
    */
   toLibrary: () => LibraryDefinition<S, C>;
 
   /**
+   * Finalise as an `iTestRunner` for use in vitest specs.
+   *
+   * @remarks
+   * Internally calls `.toApplication()` and wraps the result in a `TestRunner`.
+   * Prefer `.toTest()` in spec files over manually constructing both.
+   *
    * export as test
    */
   toTest: () => iTestRunner<S, C>;
 };
 
-// #MARK: createModule
+// --- createModule factory -----------------------------------------------------
+
+/**
+ * Construct a new {@link DigitalAlchemyModule} from a raw options object.
+ *
+ * @remarks
+ * `createModule` is the entry point for the chainable module pattern. It
+ * captures the options into a working module object and exposes `.extend()` to
+ * begin the mutation chain. No library or application definition is produced
+ * until a terminal method is called on the resulting {@link ModuleExtension}.
+ *
+ * Use the static helpers `createModule.fromApplication` and
+ * `createModule.fromLibrary` to seed the builder from an existing definition
+ * instead of building from scratch.
+ *
+ * Typical call sequence:
+ * ```typescript
+ * createModule({ name: "my-lib", services, configuration, depends: [], priorityInit: [] })
+ *   .extend()
+ *   .appendLibrary(someLibrary)
+ *   .toLibrary();
+ * ```
+ */
 export function createModule<S extends ServiceMap, C extends OptionalModuleConfiguration>(
   options: CreateModuleOptions<S, C>,
 ): DigitalAlchemyModule<S, C> {
@@ -108,18 +227,32 @@ export function createModule<S extends ServiceMap, C extends OptionalModuleConfi
       appendLibrary: (library: TLibrary) => {
         const name = library.name;
         if (appendLibrary.has(name)) {
-          throw new Error(`${name} already is appended`);
+          throw new BootstrapException(
+            MODULE_CONTEXT,
+            "LIBRARY_ALREADY_APPENDED",
+            `${name} already is appended`,
+          );
         }
         const exists = workingModule.depends.some(i => i.name === name);
         if (exists) {
-          throw new Error(`${name} exists as a library in base, use replaceLibrary`);
+          // base depends list owns this name; callers must use replaceLibrary to swap it
+          throw new BootstrapException(
+            MODULE_CONTEXT,
+            "LIBRARY_USE_REPLACE",
+            `${name} exists as a library in base, use replaceLibrary`,
+          );
         }
         appendLibrary.set(name, library);
         return extend;
       },
       appendService: (name: string, service: ServiceFunction) => {
         if (name in services) {
-          throw new Error(`${name} exists as a service in base, use replaceService`);
+          // service already registered; callers must explicitly opt into replacement
+          throw new BootstrapException(
+            MODULE_CONTEXT,
+            "SERVICE_USE_REPLACE",
+            `${name} exists as a service in base, use replaceService`,
+          );
         }
         // @ts-expect-error the interface makes this type properly, idc
         services[name] = service;
@@ -144,11 +277,17 @@ export function createModule<S extends ServiceMap, C extends OptionalModuleConfi
       replaceLibrary: (library: TLibrary) => {
         const name = library.name;
         if (appendLibrary.has(name)) {
+          // already in the appended set — replace in-place
           appendLibrary.set(name, library);
         } else {
           const exists = workingModule.depends.some(i => i.name === name);
           if (!exists) {
-            throw new Error(`${name} does not exist in module yet`);
+            // neither appended nor in base depends; require explicit append first
+            throw new BootstrapException(
+              MODULE_CONTEXT,
+              "LIBRARY_NOT_FOUND",
+              `${name} does not exist in module yet`,
+            );
           }
           appendLibrary.set(name, library);
         }
@@ -160,13 +299,18 @@ export function createModule<S extends ServiceMap, C extends OptionalModuleConfi
         target: FN,
       ) => {
         if (!(name in services)) {
-          throw new Error(`${String(name)} does not exist to replace`);
+          throw new BootstrapException(
+            MODULE_CONTEXT,
+            "SERVICE_NOT_FOUND",
+            `${String(name)} does not exist to replace`,
+          );
         }
         // @ts-expect-error I don't care
         services[name] = target;
         return extend;
       },
       toApplication: () => {
+        // merge base depends and appended libraries; appended wins on name collision
         const depends = {} as Record<string, TLibrary>;
         workingModule.depends?.forEach(i => (depends[i.name] = i));
         appendLibrary.forEach((value, key) => (depends[key] = value));
@@ -182,6 +326,7 @@ export function createModule<S extends ServiceMap, C extends OptionalModuleConfi
         });
       },
       toLibrary: () => {
+        // same merge logic as toApplication; both export forms share the same dependency union
         const depends = {} as Record<string, TLibrary>;
         workingModule.depends?.forEach(i => (depends[i.name] = i));
         appendLibrary.forEach((value, key) => (depends[key] = value));
@@ -216,6 +361,17 @@ export function createModule<S extends ServiceMap, C extends OptionalModuleConfi
   return workingModule;
 }
 
+// --- Static helpers on createModule -------------------------------------------
+
+/**
+ * Seed a {@link DigitalAlchemyModule} from an existing
+ * {@link ApplicationDefinition}.
+ *
+ * @remarks
+ * Copies services, configuration, libraries, and `priorityInit` into the
+ * intermediate module shape so callers can fork and modify an application
+ * without reconstructing it from scratch.
+ */
 // #MARK: fromApplication
 createModule.fromApplication = <S extends ServiceMap, C extends OptionalModuleConfiguration>(
   application: ApplicationDefinition<S, C>,
@@ -230,6 +386,14 @@ createModule.fromApplication = <S extends ServiceMap, C extends OptionalModuleCo
   });
 };
 
+/**
+ * Seed a {@link DigitalAlchemyModule} from an existing
+ * {@link LibraryDefinition}.
+ *
+ * @remarks
+ * Mirrors `fromApplication` but for library definitions, preserving
+ * `optionalDepends` which applications do not carry.
+ */
 // #MARK: fromLibrary
 createModule.fromLibrary = <S extends ServiceMap, C extends OptionalModuleConfiguration>(
   library: LibraryDefinition<S, C>,

--- a/src/helpers/service-runner.mts
+++ b/src/helpers/service-runner.mts
@@ -1,3 +1,14 @@
+/**
+ * Minimal single-service bootstrap helper for scripts and one-off operations.
+ *
+ * @remarks
+ * `ServiceRunner` creates a complete DI graph for a single service, handling
+ * all wiring, lifecycle, and teardown. It is useful for scripts that need
+ * access to the full framework without building an application. The service
+ * function receives the same `TServiceParams` as a normal service, allowing
+ * access to config, logger, scheduler, and other boilerplate.
+ */
+
 import { CreateApplication } from "../index.mts";
 import type { OptionalModuleConfiguration } from "./config.mts";
 import type {
@@ -23,7 +34,23 @@ type LocalServiceParams<C extends OptionalModuleConfiguration, NAME extends stri
 };
 
 /**
- * Type safe way to kick off a mini service / script
+ * Bootstrap and run a single typed service with full framework support.
+ *
+ * @remarks
+ * Creates an application with a single service, invokes its bootstrap lifecycle,
+ * and returns when the service completes. The service runs synchronously within
+ * the context of a fully-initialized DI graph, with access to all boilerplate
+ * services (logger, scheduler, lifecycle, config, etc.).
+ *
+ * @example
+ * ```typescript
+ * await ServiceRunner(
+ *   { configuration: { myLib: {...} } },
+ *   ({ logger, config }) => {
+ *     logger.info("running with config:", config.myLib);
+ *   }
+ * );
+ * ```
  */
 export async function ServiceRunner<
   C extends OptionalModuleConfiguration,

--- a/src/helpers/utilities.mts
+++ b/src/helpers/utilities.mts
@@ -9,53 +9,145 @@ import type { TOffset } from "./cron.mts";
 dayjs.extend(duration);
 
 /* eslint-disable @typescript-eslint/no-magic-numbers */
+
+// --- Numeric constants ---------------------------------------------------------
+// These are the canonical zero/one anchors used throughout the codebase.
+// Named constants eliminate magic numbers and make intent explicit at each
+// call site, which is why they live here rather than being inlined.
+
+/** Even divisor — used when checking parity (`value % EVEN === 0`). */
 export const EVEN = 2;
+
+/** Alias for EVEN; used when the "twoness" is conceptually a pair, not parity. */
 export const PAIR = 2;
+
+/** Multiplier for half of a value (`total * HALF`). */
 export const HALF = 0.5;
+
+/** One-third fraction constant (`total * ONE_THIRD`). */
 export const ONE_THIRD = 1 / 3;
+
+/** Two-thirds fraction constant (`total * TWO_THIRDS`). */
 export const TWO_THIRDS = 2 / 3;
+
 /**
+ * Sensible default cap for concurrency and pagination limits.
+ *
  * Good for a surprising number of situations
  */
 export const DEFAULT_LIMIT = 5;
+
+/** Multiply by this to negate a number (`value * INVERT_VALUE`). */
 export const INVERT_VALUE = -1;
+
+/** Sort comparator return for ascending order (`a > b ? UP : ...`). */
 // Sort
 export const UP = 1;
+
+/** Index of the value element in a `[label, value]` tuple. */
 // [LABEL,VALUE]
 export const VALUE = 1;
+
+/**
+ * Offset applied when converting a 1-based length to a 0-based last index
+ * (`array.length - ARRAY_OFFSET`).
+ */
 // Standard value
 export const ARRAY_OFFSET = 1;
+
+/** Step size when walking an array index one position at a time. */
 // array[number +- increment]
 export const INCREMENT = 1;
+
+/** Canonical "one of something" constant; avoids the bare literal `1`. */
 // Generic one-ness
 export const SINGLE = 1;
+
+/** Sort comparator return for equal elements (`a === b ? SAME : ...`). */
 // Sorting
 export const SAME = 0;
+
+/** Index of the label element in a `[label, value]` tuple. */
 // [LABEL,VALUE]
 export const LABEL = 0;
+
+/** Zero-based start index; use instead of bare `0` for array access. */
 // Generic start of something
 export const START = 0;
+
+/** Canonical zero-count sentinel (`if (count === NONE)`). */
 export const NONE = 0;
+
+/** First index in any zero-based collection. */
 export const FIRST = 0;
+
+/** Type alias for the literal `0`; useful in discriminated union positions. */
 export type FIRST = 0;
+
+/** Zero-length sentinel; use `length === EMPTY` instead of `length === 0`. */
 export const EMPTY = 0;
+
+/** No-op delta — returned from comparators when a value has not changed. */
 export const NO_CHANGE = 0;
 
+/** Sentinel returned by `Array.prototype.indexOf` when the element is absent. */
 // Testing of indexes
 export const NOT_FOUND = -1;
+
+/** Sort comparator return for descending order (`a < b ? DOWN : ...`). */
 // Sorting
 export const DOWN = -1;
+
+/** One minute expressed in milliseconds (`60_000`). */
 export const MINUTE = 60_000;
+
+/** One hour expressed in milliseconds (`3_600_000`). */
 export const HOUR = 3_600_000;
+
+/** One day expressed in milliseconds (`86_400_000`). */
 export const DAY = 86_400_000;
+
+/** One week expressed in milliseconds (`7 * DAY`). */
 export const WEEK = 7 * DAY;
+
+/** One second expressed in milliseconds (`1_000`). */
 export const SECOND = 1000;
+
+/** Denominator for percent calculations (`value / PERCENT * 100`). */
 export const PERCENT = 100;
+
+/** One calendar year expressed in milliseconds (`365 * DAY`). */
 export const YEAR = 365 * DAY;
 
+// --- Sleep infrastructure -----------------------------------------------------
+
+/**
+ * Live set of every `SleepReturn` that has not yet resolved or been killed.
+ *
+ * @remarks
+ * The scheduler and teardown logic iterate this set to cancel in-flight sleeps
+ * on shutdown. Entries are added when `sleep()` is called and removed when the
+ * timer fires or `.kill()` is called.
+ *
+ * @internal
+ */
 export const ACTIVE_SLEEPS = new Set<SleepReturn>();
 
 /**
+ * Normalise a {@link TOffset} into a dayjs `Duration` object.
+ *
+ * @remarks
+ * Supports the full `TOffset` union:
+ * - **function** — called first to unwrap the real offset
+ * - **`[amount, unit]` tuple** — passed directly to `dayjs.duration`
+ * - **`DurationUnitsObjectType` object** — passed to `dayjs.duration`; an existing
+ *   `Duration` instance is returned as-is
+ * - **string** — interpreted as a partial ISO 8601 duration after prepending `"PT"`
+ *   (e.g. `"30s"` → `"PT30S"`)
+ * - **number** — treated as raw milliseconds
+ *
+ * Returns `undefined` when the offset does not match any supported form.
+ *
  * Converts a TOffset to a Duration object (or undefined if invalid)
  * Handles function unwrapping, arrays, objects, strings, and numbers
  */
@@ -87,6 +179,15 @@ export function toOffsetDuration(offset: TOffset): Duration | undefined {
 }
 
 /**
+ * Normalise a {@link TOffset} into a plain millisecond count.
+ *
+ * @remarks
+ * Unwraps function offsets then takes a fast path for raw numbers to avoid
+ * allocating a `Duration` object. All other forms are delegated to
+ * {@link toOffsetDuration} and converted via `asMilliseconds()`.
+ *
+ * Returns `NONE` (0) when the offset cannot be resolved.
+ *
  * Converts a TOffset to milliseconds
  */
 export function toOffsetMs(offset: TOffset): number {
@@ -103,18 +204,38 @@ export function toOffsetMs(offset: TOffset): number {
   return duration?.asMilliseconds() ?? NONE;
 }
 
+/**
+ * A `Promise<void>` extended with a `.kill()` method for early cancellation.
+ *
+ * @remarks
+ * Returned by {@link sleep}. Awaiting resolves when the timer fires naturally.
+ * Calling `.kill("continue")` resolves the promise immediately and cancels the
+ * timer. Calling `.kill("stop")` (the default) cancels the timer and lets the
+ * promise remain forever-pending — useful when you want the awaiting code to
+ * simply stop without advancing.
+ */
 export type SleepReturn = Promise<void> & {
   kill: (execute?: "stop" | "continue") => void;
 };
+
 /**
- * #MARK: Simple usage
+ * Async delay that supports early cancellation via `.kill()`.
  *
+ * @remarks
+ * Accepts any {@link TOffset}, a JS `Date`, or a `Dayjs` instance. Absolute
+ * time values (`Date` / `Dayjs`) are converted to a relative delay from now at
+ * the moment `sleep()` is called.
+ *
+ * The returned {@link SleepReturn} is tracked in {@link ACTIVE_SLEEPS} for
+ * lifecycle-aware shutdown; it is removed automatically when the timer fires or
+ * `.kill()` is called.
+ *
+ * @example Simple usage
  * ```typescript
  * await sleep(5000);
  * ```
  *
- * #MARK: Early stop
- *
+ * @example Early stop
  * ```typescript
  * const start = Date.now();
  * const timer = sleep(5000);
@@ -154,6 +275,7 @@ export function sleep(target: TOffset | Date | Dayjs): SleepReturn {
   ACTIVE_SLEEPS.add(out);
   out.kill = (execute = "stop") => {
     ACTIVE_SLEEPS.delete(out);
+    // only resolve the promise when the caller wants execution to continue after the kill
     if (execute === "continue" && done) {
       done();
     }
@@ -163,14 +285,41 @@ export function sleep(target: TOffset | Date | Dayjs): SleepReturn {
   return out;
 }
 
+// --- Debounce infrastructure --------------------------------------------------
+
+/**
+ * Set of identifiers currently in the throttle window.
+ *
+ * @internal
+ */
 export const ACTIVE_THROTTLE = new Set<string>();
+
+/**
+ * Map of identifier → pending sleep for the active debounce window.
+ *
+ * @remarks
+ * Each key is a caller-supplied `identifier` string. When a new call arrives
+ * for an existing identifier, the current sleep is killed and replaced, pushing
+ * the expiry forward. Entries are removed once the delay resolves.
+ *
+ * @internal
+ */
 export const ACTIVE_DEBOUNCE = new Map<string, SleepReturn>();
 
 /**
+ * Debounce an async operation by identifier.
+ *
+ * @remarks
+ * Each call resets the timer for `identifier`, so the operation does not
+ * proceed until no further calls for that identifier arrive within `timeout`.
+ * Multiple concurrent callers sharing the same `identifier` all wait on the
+ * same sliding window — the last writer wins.
+ *
  * wait for duration after call before allowing next, extends for calls inside window
  */
 export async function debounce(identifier: string, timeout: TOffset): Promise<void> {
   const current = ACTIVE_DEBOUNCE.get(identifier);
+  // kill the outstanding timer so the window slides forward from this call
   if (!is.undefined(current)) {
     current.kill("stop");
   }
@@ -180,8 +329,22 @@ export async function debounce(identifier: string, timeout: TOffset): Promise<vo
   ACTIVE_DEBOUNCE.delete(identifier);
 }
 
+/** Async no-op that resolves after one event-loop tick via `sleep(0)`. */
 export const asyncNoop = async () => await sleep(NONE);
+
+/** Synchronous no-op — a named empty function for use as a default callback. */
 export const noop = () => {};
 
+/**
+ * Represents a return type that callers are not expected to use.
+ *
+ * @remarks
+ * Used as the return type annotation for fire-and-forget callbacks and service
+ * methods where the resolved value is intentionally discarded. Covers `void`,
+ * `Promise<void>`, and any other return to prevent TypeScript from complaining
+ * about unused return values.
+ */
 export type TBlackHole = unknown | void | Promise<void>;
+
+/** Loose function signature that accepts any arguments and returns a {@link TBlackHole}. */
 export type TAnyFunction = (...data: unknown[]) => TBlackHole;

--- a/src/helpers/wiring.mts
+++ b/src/helpers/wiring.mts
@@ -1,3 +1,24 @@
+/**
+ * @file helpers/wiring.mts — types and pure functions for the DI wiring engine.
+ *
+ * @remarks
+ * This file is the **type backbone** of `@digital-alchemy/core`. It owns
+ * `TServiceParams`, `CreateLibrary`, `buildSortOrder`, `wireOrder`, and the
+ * two wiring-boundary symbols (`COERCE_CONTEXT`, `WIRE_PROJECT`). Every
+ * downstream `@digital-alchemy` library depends on these types.
+ *
+ * **Split rationale.** This file was deliberately separated from
+ * `services/wiring.service.mts` to break a circular module reference that
+ * would form if types and the runtime bootstrap logic lived together. Do not
+ * merge them. Runtime orchestration (`CreateApplication`, `bootstrap`,
+ * `wireService`, `teardown`) lives in `services/wiring.service.mts`; pure
+ * types and pure functions live here.
+ *
+ * **Downstream impact.** Changes to `TServiceParams` shape or to any exported
+ * type here ripple into every library. Treat all public exports as breaking
+ * surface.
+ */
+
 import type { AsyncLocalStorage } from "node:async_hooks";
 import type { EventEmitter } from "node:events";
 
@@ -28,12 +49,45 @@ import type { TLifecycleBase } from "./lifecycle.mts";
 import type { GetLogger, TConfigLogLevel } from "./logger.mts";
 import type { TBlackHole } from "./utilities.mts";
 
+// --- Primitive service types --------------------------------------------------
+
+/**
+ * The value a service factory may return.
+ *
+ * @remarks
+ * A service that returns `void` is wired for its side effects only (e.g.
+ * attaching lifecycle hooks). A service that returns an `OBJECT` exposes that
+ * object as its public API, accessible to other services via the module's
+ * namespace on `TServiceParams`.
+ */
 export type TServiceReturn<OBJECT extends object = object> = void | OBJECT;
 
+/**
+ * Unresolved mapping of service name → factory function within a module.
+ *
+ * @internal
+ */
 export type TModuleMappings = Record<string, ServiceFunction>;
+
+/**
+ * Resolved mapping of service name → return value after the factory has run.
+ *
+ * @internal
+ */
 export type TResolvedModuleMappings = Record<string, TServiceReturn>;
 
+// --- ApplicationConfigurationOptions ------------------------------------------
+
 // #MARK: ApplicationConfigurationOptions
+/**
+ * Shape of the options object passed to `CreateApplication`.
+ *
+ * @remarks
+ * `name` must be declared in `LoadedModules` via declaration merging so the
+ * type system can track which modules are loaded. `services` is the record of
+ * service factories that make up the application. `priorityInit` lets callers
+ * force specific services to wire before the rest.
+ */
 export interface ApplicationConfigurationOptions<
   S extends ServiceMap,
   C extends OptionalModuleConfiguration,
@@ -48,23 +102,45 @@ export interface ApplicationConfigurationOptions<
   priorityInit?: Extract<keyof S, string>[];
 }
 
+/**
+ * Union of all module definition shapes — either a library or an application.
+ *
+ * @remarks
+ * Used as a generic bound wherever code needs to accept either kind without
+ * caring which one it is.
+ */
 export type TConfigurable<
   S extends ServiceMap = ServiceMap,
   C extends OptionalModuleConfiguration = OptionalModuleConfiguration,
 > = LibraryDefinition<S, C> | ApplicationDefinition<S, C>;
 
+/**
+ * Type-safe config accessor bound to a specific configurable module.
+ *
+ * @remarks
+ * `K` is constrained to the keys of the config block extracted from `PARENT`,
+ * and the return type is the concrete resolved type for that key.
+ */
 export type TGetConfig<PARENT extends TConfigurable = TConfigurable> = <
   K extends keyof ExtractConfig<PARENT>,
 >(
   key: K,
 ) => CastConfigResult<ExtractConfig<PARENT>[K]>;
 
+/**
+ * Maps a `ServiceMap` to the resolved return types of each factory.
+ *
+ * @remarks
+ * Async factories are unwrapped — `Promise<T>` becomes `T`. This is the shape
+ * of the API object exposed on `TServiceParams` for a loaded module.
+ */
 export type GetApisResult<S extends ServiceMap> = {
   [K in keyof S]: ReturnType<S[K]> extends Promise<infer AsyncResult>
     ? AsyncResult
     : ReturnType<S[K]>;
 };
 
+/** @internal — extracts the config block from a library or application definition. */
 type ExtractConfig<T> =
   T extends LibraryDefinition<ServiceMap, infer C>
     ? C
@@ -72,23 +148,44 @@ type ExtractConfig<T> =
       ? C
       : never;
 
+// --- Scheduler types ----------------------------------------------------------
+
+/** A cron expression string or a `CronExpression` enum member. */
 export type Schedule = string | CronExpression;
+
+/** A runnable item that can be started and stopped. */
 export type ScheduleItem = {
   start: () => void;
   stop: () => void;
 };
+
+/** Base options required by every scheduler method. */
 export type SchedulerOptions = {
   exec: () => TBlackHole;
 };
 
 // #MARK: TScheduler
 /**
+ * General code scheduling functions.
+ *
+ * @remarks
+ * Injected as `scheduler` into every `TServiceParams`. The scheduler is
+ * lifecycle-aware — scheduled callbacks do not begin firing until the
+ * `onReady` lifecycle stage. Each method returns a `RemoveCallback` so
+ * temporary schedules can be torn down without waiting for full shutdown.
+ *
  * General code scheduling functions
  *
  * Each method returns a stop function, for temporary scheduling items
  */
 export type TScheduler = {
   /**
+   * Run code on a cron schedule.
+   *
+   * @remarks
+   * Accepts a single schedule string or an array of schedules to fire `exec`
+   * on multiple cron patterns simultaneously.
+   *
    * Run code on a cron schedule
    */
   cron: (
@@ -97,6 +194,12 @@ export type TScheduler = {
     },
   ) => RemoveCallback;
   /**
+   * Run code at a dynamically computed time each period.
+   *
+   * @remarks
+   * Calls `next` at startup and again after each `reset` schedule fires.
+   * `next` returns the absolute `Dayjs` of the next desired execution.
+   *
    * Run code at a different time every {period}
    *
    * Calls `next` at start, and as determined by `reset`.
@@ -110,6 +213,8 @@ export type TScheduler = {
     },
   ) => RemoveCallback;
   /**
+   * Lifecycle-aware `setInterval` replacement.
+   *
    * Same as setInterval but:
    *
    * - handles shutdown events properly
@@ -117,6 +222,8 @@ export type TScheduler = {
    */
   setInterval: (callback: () => TBlackHole, target: TOffset) => RemoveCallback;
   /**
+   * Lifecycle-aware `setTimeout` replacement.
+   *
    * Same as setTimeout but:
    *
    * - handles shutdown events properly
@@ -125,10 +232,31 @@ export type TScheduler = {
   setTimeout: (callback: () => TBlackHole, target: TOffset) => RemoveCallback;
 };
 
+// --- Module registry ----------------------------------------------------------
+
+/**
+ * Registry of all loaded module definitions.
+ *
+ * @remarks
+ * Downstream libraries extend this interface via declaration merging so that
+ * `TServiceParams` can expose their APIs under the correct key. The
+ * `boilerplate` entry is always present; every other entry is added by a
+ * library's declaration merge.
+ *
+ * @example Declaration merge in a library
+ * ```typescript
+ * declare module "@digital-alchemy/core" {
+ *   export interface LoadedModules {
+ *     my_lib: typeof MY_LIB;
+ *   }
+ * }
+ * ```
+ */
 export interface LoadedModules {
   boilerplate: typeof LIB_BOILERPLATE;
 }
 
+/** @internal — maps a config definition type to its concrete injected value. */
 type CastConfigResult<T extends AnyConfig> =
   T extends StringConfig<infer STRING>
     ? STRING
@@ -142,12 +270,30 @@ type CastConfigResult<T extends AnyConfig> =
             ? VALUE
             : never;
 
+/**
+ * The fully-typed config object injected as `config` into `TServiceParams`.
+ *
+ * @remarks
+ * Shaped as `{ [ModuleName]: { [ConfigKey]: ResolvedType } }`. Populated at
+ * bootstrap time by the configuration service and kept in sync via the
+ * `configSources` loaders.
+ */
 export type TInjectedConfig = {
   [ModuleName in keyof ModuleConfigs]: ConfigTypes<ModuleConfigs[ModuleName]>;
 };
 
 // #region Special
 // SEE DOCS http://docs.digital-alchemy.app/docs/core/declaration-merging
+
+/**
+ * Per-request data that can be attached to a log entry via ALS.
+ *
+ * @remarks
+ * Extend this interface via declaration merging to attach application-specific
+ * fields to every log line emitted within an ALS context.
+ *
+ * SEE DOCS http://docs.digital-alchemy.app/docs/core/declaration-merging
+ */
 export interface AsyncLogData {
   /**
    * return ms since entry, precision is on you
@@ -159,11 +305,26 @@ export interface AsyncLogData {
   logger?: GetLogger;
 }
 
+/**
+ * Shape of the data stored inside the `AsyncLocalStorage` instance managed by
+ * the ALS service.
+ *
+ * @remarks
+ * Extend via declaration merging to carry additional request-scoped fields
+ * alongside `logs`.
+ */
 export interface AsyncLocalData {
   logs: AsyncLogData;
 }
 // #endregion
 
+/**
+ * Public API of the ALS service as injected into `TServiceParams`.
+ *
+ * @remarks
+ * Wraps `AsyncLocalStorage<AsyncLocalData>` with helpers for entering a
+ * context, reading the store, and merging per-request log data.
+ */
 export type AlsExtension = {
   asyncStorage: () => AsyncLocalStorage<AsyncLocalData>;
   getStore: () => AsyncLocalData;
@@ -172,9 +333,43 @@ export type AlsExtension = {
   getLogData: () => AsyncLogData;
 };
 
+/** A function that returns additional data to merge into ALS log context. */
 export type AlsHook = () => object;
 
 // #MARK: TServiceParams
+/**
+ * The single parameter received by every service factory in the DI graph.
+ *
+ * @remarks
+ * `TServiceParams` is the core contract of `@digital-alchemy/core`. There is
+ * no class hierarchy, no decorators, no reflection — services are plain
+ * functions that destructure the params they need:
+ *
+ * ```typescript
+ * export function MyService({ logger, lifecycle, config }: TServiceParams) {
+ *   lifecycle.onReady(() => logger.info("ready"));
+ * }
+ * ```
+ *
+ * **Well-known injections:**
+ * - `als` — `AsyncLocalStorage` wrapper for per-request context
+ * - `context` — branded string describing this service's wiring path
+ * - `event` — application-global `EventEmitter`
+ * - `internal` — utility methods and boot-state introspection
+ * - `lifecycle` — hooks into the seven boot/shutdown stages
+ * - `logger` — context-aware logger bound to this service
+ * - `scheduler` — cron/interval/sliding scheduling; respects lifecycle
+ * - `config` — typed config object; safe to read after `onPostConfig`
+ * - `params` — self-reference, useful when passing the full block deeper
+ *
+ * **Module APIs** are added as additional properties via declaration merging on
+ * {@link LoadedModules}. Each loaded library exposes its return value under the
+ * library's declared name.
+ *
+ * **Note:** `TServiceParams` lives in `helpers/wiring.mts`, not in
+ * `services/wiring.service.mts`. The split breaks a circular module reference
+ * that would form if types and the runtime bootstrap lived together.
+ */
 export type TServiceParams = {
   /**
    * hooks for AsyncLocalStorage
@@ -225,10 +420,17 @@ export type TServiceParams = {
   [K in ExternalLoadedModules]: GetApis<LoadedModules[K]>;
 };
 
+/** Names of all modules registered in `LoadedModules`. */
 export type LoadedModuleNames = Extract<keyof LoadedModules, string>;
 
+/** `LoadedModuleNames` minus `"boilerplate"` — the user-land module names. */
 type ExternalLoadedModules = Exclude<LoadedModuleNames, "boilerplate">;
 
+/**
+ * Maps each loaded module name to its declared configuration block.
+ *
+ * @internal
+ */
 type ModuleConfigs = {
   [K in LoadedModuleNames]: LoadedModules[K] extends LibraryDefinition<ServiceMap, infer Config>
     ? Config
@@ -237,11 +439,22 @@ type ModuleConfigs = {
       : never;
 };
 
-// Now, map these configurations to their respective types using CastConfigResult for each property in the configs
+/**
+ * Resolves each key of a config block to its concrete injected type.
+ *
+ * Now, map these configurations to their respective types using CastConfigResult for each property in the configs
+ */
 export type ConfigTypes<Config> = {
   [Key in keyof Config]: Config[Key] extends AnyConfig ? CastConfigResult<Config[Key]> : never;
 };
 
+/**
+ * Maps each loaded module name to its flattened `"module.service"` strings.
+ *
+ * @remarks
+ * Used to build the `levelOverrides` key set in `LoggerOptions` so callers can
+ * address per-service log levels with full type safety.
+ */
 export type ServiceNames<
   T extends Extract<LoadedModuleNames, string> = Extract<LoadedModuleNames, string>,
 > = {
@@ -252,6 +465,13 @@ export type ServiceNames<
       : never;
 };
 
+/**
+ * Union of all `"module.service"` strings across every loaded module.
+ *
+ * @remarks
+ * Flattened variant of {@link ServiceNames} — the distributed union rather
+ * than the mapped object form.
+ */
 export type FlatServiceNames<
   T extends Extract<LoadedModuleNames, string> = Extract<LoadedModuleNames, string>,
 > = {
@@ -262,6 +482,12 @@ export type FlatServiceNames<
       : never;
 }[T];
 
+/**
+ * Extracts the resolved API object type for a loaded module definition.
+ *
+ * @remarks
+ * Used internally to type the per-module properties on `TServiceParams`.
+ */
 export type GetApis<T> =
   T extends LibraryDefinition<infer S, OptionalModuleConfiguration>
     ? GetApisResult<S>
@@ -284,16 +510,44 @@ export type GetApis<T> =
 //    */
 //   priority?: Extract<keyof S, string>[];
 // };
+
+/**
+ * A function that accepts a service name and returns the resolved API for that
+ * service, handling async factories transparently.
+ *
+ * @internal
+ */
 export type Loader<PARENT extends TConfigurable> = <K extends keyof PARENT["services"]>(
   serviceName: K,
 ) => ReturnType<PARENT["services"][K]> extends Promise<infer AsyncResult>
   ? AsyncResult
   : ReturnType<PARENT["services"][K]>;
 
+/**
+ * The function signature every service factory must satisfy.
+ *
+ * @remarks
+ * A service receives `TServiceParams` and returns either a value or a
+ * `Promise` of a value. The wiring engine awaits async factories before
+ * exposing the result to other services.
+ */
 export type ServiceFunction<R = unknown> = (params: TServiceParams) => R | Promise<R>;
+
+/** A record of service-name → service factory. */
 export type ServiceMap = Record<string, ServiceFunction>;
 
+// --- LibraryConfigurationOptions ----------------------------------------------
+
 // #MARK: LibraryConfigurationOptions
+/**
+ * Shape of the options object passed to `CreateLibrary`.
+ *
+ * @remarks
+ * `name` must match the key declared in `LoadedModules`. `depends` lists
+ * libraries that must be wired before this one; `optionalDepends` lists
+ * libraries that should be wired first *if* they are present in the
+ * application but do not cause a boot failure when absent.
+ */
 export interface LibraryConfigurationOptions<
   S extends ServiceMap,
   C extends OptionalModuleConfiguration,
@@ -324,11 +578,31 @@ export interface LibraryConfigurationOptions<
 }
 
 // #MARK: PartialConfiguration
+/**
+ * Partial snapshot of the full application configuration hierarchy.
+ *
+ * @remarks
+ * Used by `BootstrapOptions.configuration` to supply override values before
+ * env/argv/file loaders run, and by the `merge` method on
+ * `DigitalAlchemyConfiguration`.
+ */
 export type PartialConfiguration = Partial<{
   [ModuleName in keyof ModuleConfigs]: Partial<ConfigTypes<ModuleConfigs[ModuleName]>>;
 }>;
 
 // #MARK: BootstrapOptions
+/**
+ * Options passed to `ApplicationDefinition.bootstrap()` to customise the boot
+ * sequence.
+ *
+ * @remarks
+ * Most fields have safe defaults and are optional. The most commonly used are:
+ * - `configuration` — seed values applied before loaders run
+ * - `appendLibrary` / `appendService` — inject test doubles without modifying
+ *   the application definition
+ * - `configSources` — opt individual loader channels in/out
+ * - `loggerOptions` — tune the built-in logger's output format
+ */
 export type BootstrapOptions = {
   /**
    * An extra library to load after the application is constructed.
@@ -395,6 +669,14 @@ export type BootstrapOptions = {
 };
 
 // #MARK: LoggerOptions
+/**
+ * Fine-grained controls for the built-in chalk/stdout logger.
+ *
+ * @remarks
+ * Passed as `loggerOptions` inside `BootstrapOptions`. Overrides here only
+ * affect the built-in logger; they are ignored when `customLogger` is
+ * provided.
+ */
 export type LoggerOptions = {
   /**
    * Generic data to include as data payload for all logs
@@ -452,8 +734,29 @@ export type LoggerOptions = {
   stdOut?: boolean;
 };
 
+// --- Wiring boundary symbols --------------------------------------------------
+
+/**
+ * Symbol used as the key for the `[WIRE_PROJECT]` method on library and
+ * application definitions.
+ *
+ * @remarks
+ * This symbol is the wiring boundary between a module definition and the
+ * bootstrap engine. `wiring.service.mts` calls `[WIRE_PROJECT]` on each
+ * module to initialise its lifecycle, load its configuration, and wire each
+ * service in priority order. Do not call `[WIRE_PROJECT]` outside of the
+ * bootstrap process.
+ *
+ * @internal
+ */
 export const WIRE_PROJECT = Symbol.for("wire-project");
 
+/**
+ * Internal wiring method present on every `LibraryDefinition` and
+ * `ApplicationDefinition`.
+ *
+ * @internal
+ */
 type Wire = {
   /**
    * Internal method used in bootstrapping, do not call elsewhere
@@ -474,6 +777,15 @@ type Wire = {
 };
 
 // #MARK: LibraryDefinition
+/**
+ * A fully-constructed library module, ready to be listed in
+ * `ApplicationConfigurationOptions.libraries`.
+ *
+ * @remarks
+ * Created by `CreateLibrary`. The `[WIRE_PROJECT]` symbol key is the bootstrap
+ * engine's entry point into this module; every other field is readable for
+ * introspection but should not be mutated after construction.
+ */
 export type LibraryDefinition<
   S extends ServiceMap,
   C extends OptionalModuleConfiguration,
@@ -483,6 +795,14 @@ export type LibraryDefinition<
   };
 
 // #MARK: ApplicationDefinition
+/**
+ * A fully-constructed application module, ready to be bootstrapped.
+ *
+ * @remarks
+ * Created by `CreateApplication` in `services/wiring.service.mts`. Extends the
+ * library configuration shape with the `bootstrap` and `teardown` methods, a
+ * `booted` flag, and a `logger` pre-bound to the application context.
+ */
 export type ApplicationDefinition<
   S extends ServiceMap,
   C extends OptionalModuleConfiguration,
@@ -494,13 +814,34 @@ export type ApplicationDefinition<
     bootstrap: (options?: BootstrapOptions) => Promise<TServiceParams>;
     teardown: () => Promise<void>;
   };
+
+/** Convenience alias for a library definition with unknown service/config types. */
 export type TLibrary = LibraryDefinition<ServiceMap, OptionalModuleConfiguration>;
 
 // #MARK: buildSortOrder
+/**
+ * Topologically sort the libraries declared by an application so that each
+ * library's dependencies are wired before it.
+ *
+ * @remarks
+ * Uses a simple iterative approach: on each pass, pick the first library whose
+ * required dependencies have all already been placed in `out`, then remove it
+ * from the working set. Optional dependencies that are not present in the
+ * application's library list are skipped rather than causing a failure.
+ *
+ * Version mismatches (same name, different object reference) emit a warning
+ * but do not block boot — the application-declared version wins.
+ *
+ * @throws {BootstrapException} `MISSING_DEPENDENCY` when a required dependency
+ * is not listed in the application's `libraries` array.
+ * @throws {BootstrapException} `BAD_SORT` when no progress can be made —
+ * usually indicates a circular dependency.
+ */
 export function buildSortOrder<S extends ServiceMap, C extends OptionalModuleConfiguration>(
   app: ApplicationDefinition<S, C>,
   logger: GetLogger,
 ) {
+  // fast path — nothing to sort when no libraries are declared
   if (is.empty(app.libraries)) {
     return [];
   }
@@ -554,6 +895,7 @@ export function buildSortOrder<S extends ServiceMap, C extends OptionalModuleCon
           app.libraries.some(index => i.name === index.name),
         ) ?? []),
       ];
+      // a library with no remaining unsatisfied dependencies can go next
       if (is.empty(depends)) {
         return true;
       }
@@ -569,10 +911,42 @@ export function buildSortOrder<S extends ServiceMap, C extends OptionalModuleCon
   return out;
 }
 
+/**
+ * Cast a plain string to the branded `TContext` type.
+ *
+ * @remarks
+ * Used at the wiring boundary to produce context strings without importing the
+ * `TContext` brand into every caller. Prefer descriptive names like
+ * `"boilerplate:wiring"` over opaque identifiers so logs are readable.
+ *
+ * @internal
+ */
 export const COERCE_CONTEXT = (context: string): TContext => context as TContext;
+
+/**
+ * Fixed context string used for all errors and log messages emitted during the
+ * wiring phase itself.
+ *
+ * @internal
+ */
 export const WIRING_CONTEXT = COERCE_CONTEXT("boilerplate:wiring");
 
 // #MARK: validateLibrary
+/**
+ * Assert that a library name and service map meet the minimum requirements to
+ * be wired.
+ *
+ * @remarks
+ * Called by `CreateLibrary` before any other work. Throws immediately if the
+ * name is empty or if any entry in `serviceList` is not a function, so
+ * misconfiguration surfaces at library-construction time rather than at wire
+ * time.
+ *
+ * @throws {BootstrapException} `MISSING_LIBRARY_NAME` when `project` is empty.
+ * @throws {BootstrapException} `INVALID_SERVICE_DEFINITION` when any service is not a function.
+ *
+ * @internal
+ */
 export function validateLibrary<S extends ServiceMap>(
   project: string,
   serviceList: S,
@@ -599,10 +973,23 @@ export function validateLibrary<S extends ServiceMap>(
 }
 
 // #MARK: wireOrder
+/**
+ * Produce a wiring order for a service list, hoisting `priority` items to the
+ * front and appending the remainder in their original order.
+ *
+ * @remarks
+ * Validates that `priority` contains no duplicates before merging, since a
+ * service wired twice would produce subtle bugs that are hard to diagnose at
+ * runtime.
+ *
+ * @throws {BootstrapException} `DOUBLE_PRIORITY` when `priority` contains
+ * duplicate service names.
+ */
 export function wireOrder<T extends string>(priority: T[], list: T[]): T[] {
   const out = [...(priority || [])];
   if (!is.empty(priority)) {
     const check = is.unique(priority);
+    // duplicate entries in priorityInit would wire the same service twice
     if (check.length !== out.length) {
       throw new BootstrapException(
         WIRING_CONTEXT,
@@ -616,6 +1003,27 @@ export function wireOrder<T extends string>(priority: T[], list: T[]): T[] {
 }
 
 // #MARK: CreateLibrary
+/**
+ * Construct a `LibraryDefinition` from a configuration options object.
+ *
+ * @remarks
+ * `CreateLibrary` is the public factory for all non-application modules. It
+ * validates the name and service map, then builds the `[WIRE_PROJECT]`
+ * implementation that the bootstrap engine calls to wire each service in order.
+ *
+ * **Lifecycle hook timing.** Services should attach all lifecycle hooks at the
+ * top level of their factory function. Hooks attached after the
+ * `[WIRE_PROJECT]` call completes will be silently lost (worst case) or cause
+ * a fatal error (best case).
+ *
+ * **Priority init.** `priorityInit` services are wired before all others in
+ * declaration order. The remaining services wire in no guaranteed order.
+ *
+ * @throws {BootstrapException} `MISSING_LIBRARY_NAME` — via `validateLibrary`.
+ * @throws {BootstrapException} `INVALID_SERVICE_DEFINITION` — via `validateLibrary`.
+ * @throws {BootstrapException} `MISSING_PRIORITY_SERVICE` when a name listed in
+ * `priorityInit` does not correspond to a service in the `services` map.
+ */
 export function CreateLibrary<S extends ServiceMap, C extends OptionalModuleConfiguration>({
   name: libraryName,
   configuration = {} as C,
@@ -632,6 +1040,7 @@ export function CreateLibrary<S extends ServiceMap, C extends OptionalModuleConf
   if (!is.empty(priorityInit)) {
     priorityInit.forEach(name => {
       if (!is.function(services[name])) {
+        // fail fast at library-construction time; catching this at wire time is much harder to debug
         throw new BootstrapException(
           WIRING_CONTEXT,
           "MISSING_PRIORITY_SERVICE",

--- a/src/services/als.service.mts
+++ b/src/services/als.service.mts
@@ -2,16 +2,65 @@ import { AsyncLocalStorage } from "node:async_hooks";
 
 import type { AlsExtension, AsyncLocalData, AsyncLogData, TBlackHole } from "../index.mts";
 
+/**
+ * AsyncLocalStorage wrapper for request-scoped context propagation.
+ *
+ * @remarks
+ * Creates and owns a single AsyncLocalStorage instance that holds
+ * request-scoped data across async boundaries. Provides methods to enter
+ * context, retrieve store, and run callbacks within a specific data context.
+ * The logger uses this to merge per-request fields into every log line
+ * without explicit parameter passing through the call chain.
+ */
 export function ALS(): AlsExtension {
   const storage = new AsyncLocalStorage<AsyncLocalData>();
   return {
+    /**
+     * Retrieve the internal AsyncLocalStorage instance.
+     */
     asyncStorage: () => storage,
+    /**
+     * Enter context with data; data persists for synchronously-executed callbacks.
+     *
+     * @remarks
+     * Sets the async local context to the provided data object. All code running
+     * on the same async task will see this data when calling `getStore()`.
+     * Unlike `run()`, this does not execute a callback; the context persists
+     * until changed by another `enterWith()` or cleared by the async context.
+     */
     enterWith(data) {
+      // establish context for the current async task
       storage.enterWith(data);
     },
+    /**
+     * Extract log-scoped fields from current context.
+     *
+     * @remarks
+     * Retrieves the `logs` sub-object from the async local store, defaulting to
+     * an empty object if no context is set. Used by logger to inject context
+     * fields into every log entry automatically without requiring per-call passing.
+     */
     getLogData: () => storage.getStore()?.logs ?? ({} as AsyncLogData),
+    /**
+     * Retrieve the full async local store.
+     *
+     * @remarks
+     * Returns the complete data object set by `enterWith()` or `run()`, or
+     * undefined if no context is active. The returned object is read-only to
+     * callers; mutation must go through `enterWith()` or `run()`.
+     */
     getStore: () => storage.getStore(),
+    /**
+     * Execute a callback within a specific data context.
+     *
+     * @remarks
+     * Runs the callback with the provided data visible to `getStore()` for the
+     * duration of the callback and all async operations it spawns. The context
+     * is automatically cleared when the callback completes (or earlier if an
+     * async boundary is crossed outside the callback).
+     */
     run(data: AsyncLocalData, callback: () => TBlackHole) {
+      // wrap the callback to establish and maintain context for its duration
       storage.run(data, () => {
         callback();
       });

--- a/src/services/configuration.service.mts
+++ b/src/services/configuration.service.mts
@@ -31,6 +31,28 @@ export type ConfigManager = ReturnType<typeof Configuration>;
 
 const DECIMALS = 2;
 
+/**
+ * Central configuration state manager for the entire application.
+ *
+ * @remarks
+ * Owns two things: the `configuration` plain-object store (all live config
+ * values keyed by `module.key`) and the `configDefinitions` map (the schema
+ * metadata declared by each library/application via `CreateLibrary`).
+ *
+ * Exposed to other services through the `config` proxy injected into every
+ * `TServiceParams`. The proxy makes `config.boilerplate.LOG_LEVEL` feel like
+ * a plain property read but actually calls `object.get(configuration, path)`
+ * on each access so reads always reflect the current value.
+ *
+ * The initialization sequence (`INITIALIZE`) is called once during bootstrap,
+ * between `PreInit` and `PostConfig`, and runs all registered config loaders
+ * in priority order: env/argv first, then file (if enabled), then any
+ * custom loaders registered via `registerLoader`.
+ *
+ * Config values can be updated at runtime via `setConfig` or `merge`; any
+ * update emits `EVENT_CONFIGURATION_UPDATED` so downstream code (e.g. the
+ * logger's level filter) can react via `onUpdate` subscriptions.
+ */
 export function Configuration({
   context,
   event,
@@ -39,7 +61,8 @@ export function Configuration({
 }: TServiceParams): DigitalAlchemyConfiguration {
   const { is } = internal.utils;
 
-  // modern problems require modern solutions
+  // logger is not yet available at construction time (chicken-and-egg with
+  // boilerplate wiring order), so we grab it on the first lifecycle hook
   let logger: ILogger;
   lifecycle.onPreInit(() => (logger = internal.boilerplate.logger.context(context)));
   const configDefinitions: KnownConfigs = new Map();
@@ -47,10 +70,14 @@ export function Configuration({
   const loaded = new Set<string>();
   const loaders = new Map<DataTypes, ConfigLoader>([]);
 
-  // #MARK:
+  // #MARK: configValueProxy
+  // proxyData exists only to satisfy Proxy's ownKeys/has contract which requires
+  // the target object to have enumerable keys for spread operations to work;
+  // actual reads are always routed through object.get(configuration, path)
   const proxyData = {} as Record<string, object>;
   const configValueProxy = new Proxy(proxyData as TInjectedConfig, {
     get(_, project: keyof TInjectedConfig) {
+      // always read live from configuration so callers see post-load values
       return { ...internal.utils.object.get(configuration, project) };
     },
     has(_, key: keyof TInjectedConfig) {
@@ -62,24 +89,40 @@ export function Configuration({
       return Object.keys(configuration);
     },
     set() {
+      // configuration is read-only via the proxy; use setConfig() to mutate
       return false;
     },
   });
 
   // #MARK: setConfig
+  /**
+   * Set a single config property and emit an update event.
+   *
+   * @remarks
+   * Writes directly into the live `configuration` store and fires
+   * `EVENT_CONFIGURATION_UPDATED` so any `onUpdate` listeners react
+   * immediately. Prefer `merge` for bulk updates.
+   */
   function setConfig<
     Project extends keyof TInjectedConfig,
     Property extends keyof TInjectedConfig[Project],
   >(project: Project, property: Property, value: TInjectedConfig[Project][Property]): void {
+    // logger may not be available if called during early wiring (before onPreInit)
+    logger?.trace({ name: setConfig, property: String(property), project }, "setting config");
     internal.utils.object.set(configuration, [project, property].join("."), value);
-    // in case anyone needs a hook
+    // notify any onUpdate listeners so they can react to the changed value
     event.emit(EVENT_CONFIGURATION_UPDATED, project, property);
+    logger?.debug({ name: setConfig, property: String(property), project }, "config set");
   }
 
   // #MARK: validateConfig
+  /**
+   * Assert that every `required: true` config property has been given a value.
+   *
+   * @throws {BootstrapException} `REQUIRED_CONFIGURATION_MISSING` if any
+   *   required property is still `undefined` after all loaders have run.
+   */
   function validateConfig() {
-    // * validate
-    // - ensure all required properties have been defined
     configDefinitions.forEach((definitions, project) => {
       Object.keys(definitions).forEach(key => {
         const config = [project, key].join(".");
@@ -87,7 +130,8 @@ export function Configuration({
           definitions[key].required &&
           is.undefined(internal.utils.object.get(configuration, config))
         ) {
-          // ruh roh
+          // required property was never populated by any loader or bootstrap config;
+          // treat as a fatal wiring error so the app does not silently start broken
           throw new BootstrapException(
             context,
             "REQUIRED_CONFIGURATION_MISSING",
@@ -99,13 +143,32 @@ export function Configuration({
   }
 
   // #MARK: registerLoader
+  /**
+   * Register a custom config loader for a given `DataTypes` key.
+   *
+   * @remarks
+   * Loaders run during `initialize`, after the built-in env/file loaders,
+   * in the order they were registered. Only one loader per `DataTypes` key
+   * is retained — registering twice replaces the first.
+   */
   function registerLoader(loader: ConfigLoader, name: DataTypes) {
+    // logger may not be available if called during early wiring (before onPreInit)
+    logger?.trace({ name: registerLoader, type: name }, "registering config loader");
     loaders.set(name, loader);
   }
 
   // #MARK: mergeConfig
+  /**
+   * Merge raw loader output into the live config store, respecting source restrictions.
+   *
+   * @remarks
+   * Each config property can declare a `source` allow-list (e.g. `["argv"]`).
+   * Properties whose source list does not include any of the `type` values
+   * passed here are silently skipped, preventing e.g. a file loader from
+   * overwriting an argv-only value.
+   */
   function mergeConfig(data: Partial<AbstractConfig>, type: DataTypes[]) {
-    // * prevents loaders from setting properties that they aren't supposed to
+    // skip properties whose declared source list excludes every type in this batch
     configDefinitions.forEach((project, name) => {
       const keys = Object.keys(project) as (keyof typeof project)[];
       keys.forEach(key => {
@@ -126,11 +189,23 @@ export function Configuration({
   }
 
   // #MARK: initialize
+  /**
+   * Run all config loaders and validate required properties.
+   *
+   * @remarks
+   * Called exactly once by `wiring.service.mts` between `PreInit` and
+   * `PostConfig`. Order: env/argv → file (if `configSources.file` is truthy)
+   * → any custom loaders registered via `registerLoader`. Returns a formatted
+   * duration string that is included in bootstrap timing stats.
+   *
+   * @internal
+   */
   async function initialize<S extends ServiceMap, C extends OptionalModuleConfiguration>(
     application: ApplicationDefinition<S, C>,
   ): Promise<string> {
     const start = performance.now();
     const configTimings: Record<string, string> = {};
+    logger.trace({ name: initialize }, "loading configuration");
 
     // ConfigLoaderEnvironment handles both env and argv and tracks timings internally
     mergeConfig(
@@ -145,7 +220,9 @@ export function Configuration({
     );
 
     const canFile = internal.boot.options?.configSources?.file ?? false;
+    // file loading is opt-in; default-off avoids unexpected file reads in tests
     if (canFile) {
+      logger.trace({ name: initialize }, "loading file config");
       const fileStart = performance.now();
       mergeConfig(
         await configLoaderFile({
@@ -158,12 +235,15 @@ export function Configuration({
       );
       configTimings.file = `${(performance.now() - fileStart).toFixed(DECIMALS)}ms`;
     }
-    // * load!
+    // run any additional loaders registered by library code
     const configSources = internal.boot.options.configSources ?? {};
     await eachSeries([...loaders.entries()], async ([type, loader]) => {
+      // configSources[type] === false is an explicit opt-out; absence defaults to enabled
       if (configSources[type] === false) {
+        logger.trace({ name: initialize, type }, "loader disabled via configSources, skipping");
         return;
       }
+      logger.trace({ name: initialize, type }, "running loader");
       const loaderStart = performance.now();
       mergeConfig(await loader({ application, configs: configDefinitions, internal, logger }), [
         type,
@@ -175,16 +255,39 @@ export function Configuration({
 
     internal.boot.configTimings = configTimings;
 
-    return `${(performance.now() - start).toFixed(DECIMALS)}ms`;
+    const total = `${(performance.now() - start).toFixed(DECIMALS)}ms`;
+    logger.debug({ name: initialize, timings: configTimings, total }, "configuration loaded");
+    return total;
   }
 
   // #MARK: merge
+  /**
+   * Deep-merge a partial configuration object into the live store.
+   *
+   * @remarks
+   * Does not emit `EVENT_CONFIGURATION_UPDATED`; intended for bulk
+   * pre-boot merges (e.g. bootstrap `options.configuration`).
+   * Use `setConfig` for individual runtime updates that need listeners notified.
+   */
   function merge(merge: Partial<PartialConfiguration>) {
     return deepExtend(configuration, merge);
   }
 
   // #MARK: loadProject
+  /**
+   * Register a module's config schema and populate default values.
+   *
+   * @remarks
+   * Called once per library/application during wiring. Idempotent — a second
+   * call for the same library name is silently ignored to prevent re-initialisation
+   * during test re-runs. After registering defaults, any values already present
+   * in `options.configuration` for this project are applied immediately so they
+   * take effect before any loader runs.
+   *
+   * @internal
+   */
   function loadProject(library: string, definitions: CodeConfigDefinition) {
+    // guard against double-registration (e.g. test re-runs, appendLibrary replacing)
     if (loaded.has(library)) {
       return;
     }
@@ -194,6 +297,8 @@ export function Configuration({
       internal.utils.object.set(configuration, [library, key].join("."), definitions[key].default);
     });
     configDefinitions.set(library, definitions);
+    // apply any values that were baked into bootstrap options for this project;
+    // these take priority over schema defaults but lose to loader-sourced values
     const bootConfig = internal.boot.options?.configuration ?? {};
     if (library in bootConfig) {
       const project = library as keyof typeof bootConfig;
@@ -209,11 +314,21 @@ export function Configuration({
   }
 
   // #MARK: onUpdate
+  /**
+   * Subscribe to configuration change events.
+   *
+   * @remarks
+   * When `project` and/or `property` are provided the callback is only
+   * invoked for changes to that specific path. Omitting both subscribes to
+   * all configuration changes. The callback receives `(project, property)`
+   * matching the changed key.
+   */
   function onUpdate<
     Project extends keyof TInjectedConfig,
     Property extends Extract<keyof TInjectedConfig[Project], string>,
   >(callback: OnConfigUpdateCallback<Project, Property>, project?: Project, property?: Property) {
     event.on(EVENT_CONFIGURATION_UPDATED, (updatedProject, updatedProperty) => {
+      // filter to the specific project/property if the caller narrowed the subscription
       if (!is.empty(project) && project !== updatedProject) {
         return;
       }
@@ -240,21 +355,35 @@ export function Configuration({
     [LOAD_PROJECT]: loadProject,
 
     /**
-     * retrieve the metadata that was originally used to define the configs
+     * Retrieve the metadata that was originally used to define the configs.
      */
     getDefinitions: () => configDefinitions,
 
     /**
-     * take a configuration object, and deep merge values
+     * Deep-merge a partial configuration object into the live store.
      *
-     * intended for initial loading workflows
+     * @remarks
+     * Intended for initial loading workflows. Does not fire `EVENT_CONFIGURATION_UPDATED`.
      */
     merge,
 
+    /**
+     * Subscribe to configuration change events.
+     *
+     * @remarks
+     * Narrow to a specific project and/or property, or omit both to receive all updates.
+     */
     onUpdate,
 
+    /**
+     * Register a custom config loader for a given `DataTypes` key.
+     */
     registerLoader,
 
+    /**
+     * Set a single config property and notify all `onUpdate` subscribers.
+     */
     set: setConfig as TSetConfig,
   };
 }
+

--- a/src/services/configuration.service.mts
+++ b/src/services/configuration.service.mts
@@ -386,4 +386,3 @@ export function Configuration({
     set: setConfig as TSetConfig,
   };
 }
-

--- a/src/services/index.mts
+++ b/src/services/index.mts
@@ -1,3 +1,11 @@
+/**
+ * Service factories and utilities for @digital-alchemy/core.
+ *
+ * @remarks
+ * Exports all service-level APIs: lifecycle event registry, async local storage
+ * wrapper, type guards, configuration, logger, scheduler, wiring, and internal utilities.
+ * Each service is a factory function that receives TServiceParams and returns its API.
+ */
 export * from "./als.service.mts";
 export * from "./configuration.service.mts";
 export * from "./internal.service.mts";

--- a/src/services/internal.service.mts
+++ b/src/services/internal.service.mts
@@ -58,25 +58,41 @@ const formatter = new Intl.RelativeTimeFormat("en", {
 });
 
 // #MARK: misc
+/**
+ * Stateless utility bag attached to every `InternalDefinition` instance.
+ *
+ * @remarks
+ * Holds the global `EventEmitter`, the `is` type-guard singleton, and helpers
+ * for date math, object path operations, and string formatting.
+ * Constructed once per bootstrap cycle; replaced on teardown via a fresh
+ * `InternalDefinition`.
+ */
 export class InternalUtils {
   /**
-   * The global eventemitter. All of `@digital-alchemy` will be wired through this
+   * The global eventemitter. All of `@digital-alchemy` will be wired through this.
    *
-   * **NOTE:** bootstrapping process will initialize this at boot, and cleanup at teardown.
-   * Making listener changes should only be done from within the context of service functions
+   * @remarks
+   * Bootstrapping process will initialize this at boot and clean it up at
+   * teardown. Making listener changes should only be done from within the
+   * context of service functions.
    */
   public event: EventEmitter;
 
   /**
-   * reference to `is` instance that's importable from `core`
+   * Reference to the `is` type-guard singleton importable from `core`.
    */
   public is: IsIt;
 
   constructor() {
+    // unlimited listeners because every service may register lifecycle callbacks,
+    // and the default of 10 would fire spurious MaxListenersExceededWarnings
     this.event = new EventEmitter();
     this.event.setMaxListeners(NONE);
   }
 
+  /**
+   * Convert a `camelCase`, `snake_case`, or `kebab-case` string to `Title Case`.
+   */
   public titleCase(input: string): string {
     const matches = input.match(new RegExp("[a-z][A-Z]", "g"));
     if (matches) {
@@ -88,16 +104,32 @@ export class InternalUtils {
       .join(" ");
   }
 
+  /**
+   * Compute the target `Dayjs` moment when an offset will elapse.
+   */
   getIntervalTarget(offset: TOffset): Dayjs {
     const duration = toOffsetDuration(offset);
     const now = dayjs();
     return duration ? now.add(duration) : now;
   }
 
+  /**
+   * Resolve a `TOffset` value to milliseconds.
+   */
   getIntervalMs(offset: TOffset): number {
     return toOffsetMs(offset);
   }
 
+  /**
+   * Format the elapsed time between two dates as a human-readable relative string.
+   *
+   * @remarks
+   * Iterates unit buckets from largest (year) to smallest (second) and returns
+   * the first unit whose cutoff is exceeded. Falls back to "second" when the
+   * difference is less than one minute so there is always a non-empty result.
+   *
+   * @throws {Error} if either date argument cannot be parsed by `dayjs`.
+   */
   public relativeDate(pastDate: inputFormats, futureDate: inputFormats = new Date().toISOString()) {
     const past = dayjs(pastDate);
     if (!past.isValid()) {
@@ -124,8 +156,19 @@ export class InternalUtils {
   }
 
   // #region .object
+  /**
+   * Dot-path object utilities: `get`, `set`, `del`, and `deepExtend`.
+   *
+   * @remarks
+   * Used throughout core to read and write nested configuration paths like
+   * `"boilerplate.LOG_LEVEL"` without assuming the intermediate objects exist.
+   */
   public object = {
     deepExtend,
+    /**
+     * Delete the value at `path` within `object`. Silently no-ops if any
+     * intermediate key does not exist.
+     */
     del<T>(object: T, path: string): void {
       const keys = path.split(".");
       let current = object as unknown; // Starting with the object as an unknown type
@@ -154,6 +197,10 @@ export class InternalUtils {
         }
       }
     },
+    /**
+     * Read the value at `path` within `object`. Returns `undefined` if any
+     * intermediate key is missing.
+     */
     get<T, P extends string>(object: T, path: P): Get<T, P> {
       const keys = path.split(".");
       let current: unknown = object;
@@ -167,6 +214,16 @@ export class InternalUtils {
 
       return current as Get<T, P>;
     },
+    /**
+     * Write `value` at `path` within `object`, creating intermediate objects
+     * as needed.
+     *
+     * @remarks
+     * When `doNotReplace` is true the write is skipped if the key already
+     * has a value — useful for applying defaults without overwriting explicit config.
+     *
+     * @throws {Error} if an intermediate path segment resolves to a non-object.
+     */
     set<T>(object: T, path: string, value: unknown, doNotReplace: boolean = false): void {
       const keys = path.split(".");
       let current = object as unknown; // Starting with the object as an unknown type
@@ -213,77 +270,91 @@ type SafeExecOptions = {
 type Phase = "bootstrap" | "teardown" | "running";
 
 // #region Base definition
+/**
+ * Bootstrap-scoped state container passed as `internal` into every service.
+ *
+ * @remarks
+ * Created fresh on each `bootstrap()` call and torn down with the application.
+ * Holds the boot-time module registry (`loadedModules`, `moduleMappings`),
+ * the lifecycle event bus, references to boilerplate service APIs, and the
+ * `InternalUtils` helper bag.
+ *
+ * Downstream code should treat `internal` as read-only except for the
+ * documented mutation points (`safeExec`, `removeFn`, explicit setters on
+ * `boot.*`).
+ */
 export class InternalDefinition {
   /**
-   * Utility methods provided by boilerplate
+   * Utility methods provided by boilerplate.
    */
   public boilerplate: Pick<GetApis<typeof LIB_BOILERPLATE>, "configuration" | "logger">;
   /**
-   * alias for `internal.boilerplate.configuration`
+   * Alias for `internal.boilerplate.configuration`.
    */
   public config: GetApis<typeof LIB_BOILERPLATE>["configuration"];
   public boot: {
     /**
-     * Options that were passed into bootstrap
+     * Options that were passed into bootstrap.
      */
     options: BootstrapOptions;
 
     /**
-     * Application that was bootstrapped
+     * Application that was bootstrapped.
      */
     application: ApplicationDefinition<ServiceMap, OptionalModuleConfiguration>;
 
     /**
-     * Lifecycle events that have completed
+     * Lifecycle events that have completed.
      */
     completedLifecycleEvents: Set<LifecycleStages>;
 
     /**
-     * for internal operations
+     * Internal lifecycle event bus; services attach hooks via the injected `lifecycle` param.
      */
     lifecycle: ReturnType<typeof CreateLifecycle>;
 
     /**
-     * Roughly speaking, what's the application doing? Mostly useful for debugging
+     * Roughly speaking, what is the application doing? Mostly useful for debugging.
      */
     phase: Phase;
 
     /**
-     * association of projects to { service : Declaration Function }
+     * Association of project names to `{ service: DeclarationFunction }`.
      */
     moduleMappings: Map<string, TModuleMappings>;
 
     /**
-     * association of projects to { service : Initialized Service }
+     * Association of project names to `{ service: InitializedService }`.
      */
     loadedModules: Map<string, TResolvedModuleMappings>;
 
     /**
-     * simple list of modules that have their construction phase complete
+     * Simple list of modules that have their construction phase complete.
      */
     constructComplete: Set<string>;
     startup: Date;
     /**
-     * Service construction times in order
+     * Service construction times in order.
      */
     serviceConstructionTimes: Array<{ module: string; service: string; duration: string }>;
     /**
-     * Config loader execution times
+     * Config loader execution times.
      */
     configTimings?: Record<string, string>;
   };
   public utils = new InternalUtils();
 
   /**
+   * Wrap a remove callback so it can be called directly or via `{ remove }` destructuring.
    *
+   * @remarks
+   * Accommodates callers that prefer either:
    * ```typescript
-   * // Is it
    * const remove = doThing();
    * // or
    * const { remove } = doThing();
    * ```
-   *
-   * Now it's both! Inconsistency is the now supported
+   * Both styles are now supported; inconsistency between APIs is intentional.
    */
   public removeFn(remove: () => TBlackHole): RemoveCallback {
     const out = remove as RemoveCallback;
@@ -292,10 +363,21 @@ export class InternalDefinition {
   }
 
   // #MARK: safeExec
+  /**
+   * Execute a callback, swallowing and logging any thrown error.
+   *
+   * @remarks
+   * Used throughout scheduler and lifecycle code to ensure that a misbehaving
+   * user callback cannot crash the entire wiring engine. Errors are logged at
+   * `error` level with full context so they remain visible without being fatal.
+   * Returns `undefined` on any error path so callers can treat the return type
+   * as optional without extra null-checks.
+   */
   public async safeExec<T>(options: (() => TBlackHole) | SafeExecOptions): Promise<T> {
     const logger = this.boilerplate.logger.systemLogger;
     const context = is.function(options) ? undefined : options?.context;
     const exec = is.function(options) ? options : options?.exec;
+    // a non-function exec is a programming error, not a runtime error; log and bail
     if (!is.function(exec)) {
       logger.error({ context }, `received non-function callback to [safeExec]`);
       return undefined;

--- a/src/services/is.service.mts
+++ b/src/services/is.service.mts
@@ -19,37 +19,68 @@ type MaybeEmptyTypes =
 type MaybeFunction = (...parameters: unknown[]) => TBlackHole;
 
 /**
- * type testing and basic conversion tools
+ * Type guard and basic utility class for runtime type testing.
+ *
+ * @remarks
+ * Provides a unified API for type narrowing, equality, emptiness checks, and
+ * basic conversions. All methods are designed as type guards where applicable
+ * (e.g., `array()`, `string()` narrow their arguments) and simple predicates
+ * elsewhere (e.g., `even()`, `empty()`). The singleton `is` instance is
+ * imported directly in lifecycle and wiring services to avoid circular
+ * dependencies; everywhere else it is accessed via `internal.utils.is`.
  */
 export class IsIt {
-  public array(test: unknown): test is Array<unknown> {
+  /**
+   * Test whether a value is an array.
+   */
+  public array<T>(test: unknown): test is Array<T> {
     return Array.isArray(test);
   }
 
+  /**
+   * Test whether a value is a boolean.
+   */
   public boolean(test: unknown): test is boolean {
     return typeof test === "boolean";
   }
 
   /**
-   * The internals of this test may get more creative as context evolves
+   * Test whether a value is a valid context (branded string).
+   *
+   * @remarks
+   * The internals of this test may get more creative as context evolves;
+   * currently a simple string type guard.
    */
   public context(test: unknown): test is TContext {
     return typeof test === "string";
   }
 
   /**
-   * test is valid date
+   * Test whether a value is a valid Date object.
+   *
+   * @remarks
+   * Checks both that the value is a Date and that its time is a valid number;
+   * this filters out invalid Date instances like `new Date(NaN)`.
    */
   public date(test: unknown): test is Date {
     return types.isDate(test) && is.number(test.getTime());
   }
 
+  /**
+   * Test whether a value is a valid dayjs instance.
+   */
   public dayjs(test: unknown): test is Dayjs {
     return test instanceof dayjs && (test as Dayjs).isValid();
   }
 
+  /**
+   * Test whether a value is empty: undefined, zero-length, zero size, or empty object.
+   *
+   * @throws When the input type is not recognized (string, array, Map, Set, object, number, undefined).
+   */
   public empty(test: MaybeEmptyTypes): boolean {
     if (test === undefined) {
+      // undefined is always empty
       return true;
     }
     if (typeof test === "string" || Array.isArray(test)) {
@@ -59,6 +90,7 @@ export class IsIt {
       return test.size === EMPTY;
     }
     if (typeof test === "object") {
+      // walk the object to detect whether any own properties exist
       for (const key in test) {
         if (Object.prototype.hasOwnProperty.call(test, key)) {
           return false;
@@ -67,52 +99,83 @@ export class IsIt {
       return true;
     }
     if (typeof test === "number") {
+      // NaN is the only number that is empty
       return Number.isNaN(test);
     }
-    // Optional: Throw an error or return a default value for unsupported types
+    // unsupported type — reject rather than silently pass
     throw new Error("Unsupported type " + typeof test);
   }
 
   /**
    * #MARK: Deep equality test
    */
+  /**
+   * Test whether two values are deeply equal using strict comparison.
+   */
   public equal<T extends unknown>(a: T, b: T): boolean {
     return isDeepStrictEqual(a, b);
   }
 
+  /**
+   * Test whether a number is even.
+   */
   public even(test: number): boolean {
     return test % EVEN === EMPTY;
   }
 
+  /**
+   * Test whether a value is a function.
+   */
   public function<T extends MaybeFunction>(test: unknown): test is T {
     return typeof test === "function";
   }
 
+  /**
+   * Test whether a value is a valid number (not NaN).
+   */
   public number(test: unknown): test is number {
     return typeof test === "number" && !Number.isNaN(test);
   }
 
+  /**
+   * Test whether a value is a plain object (not an array or null).
+   */
   public object(test: unknown): test is object {
     return typeof test === "object" && test !== null && !Array.isArray(test);
   }
 
+  /**
+   * Return a random element from the provided list.
+   */
   public random<T>(list: T[]): T {
     // eslint-disable-next-line @typescript-eslint/no-magic-numbers
     return list[Math.floor(randomBytes(1)[0] % list.length)];
   }
 
+  /**
+   * Test whether a value is a string.
+   */
   public string(test: unknown): test is string {
     return typeof test === "string";
   }
 
+  /**
+   * Test whether a value is a symbol.
+   */
   public symbol(test: unknown): test is symbol {
     return typeof test === "symbol";
   }
 
+  /**
+   * Test whether a value is undefined.
+   */
   public undefined(test: unknown): test is undefined {
     return test === undefined;
   }
 
+  /**
+   * Return a new array containing unique items from the input (deduplication).
+   */
   public unique<T>(items: T[]): T[] {
     return [...new Set(items)];
   }

--- a/src/services/lifecycle.service.mts
+++ b/src/services/lifecycle.service.mts
@@ -9,33 +9,96 @@ type EventMapObject = {
 const PRE_CALLBACKS_START = 0;
 const DECIMALS = 2;
 
+/**
+ * Lifecycle event registry for per-bootstrap stage callbacks.
+ *
+ * @remarks
+ * Creates and owns a Map of lifecycle stage names to callback lists. Exposes
+ * seven hook attachment methods (`onPreInit`, `onPostConfig`, etc.) that queue
+ * callbacks for later execution. The returned `exec()` method is called by the
+ * wiring engine at each stage to fire callbacks in strict order: positive
+ * priorities (high to low), unprioritized (any order), negative priorities
+ * (high to low). Each stage is fired only once; subsequent attaches on a stage
+ * that has already executed fire the callback immediately.
+ */
 export function CreateLifecycle() {
   const events = new Map(
     LIFECYCLE_STAGES.map((event): [LifecycleStages, EventMapObject[]] => [event, []]),
   );
 
+  /**
+   * Attach a callback to a named lifecycle stage with optional priority.
+   *
+   * @remarks
+   * If the stage has not yet been stored in the map (already executed), the
+   * callback fires immediately unless it is a Shutdown stage (which are never
+   * re-fired after they have been executed).
+   */
   function attachEvent(callback: LifecycleCallback, name: LifecycleStages, priority?: number) {
     const stageList = events.get(name);
+    // stage already executed (not in the map) — fire immediately unless Shutdown
     if (!is.array(stageList)) {
       if (!name.includes("Shutdown")) {
         callback();
       }
       return;
     }
+    // stage is still pending; queue the callback with its priority
     stageList.push({ callback, priority });
   }
 
   return {
+    /**
+     * Event hook registry for all seven lifecycle stages.
+     */
     events: {
+      /**
+       * Pre-initialization hook; safe for initial state setup.
+       *
+       * @remarks
+       * Config is not yet loaded; do not read `config.*` at this stage.
+       */
       onBootstrap: (callback, priority) => attachEvent(callback, "Bootstrap", priority),
+      /**
+       * Post-config hook; all configuration is now available.
+       */
       onPostConfig: (callback, priority) => attachEvent(callback, "PostConfig", priority),
+      /**
+       * Pre-initialization hook; config and modules are loaded.
+       */
       onPreInit: (callback, priority) => attachEvent(callback, "PreInit", priority),
+      /**
+       * Pre-shutdown hook; graceful shutdown is beginning.
+       */
       onPreShutdown: (callback, priority) => attachEvent(callback, "PreShutdown", priority),
+      /**
+       * Ready hook; all services are wired and the app is fully running.
+       *
+       * @remarks
+       * This is the stage where schedulers, servers, and long-running tasks begin.
+       */
       onReady: (callback, priority) => attachEvent(callback, "Ready", priority),
+      /**
+       * Shutdown-complete hook; cleanup is done.
+       */
       onShutdownComplete: (callback, priority) =>
         attachEvent(callback, "ShutdownComplete", priority),
+      /**
+       * Shutdown-start hook; active connections are closing.
+       */
       onShutdownStart: (callback, priority) => attachEvent(callback, "ShutdownStart", priority),
     } satisfies TLifecycleBase as TLifecycleBase,
+    /**
+     * Execute all callbacks for a named lifecycle stage in strict order.
+     *
+     * @remarks
+     * Splits callbacks by priority: positive (high to low), unprioritized (any
+     * order), negative (high to low). Runs positive and negative series in order,
+     * unprioritized in parallel. Removes the stage from the map after execution
+     * so that late-attaching callbacks to an executed stage fire immediately.
+     *
+     * @returns Execution duration in milliseconds.
+     */
     async exec(stage: LifecycleStages): Promise<string> {
       const start = performance.now();
       const list = events.get(stage);
@@ -46,7 +109,7 @@ export function CreateLifecycle() {
         const positive = [] as EventMapObject[];
         const negative = [] as EventMapObject[];
 
-        // console.error("HIT 1");
+        // segregate sorted callbacks into positive and negative priority buckets
         sorted.forEach(i => {
           if (i.priority >= PRE_CALLBACKS_START) {
             positive.push(i);
@@ -55,21 +118,16 @@ export function CreateLifecycle() {
           negative.push(i);
         });
 
-        // * callbacks with a priority greater than 0
-        // high to low (1000 => 0)
+        // execute positive priorities in descending order (high to low)
         await eachSeries(
           positive.toSorted((a, b) => (a.priority < b.priority ? UP : DOWN)),
           async ({ callback }) => await callback(),
         );
-        // console.error("HIT 2");
 
-        // * callbacks without a priority
-        // any order
+        // execute unprioritized callbacks in parallel
         await each(quick, async ({ callback }) => await callback());
-        // console.error("HIT 3");
 
-        // * callbacks with a priority less than 0
-        // high to low (-1 => -1000)
+        // execute negative priorities in descending order (-1 to -1000)
         await eachSeries(
           negative.toSorted((a, b) => (a.priority < b.priority ? UP : DOWN)),
           async ({ callback }) => await callback(),

--- a/src/services/logger.service.mts
+++ b/src/services/logger.service.mts
@@ -41,6 +41,33 @@ const SYMBOL_START = 1;
 const SYMBOL_END = -1;
 const LEVEL_MAX = 7;
 
+/**
+ * Logger factory — chalk/stdout formatter, ALS integration, level filtering,
+ * multi-target fan-out, and the `context(ctx)` builder.
+ *
+ * @remarks
+ * Owns the module-level `logger` record that maps each log level to a
+ * formatting+routing function. That record is replaced wholesale when a
+ * `customLogger` is provided via bootstrap options.
+ *
+ * The `context(ctx)` method returns a `GetLogger` scoped to a specific
+ * `TContext` string. Each scoped logger evaluates `shouldILog[level]` on every
+ * call so level changes propagated via `EVENT_UPDATE_LOG_LEVELS` take effect
+ * immediately without any per-call config lookup.
+ *
+ * **Pretty format** applies chalk colorization and bracket/brace highlighting
+ * to messages up to `MAX_CUTOFF` characters. Turn it off (e.g. for Docker
+ * log aggregators) via `loggerOptions.pretty = false` in bootstrap options.
+ *
+ * **ALS integration** (`loggerOptions.als = true`) merges per-request data
+ * stored in `AsyncLocalStorage` into every log payload, and can substitute a
+ * thread-local child logger for the default stdout writer.
+ *
+ * **Extra targets** (`addTarget`) accept either a `LogStreamTarget` function
+ * (raw msg + payload) or any object that conforms to `GetLogger` (same level
+ * methods as the default logger). All registered targets receive every log
+ * regardless of the `stdOut` setting.
+ */
 export async function Logger({
   lifecycle,
   config,
@@ -63,11 +90,19 @@ export async function Logger({
   const YELLOW_DASH = chalk.yellowBright(frontDash);
   const BLUE_TICK = chalk.blue(`>`);
   let prettyFormat = is.boolean(loggerOptions.pretty) ? loggerOptions.pretty : true;
-  // make sure the object formatter respects the pretty option
-  // if this is enabled while outputting to docker logs, the output becomes much harder to read
+  // keep inspect colorization in sync with the pretty flag so object dumps
+  // look consistent whether output goes to a TTY or a log aggregator
   inspect.defaultOptions.colors = prettyFormat;
 
   // #MARK: mergeData
+  /**
+   * Augment a log data object with counter, ALS fields, and `mergeData` overrides.
+   *
+   * @remarks
+   * When `loggerOptions.als` is enabled, reads the current ALS store and merges
+   * it into the payload. Also pulls the optional thread-local child logger that
+   * ALS callers can inject to redirect a specific request's logs somewhere else.
+   */
   function mergeData<T extends object>(data: T): [T, ILogger] {
     let out = { ...data, ...loggerOptions.mergeData };
 
@@ -91,10 +126,26 @@ export async function Logger({
   }
 
   // #MARK: prettyFormatMessage
+  /**
+   * Apply chalk syntax highlighting to a log message string.
+   *
+   * @remarks
+   * Only runs when `prettyFormat` is true and the message is under
+   * `MAX_CUTOFF` characters — very long strings are passed through verbatim
+   * to avoid performance degradation from heavy regex over large payloads.
+   *
+   * Highlighting rules:
+   * - `word#word` → yellow (symbol-style identifiers)
+   * - `[A] > [B]` → blue `>` separators
+   * - `[Text]` → bold magenta, brackets stripped
+   * - `{Text}` → bold gray, braces stripped
+   * - Leading ` - ` dash prefix → yellow dash
+   */
   function prettyFormatMessage(message: string): string {
     if (!message) {
       return ``;
     }
+    // skip expensive regex on very long messages or when pretty is disabled
     if (!prettyFormat || message.length > MAX_CUTOFF) {
       return message;
     }
@@ -119,6 +170,9 @@ export async function Logger({
 
   if (is.empty(internal.boot.options?.customLogger)) {
     // #MARK: formatter
+    // build a per-level formatter function and store it in the module-level logger record;
+    // each function closes over the shared prettyFormat/extraTargets state so runtime
+    // changes (setPrettyFormat, addTarget) take effect on the next log call
     [...METHOD_COLORS.keys()].forEach(key => {
       logger[key] = (context: TContext, ...parameters: Parameters<TLoggerFunction>) => {
         const [data, child] = mergeData(
@@ -132,8 +186,8 @@ export async function Logger({
             : {},
         );
 
-        // common for functions to be thrown in
-        // extract it's declared name and discard the rest of the info
+        // functions are commonly passed as the `name` field to tag the call-site;
+        // extract the declared `.name` string and discard the function reference
         data.name = is.object(data.name) || is.function(data.name) ? data.name.name : data.name;
 
         // ? full data object representing this log
@@ -167,7 +221,8 @@ export async function Logger({
           rawData.ms = ms;
         }
 
-        // emit logs to external targets
+        // emit logs to external targets before the stdOut guard so targets always
+        // receive every message regardless of whether stdout is suppressed
         extraTargets.forEach(target => {
           // stream targets, just take all messages and do the exact same thing with them
           // ex: send to http endpoint
@@ -206,6 +261,7 @@ export async function Logger({
             context: ctx,
             ...extra
           } = data;
+          // only inspect extra fields that aren't already rendered in the message line
           if (!is.empty(extra)) {
             message +=
               "\n" +
@@ -220,12 +276,15 @@ export async function Logger({
                 .join("\n");
           }
         }
+        // ALS child logger takes precedence so per-request log redirection works
         if (child) {
           child[key](message);
           return;
         }
 
         // #MARK: globalThis.console
+        // route through the appropriate console method so browser devtools and
+        // Node's built-in log level filtering see the right severity
         switch (key) {
           case "warn": {
             globalThis.console.warn(message);
@@ -250,18 +309,31 @@ export async function Logger({
       };
     });
   } else {
+    // custom logger provided at bootstrap — use it verbatim instead of the built-in formatter
     logger = internal.boot.options.customLogger;
   }
 
-  // if bootstrap hard coded something specific, then start there
-  // otherwise, be noisy until config loads a user preference
+  // if bootstrap hard coded something specific, then start there;
+  // otherwise be noisy until config loads a user preference
   //
-  // stored as separate variable to cut down on internal config lookups
+  // stored as a separate variable to avoid per-call config proxy lookups
   let CURRENT_LOG_LEVEL: TConfigLogLevel =
     internal.utils.object.get(internal, "boot.options.configuration.boilerplate.LOG_LEVEL") ||
     "trace";
 
   // #MARK: context
+  /**
+   * Create a `GetLogger` scoped to a specific `TContext` string.
+   *
+   * @remarks
+   * Each returned logger checks `shouldILog[level]` before forwarding the
+   * call, making the check a simple boolean property access on every log line.
+   * `shouldILog` is rebuilt whenever `EVENT_UPDATE_LOG_LEVELS` fires, so
+   * level overrides and global level changes propagate to all existing scoped
+   * loggers automatically.
+   *
+   * Level resolution order: per-service override → module-level override → global level.
+   */
   function context(context: string | TContext) {
     const name = context as FlatServiceNames;
     const shouldILog = {} as Record<TConfigLogLevel, boolean>;
@@ -271,7 +343,7 @@ export async function Logger({
         // global level
         let target = LOG_LEVEL_PRIORITY[CURRENT_LOG_LEVEL];
 
-        // override directly
+        // per-service override takes priority over module-level override
         if (loggerOptions?.levelOverrides?.[name]) {
           target = LOG_LEVEL_PRIORITY[loggerOptions?.levelOverrides?.[name]];
           // module level override
@@ -302,6 +374,15 @@ export async function Logger({
   }
 
   // #MARK updateShouldLog:
+  /**
+   * Sync `CURRENT_LOG_LEVEL` from config and broadcast a level-update event.
+   *
+   * @remarks
+   * Called after `onPostConfig` (when the user's `LOG_LEVEL` preference is
+   * available) and on every subsequent `boilerplate.LOG_LEVEL` config change.
+   * Emitting `EVENT_UPDATE_LOG_LEVELS` causes every scoped logger's `shouldILog`
+   * map to be rebuilt synchronously so level changes take effect immediately.
+   */
   function updateShouldLog() {
     if (!is.empty(config.boilerplate.LOG_LEVEL)) {
       CURRENT_LOG_LEVEL = config.boilerplate.LOG_LEVEL;
@@ -310,31 +391,74 @@ export async function Logger({
   }
 
   // #MARK: lifecycle
+  // only read config after PostConfig fires; value is undefined before that
   lifecycle.onPostConfig(() => internal.boilerplate.logger.updateShouldLog());
+  // also update whenever LOG_LEVEL is changed at runtime (e.g. via setConfig)
   internal.boilerplate.configuration.onUpdate(
     () => internal.boilerplate.logger.updateShouldLog(),
     "boilerplate",
     "LOG_LEVEL",
   );
 
+  /**
+   * Register an additional log destination.
+   *
+   * @remarks
+   * Accepts either a `LogStreamTarget` function `(msg, rawData) => void`
+   * or any object that implements the `GetLogger` interface. All registered
+   * targets receive every log message before the `stdOut` guard, so targets
+   * see logs even when `stdOut` is disabled.
+   */
   function addTarget(target: GetLogger | LogStreamTarget) {
     extraTargets.add(target);
   }
 
   // #MARK: return object
   return {
+    /**
+     * Register an additional log destination (function or `GetLogger` object).
+     */
     addTarget,
+    /**
+     * Create a `GetLogger` scoped to the given context string.
+     */
     context,
+    /**
+     * Access the raw per-level formatter record.
+     * @internal
+     */
     getBaseLogger: () => logger,
+    /**
+     * Return the current pretty-format flag.
+     */
     getPrettyFormat: () => prettyFormat,
+    /**
+     * Apply chalk syntax highlighting to a message string (respects `prettyFormat` flag).
+     */
     prettyFormatMessage,
+    /**
+     * Replace the underlying per-level formatter record.
+     * @internal
+     */
     setBaseLogger: base => (logger = base),
+    /**
+     * Toggle chalk colorization on stdout output.
+     *
+     * @remarks
+     * Also updates `inspect.defaultOptions.colors` so object dumps remain consistent.
+     */
     setPrettyFormat: state => {
       prettyFormat = state;
       inspect.defaultOptions.colors = prettyFormat;
       return prettyFormat;
     },
+    /**
+     * Pre-built scoped logger for the framework's own internal log lines.
+     */
     systemLogger: context("digital-alchemy:system-logger"),
+    /**
+     * Sync the active log level from config and notify all scoped loggers.
+     */
     updateShouldLog,
   };
 }

--- a/src/services/scheduler.service.mts
+++ b/src/services/scheduler.service.mts
@@ -14,12 +14,32 @@ import type {
 } from "../index.mts";
 import { BootstrapException, sleep } from "../index.mts";
 
+/**
+ * Builder-style scheduler factory injected into every service via `TServiceParams`.
+ *
+ * @remarks
+ * Returns a function that accepts a `TContext` and produces the per-caller scheduler
+ * API (`cron`, `interval`, `sliding`, `setTimeout`, `setInterval`, `sleep`).
+ * This two-level shape is deliberate: the outer factory sets up lifecycle hooks
+ * shared across all callers; the inner function binds the per-caller context so
+ * every scheduled callback is associated with the service that created it.
+ *
+ * All schedules are registered against a shared `stop` set so a single
+ * `onPreShutdown` hook can cleanly cancel every outstanding timer in one pass.
+ * Schedules only start firing after the `onReady` lifecycle event; creating a
+ * scheduler before `onReady` is safe — the job is registered but does not run
+ * until the application is ready.
+ *
+ * Remove callbacks returned from each method are dual-arity:
+ * call them directly (`remove()`) or destructure `{ remove }` — both work.
+ */
 export function Scheduler({ logger, lifecycle, internal }: TServiceParams): SchedulerBuilder {
   const { is } = internal.utils;
   const stop = new Set<RemoveCallback>();
 
   // #MARK: lifecycle events
   lifecycle.onPreShutdown(function onPreShutdown() {
+    // skip teardown work if nothing was ever scheduled for this instance
     if (is.empty(stop)) {
       return;
     }
@@ -32,6 +52,15 @@ export function Scheduler({ logger, lifecycle, internal }: TServiceParams): Sche
 
   return (context: TContext) => {
     // #MARK: cron
+    /**
+     * Run `exec` on one or more cron schedules.
+     *
+     * @remarks
+     * Accepts a single schedule string or an array; each schedule creates an
+     * independent `CronJob`. Jobs start on `onReady` and are registered in the
+     * shared `stop` set so they are cancelled during `onPreShutdown`.
+     * Returns a combined remove callback that cancels all jobs created by this call.
+     */
     function cron({ exec, schedule: scheduleList }: SchedulerCronOptions) {
       const stopFunctions: RemoveCallback[] = [];
       [scheduleList].flat().forEach(cronSchedule => {
@@ -52,10 +81,19 @@ export function Scheduler({ logger, lifecycle, internal }: TServiceParams): Sche
         return stopFunction;
       });
 
+      // wrap all individual stop functions so a single call cancels every schedule
       return internal.removeFn(() => stopFunctions.forEach(stop => stop()));
     }
 
     // #MARK: interval
+    /**
+     * Run `exec` repeatedly at a fixed `interval` millisecond cadence.
+     *
+     * @remarks
+     * The underlying `setInterval` does not start until `onReady`. If the
+     * application is torn down before `onReady` fires the `stopped` guard
+     * prevents the timer from being created at all.
+     */
     function interval({ exec, interval }: SchedulerIntervalOptions) {
       let runningInterval: ReturnType<typeof setInterval>;
       lifecycle.onReady(() => {
@@ -72,6 +110,28 @@ export function Scheduler({ logger, lifecycle, internal }: TServiceParams): Sche
     }
 
     // #MARK: sliding
+    /**
+     * Schedule an execution at a time determined dynamically by a `next` callback.
+     *
+     * @remarks
+     * Unlike cron (fixed periods) or interval (fixed gaps), sliding lets the
+     * caller compute the *exact* next run time. `reset` is a cron expression
+     * that controls how often `next` is re-evaluated; `next` returns the target
+     * `Dayjs` moment for the actual `exec` call.
+     *
+     * Decision points:
+     * - If `next()` returns falsy the window is skipped — caller can signal
+     *   "nothing to do right now" without throwing.
+     * - If the computed time is already in the past at evaluation time, the
+     *   execution is skipped. This most commonly happens on first boot when the
+     *   slot has already passed for today; treating it as a no-op avoids an
+     *   immediate double-fire.
+     * - If `waitForNext` is called while a previous timeout is still pending,
+     *   it cancels the old one and schedules fresh — ensures the schedule stays
+     *   coherent if the reset cron fires more aggressively than expected.
+     *
+     * @throws {BootstrapException} `BAD_NEXT` if `next` or `exec` is not a function.
+     */
     function sliding({ exec, reset, next }: SchedulerSlidingOptions) {
       if (!is.function(next)) {
         throw new BootstrapException(
@@ -90,6 +150,8 @@ export function Scheduler({ logger, lifecycle, internal }: TServiceParams): Sche
       let timeout: ReturnType<typeof setTimeout>;
 
       const waitForNext = () => {
+        // a pending timeout means the reset cron fired before the scheduled exec ran;
+        // cancel and reschedule so the next time is always freshly computed
         if (timeout) {
           logger.warn(
             { context, name: sliding },
@@ -98,15 +160,16 @@ export function Scheduler({ logger, lifecycle, internal }: TServiceParams): Sche
           clearTimeout(timeout);
         }
         let nextTime = next();
+        // next() returning falsy is the caller's way of saying "skip this window"
         if (!nextTime) {
-          // nothing to do?
-          // will try again next schedule
+          logger.trace({ context, name: sliding }, "next returned falsy, skipping window");
           return;
         }
         nextTime = dayjs(nextTime);
+        // if the target time is already past at evaluation, skip to avoid an immediate
+        // double-fire; most common on first boot when the slot passed earlier today
         if (dayjs().isAfter(nextTime)) {
-          // probably a result of boot
-          // ignore
+          logger.trace({ context, name: sliding }, "next time is in the past, skipping");
           return;
         }
         if (nextTime) {
@@ -135,10 +198,20 @@ export function Scheduler({ logger, lifecycle, internal }: TServiceParams): Sche
       });
     }
 
+    /**
+     * Fire `callback` once after `target` offset elapses.
+     *
+     * @remarks
+     * Wraps the native `setTimeout` with lifecycle awareness: the timer is not
+     * armed until `onReady`, and is automatically cancelled during shutdown via
+     * the shared `stop` set. If `remove()` is called before `onReady` the
+     * `stopped` flag prevents the timer from ever being created.
+     */
     function SetTimeout(callback: () => TBlackHole, target: TOffset) {
       let timer: ReturnType<typeof setTimeout>;
       let stopped = false;
       lifecycle.onReady(() => {
+        // guard against the case where remove() was called before onReady fired
         if (stopped) {
           return;
         }
@@ -158,10 +231,20 @@ export function Scheduler({ logger, lifecycle, internal }: TServiceParams): Sche
       return remove;
     }
 
+    /**
+     * Fire `callback` repeatedly at every `target` offset interval.
+     *
+     * @remarks
+     * Lifecycle-aware wrapper around `setInterval`. Timer starts on `onReady`
+     * and is cancelled during shutdown via the shared `stop` set. If `remove()`
+     * is called before `onReady`, the `stopped` guard prevents the interval
+     * from ever starting.
+     */
     function SetInterval(callback: () => TBlackHole, target: TOffset) {
       let timer: ReturnType<typeof setInterval>;
       let stopped = false;
       lifecycle.onReady(() => {
+        // guard against the case where remove() was called before onReady fired
         if (stopped) {
           return;
         }

--- a/src/services/wiring.service.mts
+++ b/src/services/wiring.service.mts
@@ -40,6 +40,8 @@ import {
   LOAD_PROJECT,
 } from "./configuration.service.mts";
 import { InternalDefinition } from "./internal.service.mts";
+// direct import of `is` from its source file to avoid a circular dependency:
+// going through ../index.mts would force wiring.mts to resolve before is.service.mts
 import { is } from "./is.service.mts";
 import { CreateLifecycle } from "./lifecycle.service.mts";
 import { Logger } from "./logger.service.mts";
@@ -56,6 +58,17 @@ const SIGINT = 130;
 const SIGTERM = 143;
 
 // #MARK: CreateBoilerplate
+/**
+ * Construct a fresh `LIB_BOILERPLATE` library definition.
+ *
+ * @remarks
+ * Must remain in this file. Moving it to another module causes code-init race
+ * conditions because the boilerplate services depend on types that are only
+ * resolved after the module graph is fully settled. The library is recreated
+ * on every `bootstrap()` call so tests get a clean instance.
+ *
+ * @internal
+ */
 function createBoilerplate() {
   // ! DO NOT MOVE TO ANOTHER FILE !
   // While it SEEMS LIKE this can be safely moved, it causes code init race conditions.
@@ -180,13 +193,21 @@ function createBoilerplate() {
   });
 }
 
-// (re)defined at bootstrap
-// unclear if this variable even serves a purpose beyond types
+// (re)defined at bootstrap; exported so downstream code can reference its type
 export let LIB_BOILERPLATE: ReturnType<typeof createBoilerplate>;
 type GenericApp = ApplicationDefinition<ServiceMap, OptionalModuleConfiguration>;
 const RUNNING_APPLICATIONS = new Map<string, GenericApp>();
 
 // #MARK: QuickShutdown
+/**
+ * Trigger teardown on every currently-running application.
+ *
+ * @remarks
+ * Called by the SIGINT/SIGTERM process event handlers so all applications
+ * go through their full shutdown lifecycle before the process exits.
+ *
+ * @internal
+ */
 async function quickShutdown(reason: string) {
   await each([...RUNNING_APPLICATIONS.values()], async application => {
     application.logger.warn({ reason }, `starting shutdown`);
@@ -195,6 +216,9 @@ async function quickShutdown(reason: string) {
 }
 
 // #MARK: processEvents
+// SIGTERM is sent by orchestrators (e.g. Docker, Kubernetes) for graceful shutdown;
+// SIGINT is sent by the terminal (Ctrl-C); both should drain the lifecycle cleanly
+// before exiting rather than killing the process immediately
 const processEvents = new Map([
   [
     "SIGTERM",
@@ -219,6 +243,23 @@ const BOILERPLATE = (internal: InternalDefinition) =>
   internal.boot.loadedModules.get("boilerplate") as GetApis<ReturnType<typeof createBoilerplate>>;
 
 // #MARK: CreateApplication
+/**
+ * Define an application and return a handle that can be bootstrapped.
+ *
+ * @remarks
+ * Does not start any services. Call `.bootstrap(options)` on the returned
+ * handle to wire services and run the lifecycle. Only one bootstrap per
+ * handle is allowed; a second call throws `DOUBLE_BOOT`.
+ *
+ * The returned handle also exposes `.teardown()` for orderly shutdown —
+ * this is the same path taken by the SIGINT/SIGTERM handlers.
+ *
+ * `priorityInit` controls which services are wired first within this
+ * application; all others are wired in declaration order after them.
+ *
+ * @throws {BootstrapException} `MISSING_PRIORITY_SERVICE` if a service listed
+ *   in `priorityInit` is not present in `services`.
+ */
 export function CreateApplication<S extends ServiceMap, C extends OptionalModuleConfiguration>({
   name,
   services = {} as S,
@@ -229,6 +270,8 @@ export function CreateApplication<S extends ServiceMap, C extends OptionalModule
 }: ApplicationConfigurationOptions<S, C>) {
   let internal: InternalDefinition;
 
+  // validate priority list up front so misconfiguration fails loudly at definition
+  // time rather than silently during bootstrap when the service is just missing
   if (!is.empty(priorityInit)) {
     priorityInit.forEach(name => {
       if (!is.function(services[name])) {
@@ -260,6 +303,8 @@ export function CreateApplication<S extends ServiceMap, C extends OptionalModule
         );
       });
       const append = internal.boot.options?.appendService;
+      // appendService allows tests (and advanced users) to inject extra services
+      // without modifying the application definition
       if (!is.empty(append)) {
         await eachSeries(Object.keys(append), async service => {
           await wireService(
@@ -275,6 +320,8 @@ export function CreateApplication<S extends ServiceMap, C extends OptionalModule
     },
     booted: false,
     bootstrap: async (options: BootstrapOptions) => {
+      // guard against accidentally bootstrapping the same application twice;
+      // this is always a programming error — each app should have a single entry point
       if (application.booted) {
         throw new BootstrapException(
           WIRING_CONTEXT,
@@ -298,6 +345,8 @@ export function CreateApplication<S extends ServiceMap, C extends OptionalModule
     services,
     async teardown() {
       if (!application.booted) {
+        // remove signal handlers even for un-booted teardown so they don't
+        // accumulate across test re-runs
         processEvents.forEach((callback, event) => process.removeListener(event, callback));
         return;
       }
@@ -312,6 +361,22 @@ export function CreateApplication<S extends ServiceMap, C extends OptionalModule
 }
 
 // #MARK: WireService
+/**
+ * Instantiate a single service function and register it in the module registry.
+ *
+ * @remarks
+ * Builds the full `TServiceParams` injection object from the currently loaded
+ * modules and calls the service factory. The returned value is stored in
+ * `internal.boot.loadedModules` so subsequent services can reference it.
+ *
+ * Construction time is recorded for bootstrap stats (`showExtraBootStats`).
+ *
+ * If the factory throws, the error is treated as fatal — the process exits
+ * with code 1 because a failed constructor leaves the DI graph in a
+ * partially-initialized state with no safe recovery path.
+ *
+ * @internal
+ */
 async function wireService(
   project: string,
   service: string,
@@ -324,7 +389,8 @@ async function wireService(
   internal.boot.moduleMappings.set(project, mappings);
   const context = COERCE_CONTEXT(`${project}:${service}`);
 
-  // logger gets defined first, so this really is only for the start of the start of bootstrapping
+  // logger is not yet available at the very start of bootstrap; only undefined briefly
+  // during boilerplate wiring before the logger service itself is initialized
   const boilerplate = BOILERPLATE(internal);
   const logger = boilerplate?.logger?.context(context);
   const loaded = internal.boot.loadedModules.get(project) ?? {};
@@ -332,6 +398,8 @@ async function wireService(
   try {
     logger?.trace({ name: wireService }, `initializing`);
     const serviceStart = performance.now();
+    // snapshot all currently-loaded modules so each service sees siblings
+    // that were wired before it, but not ones that come after (no forward refs)
     const inject = Object.fromEntries(
       [...internal.boot.loadedModules.keys()].map(project => [
         project as keyof TServiceParams,
@@ -349,8 +417,11 @@ async function wireService(
       lifecycle,
       logger,
       params: undefined,
+      // scheduler is a builder; call it with context so the returned API
+      // tags every scheduled callback with this service's context string
       scheduler: boilerplate?.scheduler?.(context),
     } as TServiceParams;
+    // params.params is a self-reference so callers can spread the whole bundle
     serviceParams.params = serviceParams;
 
     loaded[service] = (await definition(serviceParams)) as TServiceReturn;
@@ -364,30 +435,47 @@ async function wireService(
 
     return loaded[service];
   } catch (error) {
-    // Init errors at this level are considered blocking / fatal
+    // constructor errors are blocking — a partially-initialized service graph
+    // cannot be safely recovered, so exit immediately
     fatalLog("initialization error", error);
     process.exit(EXIT_ERROR);
   }
 }
 
+/**
+ * Execute the `PreInit` lifecycle stage and mark it complete.
+ * @internal
+ */
 const runPreInit = async (internal: InternalDefinition) => {
   const duration = await internal.boot.lifecycle.exec("PreInit");
   internal.boot.completedLifecycleEvents.add("PreInit");
   return duration;
 };
 
+/**
+ * Execute the `PostConfig` lifecycle stage and mark it complete.
+ * @internal
+ */
 const runPostConfig = async (internal: InternalDefinition) => {
   const duration = await internal.boot.lifecycle.exec("PostConfig");
   internal.boot.completedLifecycleEvents.add("PostConfig");
   return duration;
 };
 
+/**
+ * Execute the `Bootstrap` lifecycle stage and mark it complete.
+ * @internal
+ */
 const runBootstrap = async (internal: InternalDefinition) => {
   const duration = await internal.boot.lifecycle.exec("Bootstrap");
   internal.boot.completedLifecycleEvents.add("Bootstrap");
   return duration;
 };
 
+/**
+ * Execute the `Ready` lifecycle stage and mark it complete.
+ * @internal
+ */
 const runReady = async (internal: InternalDefinition) => {
   const duration = await internal.boot.lifecycle.exec("Ready");
   internal.boot.completedLifecycleEvents.add("Ready");
@@ -395,6 +483,25 @@ const runReady = async (internal: InternalDefinition) => {
 };
 
 // #MARK: Bootstrap
+/**
+ * Wire all services for an application, run the full lifecycle, and return
+ * the `TServiceParams` for the bootstrap service.
+ *
+ * @remarks
+ * Sequence:
+ * 1. Initialize a fresh `InternalDefinition.boot` record.
+ * 2. Wire boilerplate (als, configuration, logger, scheduler).
+ * 3. Register SIGINT/SIGTERM process event handlers for graceful shutdown.
+ * 4. Wire declared libraries in dependency-sorted order.
+ * 5. Wire the application services (or defer to after Bootstrap if
+ *    `bootLibrariesFirst` is set).
+ * 6. Apply any inline `options.configuration` overrides.
+ * 7. Run `PreInit → Configure (loaders) → PostConfig → Bootstrap → Ready`.
+ * 8. Resolve the returned `TServiceParams` promise via a synthetic
+ *    "bootstrap" service wire call so the caller can access the wired graph.
+ *
+ * @internal
+ */
 async function bootstrap<S extends ServiceMap, C extends OptionalModuleConfiguration>(
   application: ApplicationDefinition<S, C>,
   options: BootstrapOptions,
@@ -420,8 +527,8 @@ async function bootstrap<S extends ServiceMap, C extends OptionalModuleConfigura
     const CONSTRUCT = {} as Record<string, unknown>;
 
     // pre-create loaded module for boilerplate, so it can be attached to `internal`
-    // this allows it to be used as part of `internal` during boilerplate construction
-    // otherwise it'd only be there for everyone else
+    // before the boilerplate services themselves are wired; without this pre-seeding
+    // the boilerplate services would not find each other in the module map
     const api = {} as GetApis<ReturnType<typeof createBoilerplate>>;
     internal.boilerplate = api;
     internal.boot.loadedModules.set("boilerplate", api);
@@ -429,6 +536,8 @@ async function bootstrap<S extends ServiceMap, C extends OptionalModuleConfigura
     STATS.Construct = CONSTRUCT;
     // * Recreate base eventemitter
     internal.utils.event = new EventEmitter();
+    // unlimited listeners: every service can register lifecycle hooks, and the
+    // default cap of 10 would produce spurious MaxListenersExceededWarnings
     internal.utils.event.setMaxListeners(NONE);
 
     // * Generate a new boilerplate module
@@ -439,7 +548,7 @@ async function bootstrap<S extends ServiceMap, C extends OptionalModuleConfigura
     await LIB_BOILERPLATE[WIRE_PROJECT](internal, wireService);
 
     CONSTRUCT.boilerplate = `${(performance.now() - start).toFixed(DECIMALS)}ms`;
-    // sync properties for convenience
+    // sync convenience aliases so downstream code reaches config via either path
     internal.config = api.configuration;
     // ~ configuration
     api.configuration?.[LOAD_PROJECT](LIB_BOILERPLATE.name, LIB_BOILERPLATE.configuration);
@@ -447,7 +556,8 @@ async function bootstrap<S extends ServiceMap, C extends OptionalModuleConfigura
     application.logger = logger;
     logger.debug({ name: bootstrap }, `[boilerplate] wiring complete`);
 
-    // * Wire in various shutdown events
+    // register signal handlers now that the logger is available so teardown
+    // log lines are visible; handlers are removed on teardown/un-booted teardown
     processEvents.forEach((callback, event) => {
       process.on(event, callback);
       logger.trace({ event, name: bootstrap }, "register shutdown event");
@@ -456,6 +566,8 @@ async function bootstrap<S extends ServiceMap, C extends OptionalModuleConfigura
     // * Add in libraries
     application.libraries ??= [];
 
+    // appendLibrary allows replacing a library at bootstrap time, which is
+    // the primary mechanism for injecting test doubles at the library level
     if (!is.undefined(options?.appendLibrary)) {
       const list = is.array(options.appendLibrary)
         ? options.appendLibrary
@@ -463,7 +575,7 @@ async function bootstrap<S extends ServiceMap, C extends OptionalModuleConfigura
       list.forEach(append => {
         application.libraries.some((library, index) => {
           if (append.name === library.name) {
-            // remove existing
+            // remove existing entry so the appended version takes its slot
             logger.warn({ name: append.name }, `replacing library`);
             application.libraries.splice(index, SINGLE);
             return true;
@@ -476,6 +588,7 @@ async function bootstrap<S extends ServiceMap, C extends OptionalModuleConfigura
       });
     }
 
+    // sort libraries so each one is wired after its declared dependencies
     const order = buildSortOrder(application, logger);
     await eachSeries(order, async i => {
       start = performance.now();
@@ -489,7 +602,8 @@ async function bootstrap<S extends ServiceMap, C extends OptionalModuleConfigura
     // * Finally the application
     if (options?.bootLibrariesFirst) {
       logger.debug({ name: bootstrap }, `bootLibrariesFirst`);
-      // * preload config
+      // bootLibrariesFirst: skip application wiring here and run it later,
+      // between Bootstrap and Ready, so the app sees fully-initialized library services
       api.configuration[LOAD_PROJECT](application.name, application.configuration);
     } else {
       logger.debug({ name: bootstrap }, `init application`);
@@ -498,7 +612,7 @@ async function bootstrap<S extends ServiceMap, C extends OptionalModuleConfigura
       CONSTRUCT[application.name] = `${(performance.now() - start).toFixed(DECIMALS)}ms`;
     }
 
-    // ? Configuration values provided bootstrap take priority over module level
+    // ? Configuration values provided at bootstrap take priority over module-level defaults
     if (!is.empty(options?.configuration)) {
       api.configuration.merge(options?.configuration);
     }
@@ -518,12 +632,9 @@ async function bootstrap<S extends ServiceMap, C extends OptionalModuleConfigura
     STATS.Bootstrap = await runBootstrap(internal);
 
     if (options?.bootLibrariesFirst) {
-      // * mental note
-      // running between bootstrap & ready seems most appropriate
-      // resources are expected to *technically* be ready at this point, but not finalized
-      // reference examples:
-      // - hass: socket is open & resources are ready
-      // - fastify: bindings are available but port isn't listening
+      // wire the application between Bootstrap and Ready so library resources are
+      // fully initialized (e.g. hass socket open, fastify bindings registered)
+      // but the app itself does not start accepting work until Ready fires
 
       logger.debug({ name: bootstrap }, `late init application`);
       start = performance.now();
@@ -557,6 +668,8 @@ async function bootstrap<S extends ServiceMap, C extends OptionalModuleConfigura
       application.name,
     );
     internal.boot.phase = "running";
+    // resolve the bootstrap promise by wiring a synthetic "bootstrap" service
+    // whose params object is the fully-wired TServiceParams the caller receives
     return new Promise(done =>
       wireService(
         application.name,
@@ -575,7 +688,23 @@ async function bootstrap<S extends ServiceMap, C extends OptionalModuleConfigura
 }
 
 // #MARK: Teardown
+/**
+ * Run shutdown lifecycle stages and clean up process-level resources.
+ *
+ * @remarks
+ * Called by `.teardown()` on the application handle and indirectly by the
+ * SIGINT/SIGTERM handlers via `quickShutdown`. Idempotent at the phase check
+ * — only executes if the application is in the `"running"` phase.
+ *
+ * Sequence: `PreShutdown → ShutdownStart → (cancel active sleeps) →
+ * ShutdownComplete`. Any error during teardown is logged to stderr via
+ * `globalThis.console.error` because the logger itself may be in an
+ * indeterminate state at that point.
+ *
+ * @internal
+ */
 async function teardown(internal: InternalDefinition, logger: ILogger) {
+  // skip if the app never fully started or has already been torn down
   if (internal.boot.phase !== "running") {
     return;
   }
@@ -594,14 +723,16 @@ async function teardown(internal: InternalDefinition, logger: ILogger) {
     await internal.boot.lifecycle.exec("ShutdownStart");
     internal.boot.completedLifecycleEvents.add("ShutdownStart");
 
-    // - clean up active `sleep` calls (can keep tests open and stuff)
+    // cancel any in-flight sleep() calls; without this they keep the event loop
+    // alive and hang test runners / process exits
     ACTIVE_SLEEPS.forEach(i => i.kill("stop"));
 
     logger.debug({ name: teardown }, `[ShutdownComplete] running lifecycle callbacks`);
     await internal.boot.lifecycle.exec("ShutdownComplete");
     internal.boot.completedLifecycleEvents.add("ShutdownComplete");
   } catch (error) {
-    // ! oof
+    // teardown errors are logged via globalThis.console rather than logger because
+    // the logger service itself may have been partially torn down by this point
     globalThis.console.error(
       { error },
       "error occurred during teardown, some lifecycle events may be incomplete",
@@ -616,5 +747,7 @@ async function teardown(internal: InternalDefinition, logger: ILogger) {
     },
     `application terminated`,
   );
+  // deregister signal handlers so they don't fire again if the process receives
+  // another signal after teardown completes
   processEvents.forEach((callback, event) => process.removeListener(event, callback));
 }

--- a/src/testing/index.mts
+++ b/src/testing/index.mts
@@ -1,2 +1,7 @@
+/**
+ * Test infrastructure: mock logger and test runner factory for isolated DI bootstrapping
+ * in test suites. Both tools are safe to use without configuration changes.
+ */
+
 export * from "./mock-logger.mts";
 export * from "./test-module.mts";

--- a/src/testing/mock-logger.mts
+++ b/src/testing/mock-logger.mts
@@ -1,6 +1,15 @@
 import type { ILogger } from "../index.mts";
 
+/**
+ * Create a no-op logger for suppressing output in test specs.
+ *
+ * @remarks
+ * Returns an {@link ILogger} where every method is a stub function that discards
+ * all input. Use this in test runners or specs where logger output would pollute
+ * test output or stderr during a silent test run.
+ */
 export function createMockLogger(): ILogger {
+  // every method is a stub to avoid any side effects during testing
   return {
     debug: () => {},
     error: () => {},

--- a/src/testing/test-module.mts
+++ b/src/testing/test-module.mts
@@ -1,3 +1,18 @@
+/**
+ * Test infrastructure for bootstrapping isolated DI graphs in test suites.
+ *
+ * @remarks
+ * {@link TestRunner} boots a **real** dependency-injection graph, not a mock framework.
+ * Every lifecycle stage fires in order, every service executes normally, and every
+ * scheduler registers real event listeners. This makes it safe to test complex
+ * initialization sequences, lifecycle interactions, and async service behavior without
+ * leaking state between tests. By default, config files and environment variables
+ * are NOT loaded; opt in with `loadConfigs: true` or `setOptions({ configSources })`.
+ *
+ * Always call `.teardown()` in `afterEach` — open handles and event listeners will
+ * keep vitest hanging if left uncleaned.
+ */
+
 import { v4 } from "uuid";
 
 import type {
@@ -32,50 +47,59 @@ type TestingBootstrapOptions = {
   /**
    * default: false
    *
-   * set to true to have this test emit logs
+   * Set to true to have this test emit logs to stdout. Useful for debugging
+   * test failures during interactive development.
    */
   emitLogs?: boolean;
 
   /**
-   * pass through to bootstrap params
+   * Pass through to bootstrap params to customize logger output behavior.
    */
   loggerOptions?: LoggerOptions;
 
   /**
    * default: false
    *
-   * Should testing apps consider config file / environment variables?
+   * Whether to load config from environment variables and config files.
+   * By default, all config sources are disabled — the test environment
+   * is isolated. Opt in with `loadConfigs: true` or individual sources
+   * via `setOptions({ configSources: { env: true } })`.
    */
   loadConfigs?: boolean;
 
   /**
-   * replacement logger object to use
+   * Replacement logger object to use instead of the default no-op logger.
    *
-   * default: **NOOP**
+   * default: **no-op ILogger** (all methods are stubs)
    */
   customLogger?: ILogger;
 
   /**
-   * matches regular bootstrap options
+   * Matches regular bootstrap options for library load ordering.
    */
   bootLibrariesFirst?: boolean;
 
   /**
-   * default values to use for configurations, before user values come in
+   * Default values to use for configurations, applied before user values.
+   * Deep-merged into the module configuration during bootstrap.
    */
   configuration?: PartialConfiguration;
 
   /**
    * @internal
    *
-   * define a configuration for the unit tests
-   *
-   * > **note**: you probably don't need to do this, it's not even documented
+   * Explicit module configuration for the test runner. Only set this if you
+   * need to control the raw configuration shape; normally use `.configure()`
+   * instead.
    */
   module_config?: ModuleConfiguration;
 
   /**
-   * all properties default true if not provided
+   * Control which config sources are loaded by the test runner.
+   * Defaults to **all disabled** unless `loadConfigs: true` is passed.
+   *
+   * Example: `setOptions({ configSources: { env: true } })` enables
+   * environment variable loading without file loading.
    */
   configSources?: Partial<Record<DataTypes, boolean>>;
 };
@@ -87,67 +111,111 @@ export type ApplicationTestRunner<T> =
 
 export type iTestRunner<S extends ServiceMap, C extends OptionalModuleConfiguration> = {
   /**
-   * chained calls deep merge options together
+   * Merge configuration values into the test runner's config.
+   *
+   * @remarks
+   * Chained calls deep-merge together; order is left-to-right.
+   * Configuration is applied at bootstrap time via `onPostConfig`.
    */
   configure: (configuration: PartialConfiguration) => iTestRunner<S, C>;
 
   /**
-   * chained calls deep merge options together
+   * Merge bootstrap options into the test runner.
+   *
+   * @remarks
+   * Chained calls deep-merge together. Use this to set logging behavior,
+   * config sources, and other bootstrap-level parameters.
    */
   setOptions: (options: TestingBootstrapOptions) => iTestRunner<S, C>;
 
   /**
-   * sets flag to true
+   * Enable library-first bootstrap order for this test.
+   *
+   * @remarks
+   * Sets `bootLibrariesFirst: true` in the bootstrap options.
    */
   bootLibrariesFirst: () => iTestRunner<S, C>;
 
   /**
-   * for debugging, single command to enable logging on this test
+   * Enable logger output and optionally set the log level.
+   *
+   * @remarks
+   * Convenience method for debugging test failures. Sets `emitLogs: true`
+   * and optionally sets `boilerplate.LOG_LEVEL` if a level is provided.
    */
   emitLogs: (log_level?: TConfigLogLevel) => iTestRunner<S, C>;
 
   /**
-   * chained calls add multiple setup functions
+   * Register a service function to execute first during bootstrap.
+   *
+   * @remarks
+   * Chained calls add multiple setup functions; they execute in order
+   * via a synthetic `run_first` library that depends on all target libraries.
    */
   setup: (test: ServiceFunction) => iTestRunner<S, C>;
 
   /**
-   * cannot be used with `.run`
+   * Bootstrap and return the fully-wired {@link TServiceParams} without running an inline service.
    *
-   * returns params instead of running an inline service
+   * @remarks
+   * Cannot be used with `.run()`; they are mutually exclusive. Useful when
+   * you need to pass the params to multiple service calls or assertions.
+   * Always call `.teardown()` after you're done with the params.
    */
   serviceParams: () => Promise<TServiceParams>;
 
   /**
-   * cannot be used with `.serviceParams`
+   * Bootstrap the test application and run the provided test service.
    *
-   * returns reference to app that was booted
+   * @remarks
+   * Cannot be used with `.serviceParams()`; they are mutually exclusive.
+   * Returns the application so you can make assertions on its state after
+   * the test service completes. The returned app already has `.teardown()`
+   * wired to this runner; call it in `afterEach` to clean up.
+   *
+   * @throws Propagates any error thrown by the test service or during bootstrap.
    */
   run: (
     test: ServiceFunction,
   ) => Promise<ApplicationDefinition<ServiceMap, OptionalModuleConfiguration>>;
 
   /**
-   * add a library to the runner beyond what the target module requested
+   * Register an additional library to wire into the test application.
+   *
+   * @remarks
+   * The library is appended to the dependency list; chained calls add
+   * multiple libraries. Useful for mocking or providing test doubles
+   * without modifying the target module's definition.
    */
   appendLibrary: (library: TLibrary) => iTestRunner<S, C>;
 
   /**
-   * inject an extra service to your module
+   * Inject an extra service into the test application.
    *
-   * by default will take the function name as context, can optionally provide the name as 2nd param (if it even matters)
+   * @remarks
+   * The service is added to the application's service map by name.
+   * If `name` is not provided, the function's `.name` property is used;
+   * if that's empty, a UUID is generated. Chained calls add multiple services.
    */
   appendService: (service: ServiceFunction, name?: string) => iTestRunner<S, C>;
 
   /**
-   * substitute a library for another by name
+   * Substitute a library by name.
+   *
+   * @remarks
+   * Any library in the target module or appended libraries with matching name
+   * is replaced by the provided library. Chained calls build a replacement map.
    */
   replaceLibrary: (name: string, library: TLibrary) => iTestRunner<S, C>;
 
   /**
-   * reference to the app teardown internally
+   * Tear down the bootstrapped application and clean up all resources.
    *
-   * clean up your testing resources!
+   * @remarks
+   * Closes event listeners, cancels schedulers, and flushes any pending
+   * async work. **CRITICAL:** Call this in `afterEach` to prevent vitest
+   * hangs from unclosed file handles or event emitters. Safe to call
+   * multiple times (idempotent).
    */
   teardown: () => Promise<void>;
 
@@ -155,11 +223,26 @@ export type iTestRunner<S extends ServiceMap, C extends OptionalModuleConfigurat
 };
 
 /**
- * library optional
+ * Bootstrap a real dependency-injection graph for testing.
+ *
+ * @remarks
+ * Returns a chainable test runner that wires up a full application with all
+ * lifecycle stages executing in order. By default, config files and environment
+ * variables are NOT loaded — the test is isolated. Opt in with `loadConfigs: true`
+ * or `setOptions({ configSources: { env: true } })`.
+ *
+ * **Mocking depth matters:** when you spy on a service method, only that method
+ * is replaced, not the entire service. To substitute an entire service, use
+ * `.replaceLibrary()` or `.appendService()`.
+ *
+ * **CRITICAL:** Always call `.teardown()` in `afterEach`. Unclosed event listeners
+ * and scheduled tasks will hang the test runner.
  */
 export function TestRunner<S extends ServiceMap, C extends OptionalModuleConfiguration>(
   options: CreateTestingLibraryOptions<S, C> = {},
 ) {
+  // disable max event listener warnings in test environments where many
+  // services register lifecycle callbacks and event handlers simultaneously
   process.setMaxListeners(NONE);
   let teardown: () => Promise<void>;
   let bootOptions: TestingBootstrapOptions = {};
@@ -180,9 +263,13 @@ export function TestRunner<S extends ServiceMap, C extends OptionalModuleConfigu
     target: LibraryDefinition<S, C> | ApplicationDefinition<S, C>,
     test: ServiceFunction,
   ) {
+    // extract optional dependencies from the target; absent if target is undefined
     const optional = target && "optionalDepends" in target ? target.optionalDepends : [];
+    // gather the full library dependency tree from the target module
     const depends = [...getLibraries(target)];
 
+    // wrap the target's services and configuration into a library so it can be
+    // mixed with appended libraries and the run_first setup library
     const testLibrary = target
       ? CreateLibrary({
           configuration: target.configuration,
@@ -193,6 +280,8 @@ export function TestRunner<S extends ServiceMap, C extends OptionalModuleConfigu
           services: target.services,
         })
       : undefined;
+    // setup services (added via .setup()) run in a dedicated library that depends
+    // on the target library, ensuring they fire after the full graph is wired
     let LIB_RUN_FIRST: TLibrary;
     if (!is.empty(runFirst)) {
       LIB_RUN_FIRST = CreateLibrary({
@@ -207,17 +296,23 @@ export function TestRunner<S extends ServiceMap, C extends OptionalModuleConfigu
       });
     }
 
+    // build the application with appended libraries, the target library (if any),
+    // and the special test service that the caller provides to .run() or .serviceParams()
     const app = CreateApplication({
       configuration: bootOptions?.module_config ?? {},
+      // pass config sources from options; if loadConfigs is not set, all sources default to false
       configurationLoaders: bootOptions?.configSources,
       libraries: [
+        // map any replaced libraries; use the replacement if it exists in replaceLibrary map
         ...(is.empty(depends)
           ? []
           : depends.map(i => (replaceLibrary.has(i.name) ? replaceLibrary.get(i.name) : i))),
+        // include the target library to ensure its services and config are wired
         ...(testLibrary ? [testLibrary] : []),
       ],
       // @ts-expect-error it's life
       name,
+      // inject the test service so it receives TServiceParams at bootstrap time
       services: { test },
     });
 
@@ -226,43 +321,54 @@ export function TestRunner<S extends ServiceMap, C extends OptionalModuleConfigu
 
   const libraryTestRunner: iTestRunner<S, C> = {
     appendLibrary(library: TLibrary) {
+      // store the library for wiring during bootstrap
       appendLibraries.set(library.name, library);
       return libraryTestRunner;
     },
     appendService(service: ServiceFunction, name?: string) {
+      // use the service's own function name if no explicit name was provided
       if (is.empty(name) && !is.empty(service.name)) {
         name = service.name;
       }
+      // store the service for wiring; generate a UUID only if name is still empty
       appendServices.set(name || v4(), service);
       return libraryTestRunner;
     },
     bootLibrariesFirst() {
+      // set the flag to control library initialization order during bootstrap
       bootOptions.bootLibrariesFirst = true;
       return libraryTestRunner;
     },
     configure(configuration: PartialConfiguration) {
+      // deep-merge the configuration into existing boot options
       bootOptions = deepExtend(bootOptions, { configuration });
       return libraryTestRunner;
     },
     emitLogs(LOG_LEVEL: TConfigLogLevel) {
+      // enable logger output for debugging
       libraryTestRunner.setOptions({ emitLogs: true });
+      // only set log level if a specific level was provided
       if (!is.empty({ level: LOG_LEVEL })) {
         libraryTestRunner.configure({ boilerplate: { LOG_LEVEL } });
       }
       return libraryTestRunner;
     },
     replaceLibrary(name: string, library: TLibrary) {
+      // store the replacement; lookup happens during app construction
       replaceLibrary.set(name, library);
       return libraryTestRunner;
     },
     async run(test: ServiceFunction) {
+      // build the application with all configured libraries, services, and the test service
       const { app, LIB_RUN_FIRST } = buildApp(options?.name ?? "testing", options?.target, test);
+      // bootstrap the full application; all lifecycle stages fire here
       await app.bootstrap({
         appendLibrary: [...appendLibraries.values(), ...(LIB_RUN_FIRST ? [LIB_RUN_FIRST] : [])],
         appendService: Object.fromEntries(appendServices.entries()),
         bootLibrariesFirst: !!bootOptions?.bootLibrariesFirst,
         configSources: bootOptions?.configSources,
         configuration: bootOptions?.configuration,
+        // if logging is disabled, provide a no-op logger; otherwise use the provided custom logger or default
         customLogger: bootOptions?.emitLogs
           ? undefined
           : (bootOptions?.customLogger ?? {
@@ -276,21 +382,26 @@ export function TestRunner<S extends ServiceMap, C extends OptionalModuleConfigu
         loggerOptions: bootOptions?.loggerOptions,
       });
 
+      // capture the teardown function so callers can clean up after the test
       teardown = async () => await app.teardown();
       return app;
     },
     serviceParams() {
+      // wrap a service that returns its TServiceParams immediately; run() will inject them
       return new Promise<TServiceParams>(done => libraryTestRunner.run(done));
     },
     setOptions(options: TestingBootstrapOptions) {
+      // deep-merge bootstrap options; chained calls accumulate settings
       bootOptions = deepExtend(bootOptions, options);
       return libraryTestRunner;
     },
     setup(service: ServiceFunction) {
+      // register the service to run first; it will be added to LIB_RUN_FIRST during buildApp
       runFirst.add(service);
       return libraryTestRunner;
     },
     async teardown() {
+      // close all event listeners, cancel schedulers, and clean up async work
       if (teardown) {
         await teardown();
         teardown = undefined;

--- a/testing/configuration.spec.mts
+++ b/testing/configuration.spec.mts
@@ -359,6 +359,8 @@ describe("Configuration", () => {
         delete env["current_weather"];
         delete env["current_WEATHER"];
         delete env["CURRENT_WEATHER"];
+        delete env["testing__CURRENT_WEATHER"];
+        delete env["testing_CURRENT_WEATHER"];
       });
 
       it("should default properly if environment variables do not exist", async () => {
@@ -541,6 +543,48 @@ describe("Configuration", () => {
             lifecycle.onPostConfig(() => {
               // @ts-expect-error testing
               expect(config.testing.CURRENT_WEATHER).toBe("hail");
+            });
+          });
+      });
+
+      it("should resolve MODULE__KEY (double-underscore) env var", async () => {
+        expect.assertions(1);
+        env["testing__CURRENT_WEATHER"] = "sleet";
+        await TestRunner()
+          .setOptions({ loadConfigs: true })
+          .setOptions({
+            module_config: {
+              CURRENT_WEATHER: {
+                default: "raining",
+                type: "string",
+              },
+            },
+          })
+          .run(({ config, lifecycle }) => {
+            lifecycle.onPostConfig(() => {
+              // @ts-expect-error testing
+              expect(config.testing.CURRENT_WEATHER).toBe("sleet");
+            });
+          });
+      });
+
+      it("should resolve MODULE_KEY (single-underscore) env var", async () => {
+        expect.assertions(1);
+        env["testing_CURRENT_WEATHER"] = "fog";
+        await TestRunner()
+          .setOptions({ loadConfigs: true })
+          .setOptions({
+            module_config: {
+              CURRENT_WEATHER: {
+                default: "raining",
+                type: "string",
+              },
+            },
+          })
+          .run(({ config, lifecycle }) => {
+            lifecycle.onPostConfig(() => {
+              // @ts-expect-error testing
+              expect(config.testing.CURRENT_WEATHER).toBe("fog");
             });
           });
       });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "declaration": true,
     "noImplicitReturns": true,
     "noUnusedLocals": true,
+    "strictNullChecks": false,
     "noUnusedParameters": true,
     "rootDir": "./src",
     "skipDefaultLibCheck": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 9
   cacheKey: 10
 
 "@babel/helper-string-parser@npm:^7.27.1":
@@ -20,13 +20,13 @@ __metadata:
   linkType: hard
 
 "@babel/parser@npm:^7.29.0":
-  version: 7.29.0
-  resolution: "@babel/parser@npm:7.29.0"
+  version: 7.29.2
+  resolution: "@babel/parser@npm:7.29.2"
   dependencies:
     "@babel/types": "npm:^7.29.0"
   bin:
     parser: ./bin/babel-parser.js
-  checksum: 10/b1576dca41074997a33ee740d87b330ae2e647f4b7da9e8d2abd3772b18385d303b0cee962b9b88425e0f30d58358dbb8d63792c1a2d005c823d335f6a029747
+  checksum: 10/45d050bf75aa5194b3255f156173e8553d615ff5a2434674cc4a10cdc7c261931befb8618c996a1c449b87f0ef32a3407879af2ac967d95dc7b4fdbae7037efa
   languageName: node
   linkType: hard
 
@@ -630,51 +630,52 @@ __metadata:
   resolution: "@digital-alchemy/core@workspace:."
   dependencies:
     "@cspell/eslint-plugin": "npm:^10.0.0"
-    "@dotenvx/dotenvx": "npm:^1.51.4"
-    "@eslint/compat": "npm:^2.0.0"
-    "@eslint/eslintrc": "npm:^3.3.3"
-    "@eslint/js": "npm:^9.39.2"
-    "@faker-js/faker": "npm:^10.2.0"
+    "@dotenvx/dotenvx": "npm:^1.64.0"
+    "@eslint/compat": "npm:^2.0.5"
+    "@eslint/eslintrc": "npm:^3.3.5"
+    "@eslint/js": "npm:^10.0.1"
+    "@faker-js/faker": "npm:^10.4.0"
     "@types/ini": "npm:^4.1.1"
     "@types/js-yaml": "npm:^4.0.9"
     "@types/minimist": "npm:^1.2.5"
-    "@types/node": "npm:^25.0.3"
+    "@types/node": "npm:^25.6.0"
     "@types/sinonjs__fake-timers": "npm:^15.0.1"
-    "@typescript-eslint/eslint-plugin": "npm:8.58.2"
-    "@typescript-eslint/parser": "npm:8.58.2"
-    "@vitest/coverage-v8": "npm:^4.0.16"
+    "@typescript-eslint/eslint-plugin": "npm:8.59.1"
+    "@typescript-eslint/parser": "npm:8.59.1"
+    "@vitest/coverage-v8": "npm:^4.1.5"
     chalk: "npm:^5.6.2"
     cron: "npm:^4.4.0"
-    dayjs: "npm:^1.11.19"
+    dayjs: "npm:^1.11.20"
     eslint: "npm:10.2.1"
     eslint-config-prettier: "npm:10.1.8"
     eslint-plugin-import: "npm:^2.32.0"
-    eslint-plugin-jsonc: "npm:^2.21.0"
-    eslint-plugin-no-unsanitized: "npm:^4.1.4"
-    eslint-plugin-prettier: "npm:^5.5.4"
+    eslint-plugin-jsonc: "npm:^3.1.2"
+    eslint-plugin-no-unsanitized: "npm:^4.1.5"
+    eslint-plugin-prettier: "npm:^5.5.5"
     eslint-plugin-security: "npm:^4.0.0"
-    eslint-plugin-simple-import-sort: "npm:^12.1.1"
-    eslint-plugin-sonarjs: "npm:^4.0.0"
+    eslint-plugin-simple-import-sort: "npm:^13.0.0"
+    eslint-plugin-sonarjs: "npm:^4.0.3"
     eslint-plugin-sort-keys-fix: "npm:^1.1.2"
-    eslint-plugin-unicorn: "npm:^63.0.0"
+    eslint-plugin-unicorn: "npm:^64.0.0"
     ini: "npm:^6.0.0"
     js-yaml: "npm:^4.1.1"
     minimist: "npm:^1.2.8"
-    pino: "npm:^10.1.0"
+    npm-check-updates: "npm:^22.0.1"
+    pino: "npm:^10.3.1"
     pino-pretty: "npm:^13.1.3"
-    prettier: "npm:^3.7.4"
+    prettier: "npm:^3.8.3"
     tslib: "npm:^2.8.1"
     tsx: "npm:^4.21.0"
-    type-fest: "npm:^5.3.1"
-    typescript: "npm:^5.9.3"
-    uuid: "npm:^13.0.0"
-    vitest: "npm:^4.0.16"
+    type-fest: "npm:^5.6.0"
+    typescript: "npm:^6.0.3"
+    uuid: "npm:^14.0.0"
+    vitest: "npm:^4.1.5"
   languageName: unknown
   linkType: soft
 
-"@dotenvx/dotenvx@npm:^1.51.4":
-  version: 1.61.1
-  resolution: "@dotenvx/dotenvx@npm:1.61.1"
+"@dotenvx/dotenvx@npm:^1.64.0":
+  version: 1.64.0
+  resolution: "@dotenvx/dotenvx@npm:1.64.0"
   dependencies:
     commander: "npm:^11.1.0"
     dotenv: "npm:^17.2.1"
@@ -688,241 +689,230 @@ __metadata:
     yocto-spinner: "npm:^1.1.0"
   bin:
     dotenvx: src/cli/dotenvx.js
-  checksum: 10/8c80652da23b40e0186660262271ab3d4e2a0dd3d95d6528883b0944dc3bb8066a60a62fd004cf9832470d2e9f48094a1a5e81c23e69b7323a576ac533507237
+  checksum: 10/b3787cc4038f6909b62d19023767a0ca2e774875f006fa9b1543dd00efd1805f0be0e61a25113596da596d9b9d0eadaf0ee41e39bf9f78f79f40979985075e26
   languageName: node
   linkType: hard
 
-"@ecies/ciphers@npm:^0.2.4":
-  version: 0.2.4
-  resolution: "@ecies/ciphers@npm:0.2.4"
+"@ecies/ciphers@npm:^0.2.5":
+  version: 0.2.6
+  resolution: "@ecies/ciphers@npm:0.2.6"
   peerDependencies:
     "@noble/ciphers": ^1.0.0
-  checksum: 10/6300075ffce01765ad0ddcc26ed6150301cd448bc79b7a046cbd659c4bd6e3a05f207df2a09396cdf529bcc6ab921b26cb50483703c57f80f2d8898c369284f3
+  checksum: 10/48e98971161497b7b4a49f70e20e2b807096d477262cd86bff7b6aa7e065f7ca10e6199529f41207ab65f4486ad6689c158798cd3a0ba20b875df3c68bec6281
   languageName: node
   linkType: hard
 
-"@emnapi/core@npm:^1.7.1":
-  version: 1.9.0
-  resolution: "@emnapi/core@npm:1.9.0"
+"@emnapi/core@npm:1.10.0":
+  version: 1.10.0
+  resolution: "@emnapi/core@npm:1.10.0"
   dependencies:
-    "@emnapi/wasi-threads": "npm:1.2.0"
+    "@emnapi/wasi-threads": "npm:1.2.1"
     tslib: "npm:^2.4.0"
-  checksum: 10/52d8dc5ba0d6814c5061686b8286d84cc5349c8fc09de3a9c4175bc2369c2890b335f7b03e55bc19ce3033158962cd817522fcb3bdeb1feb9ba7a060d61b69ab
+  checksum: 10/d32f386084e64deaf2609aabb8295d1ad5af6144d0f46d2060b76cc53f1f3b486df54bec9b0f33c37d85a3822e1193ebcd4e3deb4a5f0e4cd650aa2ffc631715
   languageName: node
   linkType: hard
 
-"@emnapi/runtime@npm:^1.7.1":
-  version: 1.9.0
-  resolution: "@emnapi/runtime@npm:1.9.0"
-  dependencies:
-    tslib: "npm:^2.4.0"
-  checksum: 10/d04a7e67676c2560d5394a01d63532af943760cf19cc8f375390a345aeab2b19e9ee35485b06b5c211df18f947fb14ac50658fca5c4067946f1e50af3490b3b5
-  languageName: node
-  linkType: hard
-
-"@emnapi/wasi-threads@npm:1.2.0":
-  version: 1.2.0
-  resolution: "@emnapi/wasi-threads@npm:1.2.0"
+"@emnapi/runtime@npm:1.10.0":
+  version: 1.10.0
+  resolution: "@emnapi/runtime@npm:1.10.0"
   dependencies:
     tslib: "npm:^2.4.0"
-  checksum: 10/c8e48c7200530744dc58170d2e25933b61433e4a0c50b4f192f5d8d4b065c7023dbfc48dac0afadbc29bd239013f2ae454c6e54e0ca6e8248402bf95c9e77e22
+  checksum: 10/d21083d07fa0c2da171c142e78ef986b66b07d45b06accc0bcaf49fcc61bb4dbc10e1c1760813070165b9f49b054376a931045347f21c0f42ff1eb2d2040faac
   languageName: node
   linkType: hard
 
-"@esbuild/aix-ppc64@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/aix-ppc64@npm:0.27.1"
+"@emnapi/wasi-threads@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@emnapi/wasi-threads@npm:1.2.1"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10/57cd4292be81c05d26aa886d68a9e4c449ff666e8503fed6463dfc6b64a4e4213f03c152d53296b7cda32840271e38cd33347332070658f01befeb9bf4e59f36
+  languageName: node
+  linkType: hard
+
+"@esbuild/aix-ppc64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/aix-ppc64@npm:0.27.7"
   conditions: os=aix & cpu=ppc64
   languageName: node
   linkType: hard
 
-"@esbuild/android-arm64@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/android-arm64@npm:0.27.1"
+"@esbuild/android-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/android-arm64@npm:0.27.7"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/android-arm@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/android-arm@npm:0.27.1"
+"@esbuild/android-arm@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/android-arm@npm:0.27.7"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
 
-"@esbuild/android-x64@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/android-x64@npm:0.27.1"
+"@esbuild/android-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/android-x64@npm:0.27.7"
   conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/darwin-arm64@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/darwin-arm64@npm:0.27.1"
+"@esbuild/darwin-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/darwin-arm64@npm:0.27.7"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/darwin-x64@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/darwin-x64@npm:0.27.1"
+"@esbuild/darwin-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/darwin-x64@npm:0.27.7"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/freebsd-arm64@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/freebsd-arm64@npm:0.27.1"
+"@esbuild/freebsd-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/freebsd-arm64@npm:0.27.7"
   conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/freebsd-x64@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/freebsd-x64@npm:0.27.1"
+"@esbuild/freebsd-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/freebsd-x64@npm:0.27.7"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/linux-arm64@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/linux-arm64@npm:0.27.1"
+"@esbuild/linux-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-arm64@npm:0.27.7"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/linux-arm@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/linux-arm@npm:0.27.1"
+"@esbuild/linux-arm@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-arm@npm:0.27.7"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@esbuild/linux-ia32@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/linux-ia32@npm:0.27.1"
+"@esbuild/linux-ia32@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-ia32@npm:0.27.7"
   conditions: os=linux & cpu=ia32
   languageName: node
   linkType: hard
 
-"@esbuild/linux-loong64@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/linux-loong64@npm:0.27.1"
+"@esbuild/linux-loong64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-loong64@npm:0.27.7"
   conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
 
-"@esbuild/linux-mips64el@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/linux-mips64el@npm:0.27.1"
+"@esbuild/linux-mips64el@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-mips64el@npm:0.27.7"
   conditions: os=linux & cpu=mips64el
   languageName: node
   linkType: hard
 
-"@esbuild/linux-ppc64@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/linux-ppc64@npm:0.27.1"
+"@esbuild/linux-ppc64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-ppc64@npm:0.27.7"
   conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
 
-"@esbuild/linux-riscv64@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/linux-riscv64@npm:0.27.1"
+"@esbuild/linux-riscv64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-riscv64@npm:0.27.7"
   conditions: os=linux & cpu=riscv64
   languageName: node
   linkType: hard
 
-"@esbuild/linux-s390x@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/linux-s390x@npm:0.27.1"
+"@esbuild/linux-s390x@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-s390x@npm:0.27.7"
   conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
 
-"@esbuild/linux-x64@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/linux-x64@npm:0.27.1"
+"@esbuild/linux-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/linux-x64@npm:0.27.7"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/netbsd-arm64@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/netbsd-arm64@npm:0.27.1"
+"@esbuild/netbsd-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/netbsd-arm64@npm:0.27.7"
   conditions: os=netbsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/netbsd-x64@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/netbsd-x64@npm:0.27.1"
+"@esbuild/netbsd-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/netbsd-x64@npm:0.27.7"
   conditions: os=netbsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/openbsd-arm64@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/openbsd-arm64@npm:0.27.1"
+"@esbuild/openbsd-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/openbsd-arm64@npm:0.27.7"
   conditions: os=openbsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/openbsd-x64@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/openbsd-x64@npm:0.27.1"
+"@esbuild/openbsd-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/openbsd-x64@npm:0.27.7"
   conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/openharmony-arm64@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/openharmony-arm64@npm:0.27.1"
+"@esbuild/openharmony-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/openharmony-arm64@npm:0.27.7"
   conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/sunos-x64@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/sunos-x64@npm:0.27.1"
+"@esbuild/sunos-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/sunos-x64@npm:0.27.7"
   conditions: os=sunos & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/win32-arm64@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/win32-arm64@npm:0.27.1"
+"@esbuild/win32-arm64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/win32-arm64@npm:0.27.7"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/win32-ia32@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/win32-ia32@npm:0.27.1"
+"@esbuild/win32-ia32@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/win32-ia32@npm:0.27.7"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@esbuild/win32-x64@npm:0.27.1":
-  version: 0.27.1
-  resolution: "@esbuild/win32-x64@npm:0.27.1"
+"@esbuild/win32-x64@npm:0.27.7":
+  version: 0.27.7
+  resolution: "@esbuild/win32-x64@npm:0.27.7"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@eslint-community/eslint-utils@npm:^4.5.1, @eslint-community/eslint-utils@npm:^4.8.0, @eslint-community/eslint-utils@npm:^4.9.0":
-  version: 4.9.0
-  resolution: "@eslint-community/eslint-utils@npm:4.9.0"
-  dependencies:
-    eslint-visitor-keys: "npm:^3.4.3"
-  peerDependencies:
-    eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-  checksum: 10/89b1eb3137e14c379865e60573f524fcc0ee5c4b0c7cd21090673e75e5a720f14b92f05ab2d02704c2314b67e67b6f96f3bb209ded6b890ced7b667aa4bf1fa2
-  languageName: node
-  linkType: hard
-
-"@eslint-community/eslint-utils@npm:^4.9.1":
+"@eslint-community/eslint-utils@npm:^4.5.1, @eslint-community/eslint-utils@npm:^4.8.0, @eslint-community/eslint-utils@npm:^4.9.1":
   version: 4.9.1
   resolution: "@eslint-community/eslint-utils@npm:4.9.1"
   dependencies:
@@ -940,7 +930,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/compat@npm:^2.0.0":
+"@eslint/compat@npm:^2.0.5":
   version: 2.0.5
   resolution: "@eslint/compat@npm:2.0.5"
   dependencies:
@@ -974,7 +964,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/core@npm:^1.2.1":
+"@eslint/core@npm:^1.0.1, @eslint/core@npm:^1.1.1, @eslint/core@npm:^1.2.1":
   version: 1.2.1
   resolution: "@eslint/core@npm:1.2.1"
   dependencies:
@@ -983,7 +973,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/eslintrc@npm:^3.3.3":
+"@eslint/eslintrc@npm:^3.3.5":
   version: 3.3.5
   resolution: "@eslint/eslintrc@npm:3.3.5"
   dependencies:
@@ -1000,10 +990,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/js@npm:^9.39.2":
-  version: 9.39.2
-  resolution: "@eslint/js@npm:9.39.2"
-  checksum: 10/6b7f676746f3111b5d1b23715319212ab9297868a0fa9980d483c3da8965d5841673aada2d5653e85a3f7156edee0893a7ae7035211b4efdcb2848154bb947f2
+"@eslint/js@npm:^10.0.1":
+  version: 10.0.1
+  resolution: "@eslint/js@npm:10.0.1"
+  peerDependencies:
+    eslint: ^10.0.0
+  peerDependenciesMeta:
+    eslint:
+      optional: true
+  checksum: 10/27ff77b8f0aab350b2f7a69d974eabb816bb9f4cab986b1538782269d6bfdc29e351803fa7a62c22c0b786341324f1a28b86bc83956ddfa189aa6bead1a87758
   languageName: node
   linkType: hard
 
@@ -1011,6 +1006,16 @@ __metadata:
   version: 3.0.5
   resolution: "@eslint/object-schema@npm:3.0.5"
   checksum: 10/42e9ec2551d7cafe1825f20494576c9a867dfd26e728b66620f55d954cd5c4c9c4987755d147893985b8d39b49dace31117e59e7bc9564eb411b397e579a50e7
+  languageName: node
+  linkType: hard
+
+"@eslint/plugin-kit@npm:^0.6.0":
+  version: 0.6.1
+  resolution: "@eslint/plugin-kit@npm:0.6.1"
+  dependencies:
+    "@eslint/core": "npm:^1.1.1"
+    levn: "npm:^0.4.1"
+  checksum: 10/8af22d94720b2474a992a80c5be7584baf75821386d25c34966b359fbc1e3a319989df721404c48c08b20e115683d6d0b344793dc354f5916c2d867c6c0aa04e
   languageName: node
   linkType: hard
 
@@ -1024,27 +1029,37 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@faker-js/faker@npm:^10.2.0":
+"@faker-js/faker@npm:^10.4.0":
   version: 10.4.0
   resolution: "@faker-js/faker@npm:10.4.0"
   checksum: 10/3eaaa501435584f8164cfdaac8cd666abe6186eaccb171592f559d942211f01cba60d00616307fbcf980cb8d19512b2b8c9e926e7472fc93df580d18483f8f17
   languageName: node
   linkType: hard
 
-"@humanfs/core@npm:^0.19.1":
-  version: 0.19.1
-  resolution: "@humanfs/core@npm:0.19.1"
-  checksum: 10/270d936be483ab5921702623bc74ce394bf12abbf57d9145a69e8a0d1c87eb1c768bd2d93af16c5705041e257e6d9cc7529311f63a1349f3678abc776fc28523
+"@humanfs/core@npm:^0.19.2":
+  version: 0.19.2
+  resolution: "@humanfs/core@npm:0.19.2"
+  dependencies:
+    "@humanfs/types": "npm:^0.15.0"
+  checksum: 10/c6c0273721ec8df3d36a57c390a11a168d0a2f513d78bceb25165bded4fcb73609b1a317edc6c8f331cefd4b47285dde0b1e6679e08ef7f062232ec14fe05312
   languageName: node
   linkType: hard
 
 "@humanfs/node@npm:^0.16.6":
-  version: 0.16.7
-  resolution: "@humanfs/node@npm:0.16.7"
+  version: 0.16.8
+  resolution: "@humanfs/node@npm:0.16.8"
   dependencies:
-    "@humanfs/core": "npm:^0.19.1"
+    "@humanfs/core": "npm:^0.19.2"
+    "@humanfs/types": "npm:^0.15.0"
     "@humanwhocodes/retry": "npm:^0.4.0"
-  checksum: 10/b3633d3dce898592cac515ba5e6693c78e6be92863541d3eaf2c009b10f52b2fa62ff6e6e06f240f2447ddbe7b5f1890bc34e9308470675c876eee207553a08d
+  checksum: 10/ed01b3c066d9cec7526d139b9e71ca00ee4a30b3b5f5f5c198eb069c3509a3e167e180ba7e1e5a83b9571e906c4908bd20402b47586887452311af7354995e95
+  languageName: node
+  linkType: hard
+
+"@humanfs/types@npm:^0.15.0":
+  version: 0.15.0
+  resolution: "@humanfs/types@npm:0.15.0"
+  checksum: 10/dea3cc7fd8f8d4d088ed8d0a9921cf12bd8e1cdf40a6133106b03a6e2aebcc9a6f1771b3643b7ec71baae90d08245db34069dfcc861da8d678662741e6c3c986
   languageName: node
   linkType: hard
 
@@ -1059,20 +1074,6 @@ __metadata:
   version: 0.4.3
   resolution: "@humanwhocodes/retry@npm:0.4.3"
   checksum: 10/0b32cfd362bea7a30fbf80bb38dcaf77fee9c2cae477ee80b460871d03590110ac9c77d654f04ec5beaf71b6f6a89851bdf6c1e34ccdf2f686bd86fcd97d9e61
-  languageName: node
-  linkType: hard
-
-"@isaacs/cliui@npm:^8.0.2":
-  version: 8.0.2
-  resolution: "@isaacs/cliui@npm:8.0.2"
-  dependencies:
-    string-width: "npm:^5.1.2"
-    string-width-cjs: "npm:string-width@^4.2.0"
-    strip-ansi: "npm:^7.0.1"
-    strip-ansi-cjs: "npm:strip-ansi@^6.0.1"
-    wrap-ansi: "npm:^8.1.0"
-    wrap-ansi-cjs: "npm:wrap-ansi@^7.0.0"
-  checksum: 10/e9ed5fd27c3aec1095e3a16e0c0cf148d1fee55a38665c35f7b3f86a9b5d00d042ddaabc98e8a1cb7463b9378c15f22a94eb35e99469c201453eb8375191f243
   languageName: node
   linkType: hard
 
@@ -1109,14 +1110,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@napi-rs/wasm-runtime@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "@napi-rs/wasm-runtime@npm:1.1.1"
+"@napi-rs/wasm-runtime@npm:^1.1.4":
+  version: 1.1.4
+  resolution: "@napi-rs/wasm-runtime@npm:1.1.4"
   dependencies:
-    "@emnapi/core": "npm:^1.7.1"
-    "@emnapi/runtime": "npm:^1.7.1"
     "@tybys/wasm-util": "npm:^0.10.1"
-  checksum: 10/080e7f2aefb84e09884d21c650a2cbafdf25bfd2634693791b27e36eec0ddaa3c1656a943f8c913ac75879a0b04e68f8a827897ee655ab54a93169accf05b194
+  peerDependencies:
+    "@emnapi/core": ^1.7.1
+    "@emnapi/runtime": ^1.7.1
+  checksum: 10/1db3dc7eeb981306b09360487bd8ce4dfa5588d273bd8ea9f07dccca1b4ade57b675414180fc9bb66966c6c50b17208b0263194993e2f7f92cc7af28bda4d1af
   languageName: node
   linkType: hard
 
@@ -1143,32 +1145,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@npmcli/agent@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@npmcli/agent@npm:3.0.0"
-  dependencies:
-    agent-base: "npm:^7.1.0"
-    http-proxy-agent: "npm:^7.0.0"
-    https-proxy-agent: "npm:^7.0.1"
-    lru-cache: "npm:^10.0.1"
-    socks-proxy-agent: "npm:^8.0.3"
-  checksum: 10/775c9a7eb1f88c195dfb3bce70c31d0fe2a12b28b754e25c08a3edb4bc4816bfedb7ac64ef1e730579d078ca19dacf11630e99f8f3c3e0fd7b23caa5fd6d30a6
+"@ota-meshi/ast-token-store@npm:^0.3.0":
+  version: 0.3.0
+  resolution: "@ota-meshi/ast-token-store@npm:0.3.0"
+  checksum: 10/665a16eb4ecb0595a88a07301e702336250cd1150fdd02516986fd6853524a36814a04a7934a41025d71c372556d372780dccfbfe56617cedf6b540584965533
   languageName: node
   linkType: hard
 
-"@npmcli/fs@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@npmcli/fs@npm:4.0.0"
-  dependencies:
-    semver: "npm:^7.3.5"
-  checksum: 10/405c4490e1ff11cf299775449a3c254a366a4b1ffc79d87159b0ee7d5558ac9f6a2f8c0735fd6ff3873cef014cb1a44a5f9127cb6a1b2dbc408718cca9365b5a
-  languageName: node
-  linkType: hard
-
-"@oxc-project/types@npm:=0.122.0":
-  version: 0.122.0
-  resolution: "@oxc-project/types@npm:0.122.0"
-  checksum: 10/2b33895c7701a595d10b9c7b0927222954becc4c6cbde7a7b582e9524828937368baacba1cbb6e3c33bc9a18e0a35435ffff6c53f511762ae872d55d3e993a8c
+"@oxc-project/types@npm:=0.127.0":
+  version: 0.127.0
+  resolution: "@oxc-project/types@npm:0.127.0"
+  checksum: 10/f154f4720367186aed63a16fb1395f9039d4e6872265fe9e6b5eacc02fb2b948f9ea6c5f85efd3a015ea28aa8c31232b7a8301218ae28651659e46dd0c4f2031
   languageName: node
   linkType: hard
 
@@ -1179,13 +1166,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pkgjs/parseargs@npm:^0.11.0":
-  version: 0.11.0
-  resolution: "@pkgjs/parseargs@npm:0.11.0"
-  checksum: 10/115e8ceeec6bc69dff2048b35c0ab4f8bbee12d8bb6c1f4af758604586d802b6e669dcb02dda61d078de42c2b4ddce41b3d9e726d7daa6b4b850f4adbf7333ff
-  languageName: node
-  linkType: hard
-
 "@pkgr/core@npm:^0.2.9":
   version: 0.2.9
   resolution: "@pkgr/core@npm:0.2.9"
@@ -1193,117 +1173,119 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-android-arm64@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-android-arm64@npm:1.0.0-rc.12"
+"@rolldown/binding-android-arm64@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-android-arm64@npm:1.0.0-rc.17"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rolldown/binding-darwin-arm64@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-darwin-arm64@npm:1.0.0-rc.12"
+"@rolldown/binding-darwin-arm64@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-darwin-arm64@npm:1.0.0-rc.17"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rolldown/binding-darwin-x64@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-darwin-x64@npm:1.0.0-rc.12"
+"@rolldown/binding-darwin-x64@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-darwin-x64@npm:1.0.0-rc.17"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@rolldown/binding-freebsd-x64@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-freebsd-x64@npm:1.0.0-rc.12"
+"@rolldown/binding-freebsd-x64@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-freebsd-x64@npm:1.0.0-rc.17"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-rc.12"
+"@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-rc.17"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-arm64-gnu@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.0.0-rc.12"
+"@rolldown/binding-linux-arm64-gnu@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.0.0-rc.17"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-arm64-musl@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.0.0-rc.12"
+"@rolldown/binding-linux-arm64-musl@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.0.0-rc.17"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-ppc64-gnu@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-linux-ppc64-gnu@npm:1.0.0-rc.12"
+"@rolldown/binding-linux-ppc64-gnu@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-linux-ppc64-gnu@npm:1.0.0-rc.17"
   conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-s390x-gnu@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.0.0-rc.12"
+"@rolldown/binding-linux-s390x-gnu@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.0.0-rc.17"
   conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-x64-gnu@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.0.0-rc.12"
+"@rolldown/binding-linux-x64-gnu@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.0.0-rc.17"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-x64-musl@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-linux-x64-musl@npm:1.0.0-rc.12"
+"@rolldown/binding-linux-x64-musl@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-linux-x64-musl@npm:1.0.0-rc.17"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rolldown/binding-openharmony-arm64@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-openharmony-arm64@npm:1.0.0-rc.12"
+"@rolldown/binding-openharmony-arm64@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-openharmony-arm64@npm:1.0.0-rc.17"
   conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rolldown/binding-wasm32-wasi@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-wasm32-wasi@npm:1.0.0-rc.12"
+"@rolldown/binding-wasm32-wasi@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-wasm32-wasi@npm:1.0.0-rc.17"
   dependencies:
-    "@napi-rs/wasm-runtime": "npm:^1.1.1"
+    "@emnapi/core": "npm:1.10.0"
+    "@emnapi/runtime": "npm:1.10.0"
+    "@napi-rs/wasm-runtime": "npm:^1.1.4"
   conditions: cpu=wasm32
   languageName: node
   linkType: hard
 
-"@rolldown/binding-win32-arm64-msvc@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.0.0-rc.12"
+"@rolldown/binding-win32-arm64-msvc@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.0.0-rc.17"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rolldown/binding-win32-x64-msvc@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.0.0-rc.12"
+"@rolldown/binding-win32-x64-msvc@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.0.0-rc.17"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@rolldown/pluginutils@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "@rolldown/pluginutils@npm:1.0.0-rc.12"
-  checksum: 10/6ce1601849b3095a2b6e57074c1f8a661eba67ebf65cf9afdf894d903302318247ddb69ab6cbc621e7f582408af301ea0523ed59ddb9a4ef3ea97f3d7002683e
+"@rolldown/pluginutils@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "@rolldown/pluginutils@npm:1.0.0-rc.17"
+  checksum: 10/d659ea756ee6d360a015708d1035c07047e08db99a4160c74c7f22a7ece5611efcc18ad56db4a63b69edb506ded47596d9c0d301919242470d8c412d916b9750
   languageName: node
   linkType: hard
 
@@ -1403,7 +1385,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^25.0.3":
+"@types/node@npm:^25.6.0":
   version: 25.6.0
   resolution: "@types/node@npm:25.6.0"
   dependencies:
@@ -1419,105 +1401,105 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:8.58.2":
-  version: 8.58.2
-  resolution: "@typescript-eslint/eslint-plugin@npm:8.58.2"
+"@typescript-eslint/eslint-plugin@npm:8.59.1":
+  version: 8.59.1
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.59.1"
   dependencies:
     "@eslint-community/regexpp": "npm:^4.12.2"
-    "@typescript-eslint/scope-manager": "npm:8.58.2"
-    "@typescript-eslint/type-utils": "npm:8.58.2"
-    "@typescript-eslint/utils": "npm:8.58.2"
-    "@typescript-eslint/visitor-keys": "npm:8.58.2"
+    "@typescript-eslint/scope-manager": "npm:8.59.1"
+    "@typescript-eslint/type-utils": "npm:8.59.1"
+    "@typescript-eslint/utils": "npm:8.59.1"
+    "@typescript-eslint/visitor-keys": "npm:8.59.1"
     ignore: "npm:^7.0.5"
     natural-compare: "npm:^1.4.0"
     ts-api-utils: "npm:^2.5.0"
   peerDependencies:
-    "@typescript-eslint/parser": ^8.58.2
+    "@typescript-eslint/parser": ^8.59.1
     eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10/e17da9302a66c405d6f7ca33409b177535933b96b9548825c0c66368813b21aeff9550348234ea1b882427fbdc246e5032fbe655cea6bc71aa688417f988c934
+  checksum: 10/c736ee32211a3751e31151b51dacc8cfa5bf18e086f2a87aba7ee325f7e2fa96d8b9febdbaf4dfa70d14954312b7b9740fbe5d5886b3f8561c4a94a9c7ff7688
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:8.58.2":
-  version: 8.58.2
-  resolution: "@typescript-eslint/parser@npm:8.58.2"
+"@typescript-eslint/parser@npm:8.59.1":
+  version: 8.59.1
+  resolution: "@typescript-eslint/parser@npm:8.59.1"
   dependencies:
-    "@typescript-eslint/scope-manager": "npm:8.58.2"
-    "@typescript-eslint/types": "npm:8.58.2"
-    "@typescript-eslint/typescript-estree": "npm:8.58.2"
-    "@typescript-eslint/visitor-keys": "npm:8.58.2"
+    "@typescript-eslint/scope-manager": "npm:8.59.1"
+    "@typescript-eslint/types": "npm:8.59.1"
+    "@typescript-eslint/typescript-estree": "npm:8.59.1"
+    "@typescript-eslint/visitor-keys": "npm:8.59.1"
     debug: "npm:^4.4.3"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10/276da6985cd531615d99a1875d87e2d619adbc6377577849c4f3abc4402a7101dea35b7666019c0e83f3346cace002448668e4a4ebe35734d504d48689a7e836
+  checksum: 10/b014b485e5ec9c7430a87117271836b86fd80083fe6b1d216167313518f26222f45c0ee3f4cbc0616dbd6335cbde50336d8953ca5ffefecc55b2d896ac7645f9
   languageName: node
   linkType: hard
 
-"@typescript-eslint/project-service@npm:8.58.2":
-  version: 8.58.2
-  resolution: "@typescript-eslint/project-service@npm:8.58.2"
+"@typescript-eslint/project-service@npm:8.59.1":
+  version: 8.59.1
+  resolution: "@typescript-eslint/project-service@npm:8.59.1"
   dependencies:
-    "@typescript-eslint/tsconfig-utils": "npm:^8.58.2"
-    "@typescript-eslint/types": "npm:^8.58.2"
+    "@typescript-eslint/tsconfig-utils": "npm:^8.59.1"
+    "@typescript-eslint/types": "npm:^8.59.1"
     debug: "npm:^4.4.3"
   peerDependencies:
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10/fcaf2b17aa0476164a53626b2754ab01ca595e913828699276972dcafe6369dd31cb7ce73cd32b8f4dd9209a7bf480c51b87266d0c434adb27a462e24e7940af
+  checksum: 10/dd98f49a407cb21999d31ec527a0f8c2c34422dde9fdb21210d66c3cc3d498d9d3678d95c99d76450af68ce3392692902d9ba044718d6c99122655df7afdc0a7
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:8.58.2":
-  version: 8.58.2
-  resolution: "@typescript-eslint/scope-manager@npm:8.58.2"
+"@typescript-eslint/scope-manager@npm:8.59.1":
+  version: 8.59.1
+  resolution: "@typescript-eslint/scope-manager@npm:8.59.1"
   dependencies:
-    "@typescript-eslint/types": "npm:8.58.2"
-    "@typescript-eslint/visitor-keys": "npm:8.58.2"
-  checksum: 10/d38da7a1d6e9d8ec87eb0d5115e3978ebe33fa5cb0f5b9b1c202ab314ebf352d33c66b0070ab3244ff79beec8fff19ec9e4063c36288ec0bc66fd24508d2b264
+    "@typescript-eslint/types": "npm:8.59.1"
+    "@typescript-eslint/visitor-keys": "npm:8.59.1"
+  checksum: 10/50c941d1af470d3e67a9bd2247c541a676ae6bb2931440a44458682d61382ba1194ce29d0388dd1e538c5a35d7a542febd9519d8170abe758692d1b6cd196eab
   languageName: node
   linkType: hard
 
-"@typescript-eslint/tsconfig-utils@npm:8.58.2, @typescript-eslint/tsconfig-utils@npm:^8.58.2":
-  version: 8.58.2
-  resolution: "@typescript-eslint/tsconfig-utils@npm:8.58.2"
+"@typescript-eslint/tsconfig-utils@npm:8.59.1, @typescript-eslint/tsconfig-utils@npm:^8.59.1":
+  version: 8.59.1
+  resolution: "@typescript-eslint/tsconfig-utils@npm:8.59.1"
   peerDependencies:
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10/68d40f96150dba33ccb9aa5a1531cc0fb4c413ed6665a3d2b1651437ea162d1a3c9dc0c3dc8208e48f9eddcf51f35fa9880b18f9a03397bbafcbec8dae9391c9
+  checksum: 10/9e3351bb182bb02f6f140759472f08ce334c7c96f4ebfeec8e9e404fe60b8fe1865e1a6d1b50526f83f41e7224301485e46459df6c3675923f3b657177415cd7
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:8.58.2":
-  version: 8.58.2
-  resolution: "@typescript-eslint/type-utils@npm:8.58.2"
+"@typescript-eslint/type-utils@npm:8.59.1":
+  version: 8.59.1
+  resolution: "@typescript-eslint/type-utils@npm:8.59.1"
   dependencies:
-    "@typescript-eslint/types": "npm:8.58.2"
-    "@typescript-eslint/typescript-estree": "npm:8.58.2"
-    "@typescript-eslint/utils": "npm:8.58.2"
+    "@typescript-eslint/types": "npm:8.59.1"
+    "@typescript-eslint/typescript-estree": "npm:8.59.1"
+    "@typescript-eslint/utils": "npm:8.59.1"
     debug: "npm:^4.4.3"
     ts-api-utils: "npm:^2.5.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10/82eefae7f5d15cd6545deeb702ba36214903e833e58b6f460880fb3f606e1adc5eee90f55c7f0e9cb50575d17dd7c96a92e8d3e796893dd373908d8604623774
+  checksum: 10/8a8a71656f8fab446024e55b24f6f6c4b3ee4d4cdcb593ff68ec0ca10530fcb4d451628c03898c929e91445a999cbe980c0cfaec1b53a7c5ddc8ac899ad665fa
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.58.2, @typescript-eslint/types@npm:^8.58.2":
-  version: 8.58.2
-  resolution: "@typescript-eslint/types@npm:8.58.2"
-  checksum: 10/9ffbe0542c91442c9841e157b85bc7bdc7e9a3f5ad5e6ef32f8d98556bc947f9b4151e54dec414c2c6d68eb436483259e74decd8fe56330689298980949ba5cc
+"@typescript-eslint/types@npm:8.59.1, @typescript-eslint/types@npm:^8.59.1":
+  version: 8.59.1
+  resolution: "@typescript-eslint/types@npm:8.59.1"
+  checksum: 10/4d324a01c2314d8e196b43b9dc5fe9a4d82c1b65f4915cd2f965879c5565d4453603b6f7b6bcdc436fb629135f07ad0f9d274e4697b02ce8bc1c0310916f7ace
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:8.58.2":
-  version: 8.58.2
-  resolution: "@typescript-eslint/typescript-estree@npm:8.58.2"
+"@typescript-eslint/typescript-estree@npm:8.59.1":
+  version: 8.59.1
+  resolution: "@typescript-eslint/typescript-estree@npm:8.59.1"
   dependencies:
-    "@typescript-eslint/project-service": "npm:8.58.2"
-    "@typescript-eslint/tsconfig-utils": "npm:8.58.2"
-    "@typescript-eslint/types": "npm:8.58.2"
-    "@typescript-eslint/visitor-keys": "npm:8.58.2"
+    "@typescript-eslint/project-service": "npm:8.59.1"
+    "@typescript-eslint/tsconfig-utils": "npm:8.59.1"
+    "@typescript-eslint/types": "npm:8.59.1"
+    "@typescript-eslint/visitor-keys": "npm:8.59.1"
     debug: "npm:^4.4.3"
     minimatch: "npm:^10.2.2"
     semver: "npm:^7.7.3"
@@ -1525,41 +1507,41 @@ __metadata:
     ts-api-utils: "npm:^2.5.0"
   peerDependencies:
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10/e34bfcd426045d75f91b951ed35f3f880b209434d3574c44d3aac210a16e84e4489e43d4c7b8b552b7cd44862bd58c2f411ede7b40efa5f14ede835bb3e6d3c9
+  checksum: 10/8ede99640ac8b08ac73905bbc66dd06b2c4dc211240a4a9cb532b0fcf5c36ec9e7639ed7e1c17f86a948499279ff93e9dbcdf9170661d9f8347fcb53e8266772
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.58.2":
-  version: 8.58.2
-  resolution: "@typescript-eslint/utils@npm:8.58.2"
+"@typescript-eslint/utils@npm:8.59.1":
+  version: 8.59.1
+  resolution: "@typescript-eslint/utils@npm:8.59.1"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.9.1"
-    "@typescript-eslint/scope-manager": "npm:8.58.2"
-    "@typescript-eslint/types": "npm:8.58.2"
-    "@typescript-eslint/typescript-estree": "npm:8.58.2"
+    "@typescript-eslint/scope-manager": "npm:8.59.1"
+    "@typescript-eslint/types": "npm:8.59.1"
+    "@typescript-eslint/typescript-estree": "npm:8.59.1"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10/b46e6cddf2de96618b98c2635836512c7dc63217b874698b2ed079a41762b1c3c8edae4b15690e0b0c7b896e81d39617835a19bfbe03fe4176ddded49cf813d3
+  checksum: 10/26ae39a574e56d92b6fc406113e797c354fce8b377721cc5dd50579a0e9f8c3efe23c7693826ce2c16be96490520dd6ce7e145c4c39c22d8d00f2614791603ba
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:8.58.2":
-  version: 8.58.2
-  resolution: "@typescript-eslint/visitor-keys@npm:8.58.2"
+"@typescript-eslint/visitor-keys@npm:8.59.1":
+  version: 8.59.1
+  resolution: "@typescript-eslint/visitor-keys@npm:8.59.1"
   dependencies:
-    "@typescript-eslint/types": "npm:8.58.2"
+    "@typescript-eslint/types": "npm:8.59.1"
     eslint-visitor-keys: "npm:^5.0.0"
-  checksum: 10/051dd3d3507d4b36b5ead6acd3a00813b0775405cb074ad8fb4eb951b6c7a007a6f45c57b90ffab7755b8b7636e6f9a23b787221880db174584eca0739a0a9ab
+  checksum: 10/5343f3424cafdcaf2550fade29eca6b86ad3f6ac953aef6ba1dccd39789a1c38520634fbbc0814419d9227f508789053c1c9f59c2841d72e56431c3fdd93ac65
   languageName: node
   linkType: hard
 
-"@vitest/coverage-v8@npm:^4.0.16":
-  version: 4.1.4
-  resolution: "@vitest/coverage-v8@npm:4.1.4"
+"@vitest/coverage-v8@npm:^4.1.5":
+  version: 4.1.5
+  resolution: "@vitest/coverage-v8@npm:4.1.5"
   dependencies:
     "@bcoe/v8-coverage": "npm:^1.0.2"
-    "@vitest/utils": "npm:4.1.4"
+    "@vitest/utils": "npm:4.1.5"
     ast-v8-to-istanbul: "npm:^1.0.0"
     istanbul-lib-coverage: "npm:^3.2.2"
     istanbul-lib-report: "npm:^3.0.1"
@@ -1569,34 +1551,34 @@ __metadata:
     std-env: "npm:^4.0.0-rc.1"
     tinyrainbow: "npm:^3.1.0"
   peerDependencies:
-    "@vitest/browser": 4.1.4
-    vitest: 4.1.4
+    "@vitest/browser": 4.1.5
+    vitest: 4.1.5
   peerDependenciesMeta:
     "@vitest/browser":
       optional: true
-  checksum: 10/75c7bfa08d4a410dce09688a7bb1c06b782f90b785a51aea424806621dc90ce21663cf2e8f6f28e3c3c1be708932c5274408cd7cfda51e39dd3e0ae523cca133
+  checksum: 10/378e1d85a1c4670af15a18b544995a43d320460b418c188d7000f96518859e4537e00ea5e38a563c42b6183437252f0ecc92b471ede30c6d43ae87b7c8e09ed3
   languageName: node
   linkType: hard
 
-"@vitest/expect@npm:4.1.4":
-  version: 4.1.4
-  resolution: "@vitest/expect@npm:4.1.4"
+"@vitest/expect@npm:4.1.5":
+  version: 4.1.5
+  resolution: "@vitest/expect@npm:4.1.5"
   dependencies:
     "@standard-schema/spec": "npm:^1.1.0"
     "@types/chai": "npm:^5.2.2"
-    "@vitest/spy": "npm:4.1.4"
-    "@vitest/utils": "npm:4.1.4"
+    "@vitest/spy": "npm:4.1.5"
+    "@vitest/utils": "npm:4.1.5"
     chai: "npm:^6.2.2"
     tinyrainbow: "npm:^3.1.0"
-  checksum: 10/3317bc42e4ee39cfa2102a9f08f0c7975817a74d9503a14e0b1715e5b8c4ab31c5646c07ef8d2d3f71bdf6f1b3053949b175df9c8457e0c0bb3f38b9e031f259
+  checksum: 10/3e94d2d0cf4f7018ed6a7a9394bff971353ea0cc85bcbcff39212279156840b8c533be99e2fd52112e4904c4a5190bdaaf441db7c6b17e356c18577072a3f057
   languageName: node
   linkType: hard
 
-"@vitest/mocker@npm:4.1.4":
-  version: 4.1.4
-  resolution: "@vitest/mocker@npm:4.1.4"
+"@vitest/mocker@npm:4.1.5":
+  version: 4.1.5
+  resolution: "@vitest/mocker@npm:4.1.5"
   dependencies:
-    "@vitest/spy": "npm:4.1.4"
+    "@vitest/spy": "npm:4.1.5"
     estree-walker: "npm:^3.0.3"
     magic-string: "npm:^0.30.21"
   peerDependencies:
@@ -1607,63 +1589,63 @@ __metadata:
       optional: true
     vite:
       optional: true
-  checksum: 10/f07f8877635eb03f63981d0d3348bb82fabe7607bbb6b259045bf0b64fae79150b1f399aa7ce42926e4769dc8cde9b7d79d1f665eae2d17b22ecc9ec54663698
+  checksum: 10/949784ba08996543a313459a36a730d4b0847e42ee56cfda07a3e2add67c7adf8acbd59dcf9f75b1e4bc3fe7cc487f9f260905ff9a334866d389478112e5ae82
   languageName: node
   linkType: hard
 
-"@vitest/pretty-format@npm:4.1.4":
-  version: 4.1.4
-  resolution: "@vitest/pretty-format@npm:4.1.4"
+"@vitest/pretty-format@npm:4.1.5":
+  version: 4.1.5
+  resolution: "@vitest/pretty-format@npm:4.1.5"
   dependencies:
     tinyrainbow: "npm:^3.1.0"
-  checksum: 10/e06d63ce4f797ad578ee19aeec996f72835a7274ee2eb75dce12d7b45debcda72d054f58b6f4e5dac4424681dc13dbad7ac023c6017fc60406cabea5a352e4c3
+  checksum: 10/783f8c4a0e419d1024446ae8593411c95443ea09b50c4a378986b48893998acda34429b2d1deebc065405a7ef40bb19e19c68fdeb93acd46ae98b156c42d5f39
   languageName: node
   linkType: hard
 
-"@vitest/runner@npm:4.1.4":
-  version: 4.1.4
-  resolution: "@vitest/runner@npm:4.1.4"
+"@vitest/runner@npm:4.1.5":
+  version: 4.1.5
+  resolution: "@vitest/runner@npm:4.1.5"
   dependencies:
-    "@vitest/utils": "npm:4.1.4"
+    "@vitest/utils": "npm:4.1.5"
     pathe: "npm:^2.0.3"
-  checksum: 10/a852477adc6254e1d304bcba9b137f98f09a7001a557e8e4f4404518e3ade58a16ab459e83cf223e38cc37dc4b04d1248a14df56b056a0ae68fc54b19a1226fb
+  checksum: 10/ba19d84a9f7bcc3102ae5304c23e5dae789aaf8fd283f826e3fd4aca87ea2687ed606cf89869773d15799666553fd265524f7d9a0869e2869e00ebd8fd53af5b
   languageName: node
   linkType: hard
 
-"@vitest/snapshot@npm:4.1.4":
-  version: 4.1.4
-  resolution: "@vitest/snapshot@npm:4.1.4"
+"@vitest/snapshot@npm:4.1.5":
+  version: 4.1.5
+  resolution: "@vitest/snapshot@npm:4.1.5"
   dependencies:
-    "@vitest/pretty-format": "npm:4.1.4"
-    "@vitest/utils": "npm:4.1.4"
+    "@vitest/pretty-format": "npm:4.1.5"
+    "@vitest/utils": "npm:4.1.5"
     magic-string: "npm:^0.30.21"
     pathe: "npm:^2.0.3"
-  checksum: 10/e957cc95274a9663cd59e5b34c99b6e4e5cd989f04dadf9e3cec6c7bc64b4d167229644f31fd44c19c7acbbcb7cbbbb50e8084dbf1e0322ee411a697d80d490a
+  checksum: 10/cf70530d8a7320c012bdf7f6ca4f3ddbbb47c9aeb9ff5d28319e552ce64db93423d0c4facff3e112c6d711ed4228369c8fa73c88350fe6c16cf04f9ac2558caf
   languageName: node
   linkType: hard
 
-"@vitest/spy@npm:4.1.4":
-  version: 4.1.4
-  resolution: "@vitest/spy@npm:4.1.4"
-  checksum: 10/516e465413fc6a22e0c7e99871f3b9703277c309e94e7247bbdb83a8e807e2da968cf7a30c61503afd6b565787e822786b8aad443210eba5488192a36730f3ab
+"@vitest/spy@npm:4.1.5":
+  version: 4.1.5
+  resolution: "@vitest/spy@npm:4.1.5"
+  checksum: 10/4db4bb3aea01cd737fdb06d8f498bcd2127b8c2afeaa78ff9df4147e1474aa26dd16f42dc0512c31385824e94dbb17b17fa0f4c60b7595b7b4ab946f098220ab
   languageName: node
   linkType: hard
 
-"@vitest/utils@npm:4.1.4":
-  version: 4.1.4
-  resolution: "@vitest/utils@npm:4.1.4"
+"@vitest/utils@npm:4.1.5":
+  version: 4.1.5
+  resolution: "@vitest/utils@npm:4.1.5"
   dependencies:
-    "@vitest/pretty-format": "npm:4.1.4"
+    "@vitest/pretty-format": "npm:4.1.5"
     convert-source-map: "npm:^2.0.0"
     tinyrainbow: "npm:^3.1.0"
-  checksum: 10/f599ae744f0ff45edda90d0c52eea9809b7367adca39fc985f85880322236d089dfdf6625f04913f03a25a160eccbbc0b16dd3201ccc0ae48087992b1ea755d5
+  checksum: 10/4f75a2df6f910578a361ae92eb92a2b6921f50cc748994f3b2e5900d0ae687b6683f33b090dedf9b96eaca23bac117817d9448a4a333c7a96b94ee767399f18c
   languageName: node
   linkType: hard
 
-"abbrev@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "abbrev@npm:3.0.1"
-  checksum: 10/ebd2c149dda6f543b66ce3779ea612151bb3aa9d0824f169773ee9876f1ca5a4e0adbcccc7eed048c04da7998e1825e2aa76fcca92d9e67dea50ac2b0a58dc2e
+"abbrev@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "abbrev@npm:4.0.0"
+  checksum: 10/e2f0c6a6708ad738b3e8f50233f4800de31ad41a6cdc50e0cbe51b76fed69fd0213516d92c15ce1a9985fca71a14606a9be22bf00f8475a58987b9bfb671c582
   languageName: node
   linkType: hard
 
@@ -1685,16 +1667,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.15.0, acorn@npm:^8.5.0, acorn@npm:^8.9.0":
-  version: 8.15.0
-  resolution: "acorn@npm:8.15.0"
-  bin:
-    acorn: bin/acorn
-  checksum: 10/77f2de5051a631cf1729c090e5759148459cdb76b5f5c70f890503d629cf5052357b0ce783c0f976dd8a93c5150f59f6d18df1def3f502396a20f81282482fa4
-  languageName: node
-  linkType: hard
-
-"acorn@npm:^8.16.0":
+"acorn@npm:^8.15.0, acorn@npm:^8.16.0, acorn@npm:^8.5.0":
   version: 8.16.0
   resolution: "acorn@npm:8.16.0"
   bin:
@@ -1703,52 +1676,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"agent-base@npm:^7.1.0, agent-base@npm:^7.1.2":
-  version: 7.1.4
-  resolution: "agent-base@npm:7.1.4"
-  checksum: 10/79bef167247789f955aaba113bae74bf64aa1e1acca4b1d6bb444bdf91d82c3e07e9451ef6a6e2e35e8f71a6f97ce33e3d855a5328eb9fad1bc3cc4cfd031ed8
-  languageName: node
-  linkType: hard
-
 "ajv@npm:^6.14.0":
-  version: 6.14.0
-  resolution: "ajv@npm:6.14.0"
+  version: 6.15.0
+  resolution: "ajv@npm:6.15.0"
   dependencies:
     fast-deep-equal: "npm:^3.1.1"
     fast-json-stable-stringify: "npm:^2.0.0"
     json-schema-traverse: "npm:^0.4.1"
     uri-js: "npm:^4.2.2"
-  checksum: 10/c71f14dd2b6f2535d043f74019c8169f7aeb1106bafbb741af96f34fdbf932255c919ddd46344043d03b62ea0ccb319f83667ec5eedf612393f29054fe5ce4a5
-  languageName: node
-  linkType: hard
-
-"ansi-regex@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "ansi-regex@npm:5.0.1"
-  checksum: 10/2aa4bb54caf2d622f1afdad09441695af2a83aa3fe8b8afa581d205e57ed4261c183c4d3877cee25794443fde5876417d859c108078ab788d6af7e4fe52eb66b
-  languageName: node
-  linkType: hard
-
-"ansi-regex@npm:^6.0.1":
-  version: 6.2.2
-  resolution: "ansi-regex@npm:6.2.2"
-  checksum: 10/9b17ce2c6daecc75bcd5966b9ad672c23b184dc3ed9bf3c98a0702f0d2f736c15c10d461913568f2cf527a5e64291c7473358885dd493305c84a1cfed66ba94f
-  languageName: node
-  linkType: hard
-
-"ansi-styles@npm:^4.0.0":
-  version: 4.3.0
-  resolution: "ansi-styles@npm:4.3.0"
-  dependencies:
-    color-convert: "npm:^2.0.1"
-  checksum: 10/b4494dfbfc7e4591b4711a396bd27e540f8153914123dccb4cdbbcb514015ada63a3809f362b9d8d4f6b17a706f1d7bea3c6f974b15fa5ae76b5b502070889ff
-  languageName: node
-  linkType: hard
-
-"ansi-styles@npm:^6.1.0":
-  version: 6.2.3
-  resolution: "ansi-styles@npm:6.2.3"
-  checksum: 10/c49dad7639f3e48859bd51824c93b9eb0db628afc243c51c3dd2410c4a15ede1a83881c6c7341aa2b159c4f90c11befb38f2ba848c07c66c9f9de4bcd7cb9f30
+  checksum: 10/0916dda09c152fb5857bc1cc7ce61718e9cec5b7faeff44a74f5e324eed8a556e1a84856724ea322a067b436ecad9f74ac8295fd395449788cca52f0c25bd5fb
   languageName: node
   linkType: hard
 
@@ -1908,40 +1844,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"baseline-browser-mapping@npm:^2.8.19":
-  version: 2.8.20
-  resolution: "baseline-browser-mapping@npm:2.8.20"
+"baseline-browser-mapping@npm:^2.10.12":
+  version: 2.10.24
+  resolution: "baseline-browser-mapping@npm:2.10.24"
   bin:
-    baseline-browser-mapping: dist/cli.js
-  checksum: 10/50396a6cde06bd3ebfacfaa75da383aa6c4aa11ea1f0b346ea247ca2ee88b20aa632a8d1a12dd4e8b93507527c36d2f6019576cd7edd2214d0e6dd9d7b3bacd2
+    baseline-browser-mapping: dist/cli.cjs
+  checksum: 10/2bca673c12bd24d66f1a28b9eee1ba4401eb0030fe8aef6c4f711318dd312039acc3698df40a582cba8ae3100af9bb2bc541e746cb833c61b9be2b093de99bd0
   languageName: node
   linkType: hard
 
 "brace-expansion@npm:^1.1.7":
-  version: 1.1.12
-  resolution: "brace-expansion@npm:1.1.12"
+  version: 1.1.14
+  resolution: "brace-expansion@npm:1.1.14"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10/12cb6d6310629e3048cadb003e1aca4d8c9bb5c67c3c321bafdd7e7a50155de081f78ea3e0ed92ecc75a9015e784f301efc8132383132f4f7904ad1ac529c562
-  languageName: node
-  linkType: hard
-
-"brace-expansion@npm:^2.0.1":
-  version: 2.0.2
-  resolution: "brace-expansion@npm:2.0.2"
-  dependencies:
-    balanced-match: "npm:^1.0.0"
-  checksum: 10/01dff195e3646bc4b0d27b63d9bab84d2ebc06121ff5013ad6e5356daa5a9d6b60fa26cf73c74797f2dc3fbec112af13578d51f75228c1112b26c790a87b0488
-  languageName: node
-  linkType: hard
-
-"brace-expansion@npm:^5.0.2":
-  version: 5.0.3
-  resolution: "brace-expansion@npm:5.0.3"
-  dependencies:
-    balanced-match: "npm:^4.0.2"
-  checksum: 10/8ba7deae4ca333d52418d2cde3287ac23f44f7330d92c3ecd96a8941597bea8aab02227bd990944d6711dd549bcc6e550fe70be5d94aa02e2fdc88942f480c9b
+  checksum: 10/2de747a5891ea0d3a1946ea1ae26e056a47f7ea8d42a3009e1736ec3a31a5aa69a3c5da59d998426773553afe4c258e5b12d7953b534fa7f2cf12ce92eed4931
   languageName: node
   linkType: hard
 
@@ -1954,18 +1872,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:^4.26.3":
-  version: 4.27.0
-  resolution: "browserslist@npm:4.27.0"
+"browserslist@npm:^4.28.1":
+  version: 4.28.2
+  resolution: "browserslist@npm:4.28.2"
   dependencies:
-    baseline-browser-mapping: "npm:^2.8.19"
-    caniuse-lite: "npm:^1.0.30001751"
-    electron-to-chromium: "npm:^1.5.238"
-    node-releases: "npm:^2.0.26"
-    update-browserslist-db: "npm:^1.1.4"
+    baseline-browser-mapping: "npm:^2.10.12"
+    caniuse-lite: "npm:^1.0.30001782"
+    electron-to-chromium: "npm:^1.5.328"
+    node-releases: "npm:^2.0.36"
+    update-browserslist-db: "npm:^1.2.3"
   bin:
     browserslist: cli.js
-  checksum: 10/56db4cdb98b5c93797a47e5a60decb144f73a2ae41c60a16c41b75516fabcb0db0116b8cfcf3a26c960cc6c9ab1c4f4801d8d3a743ec72f27acfe5380153ba2f
+  checksum: 10/cff88386e5b5ba5614c9063bd32ef94865bba22b6a381844c7d09ea1eea62a2247e7106e516abdbfda6b75b9986044c991dfe45f92f10add5ad63dccc07589ec
   languageName: node
   linkType: hard
 
@@ -1977,9 +1895,9 @@ __metadata:
   linkType: hard
 
 "builtin-modules@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "builtin-modules@npm:5.0.0"
-  checksum: 10/85ba92a4cbd794174dae48c867d27f5529a03c9c073ccb029f106e62861eb48e09231f17a7290645e16a0a22d7401ca269ff73b760a6ddb9a3b7d1b9ceba81ac
+  version: 5.1.0
+  resolution: "builtin-modules@npm:5.1.0"
+  checksum: 10/6a2a28a0a9bf524c882112907e3bff326d29c7c1f73f28113cb0fdfbaac0513ef21c3fe580af4d129142d5dff023974d94f70b82d699ff37dd867ef39e01226f
   languageName: node
   linkType: hard
 
@@ -1990,27 +1908,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cacache@npm:^19.0.1":
-  version: 19.0.1
-  resolution: "cacache@npm:19.0.1"
-  dependencies:
-    "@npmcli/fs": "npm:^4.0.0"
-    fs-minipass: "npm:^3.0.0"
-    glob: "npm:^10.2.2"
-    lru-cache: "npm:^10.0.1"
-    minipass: "npm:^7.0.3"
-    minipass-collect: "npm:^2.0.1"
-    minipass-flush: "npm:^1.0.5"
-    minipass-pipeline: "npm:^1.2.4"
-    p-map: "npm:^7.0.2"
-    ssri: "npm:^12.0.0"
-    tar: "npm:^7.4.3"
-    unique-filename: "npm:^4.0.0"
-  checksum: 10/ea026b27b13656330c2bbaa462a88181dcaa0435c1c2e705db89b31d9bdf7126049d6d0445ba746dca21454a0cfdf1d6f47fd39d34c8c8435296b30bc5738a13
-  languageName: node
-  linkType: hard
-
-"call-bind-apply-helpers@npm:^1.0.0, call-bind-apply-helpers@npm:^1.0.1, call-bind-apply-helpers@npm:^1.0.2":
+"call-bind-apply-helpers@npm:^1.0.1, call-bind-apply-helpers@npm:^1.0.2":
   version: 1.0.2
   resolution: "call-bind-apply-helpers@npm:1.0.2"
   dependencies:
@@ -2020,15 +1918,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"call-bind@npm:^1.0.7, call-bind@npm:^1.0.8":
-  version: 1.0.8
-  resolution: "call-bind@npm:1.0.8"
+"call-bind@npm:^1.0.7, call-bind@npm:^1.0.8, call-bind@npm:^1.0.9":
+  version: 1.0.9
+  resolution: "call-bind@npm:1.0.9"
   dependencies:
-    call-bind-apply-helpers: "npm:^1.0.0"
-    es-define-property: "npm:^1.0.0"
-    get-intrinsic: "npm:^1.2.4"
+    call-bind-apply-helpers: "npm:^1.0.2"
+    es-define-property: "npm:^1.0.1"
+    get-intrinsic: "npm:^1.3.0"
     set-function-length: "npm:^1.2.2"
-  checksum: 10/659b03c79bbfccf0cde3a79e7d52570724d7290209823e1ca5088f94b52192dc1836b82a324d0144612f816abb2f1734447438e38d9dafe0b3f82c2a1b9e3bce
+  checksum: 10/25b1a98d6158f0adf9fface594ca82be4e3ed481d8ff7f36ad1fccb0c8377e38c6a04ff3248693723222d378677e93077c739defc8a6741c82b7e00bcee1245d
   languageName: node
   linkType: hard
 
@@ -2049,10 +1947,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001751":
-  version: 1.0.30001751
-  resolution: "caniuse-lite@npm:1.0.30001751"
-  checksum: 10/608f7e1248b7023020382c7dbb0ef389693b3fc98193c3ccea2d44126306d6ac905a5061cf9e62bf640535a86e7a98e563b34c02f909296cfe228f41627a4dc7
+"caniuse-lite@npm:^1.0.30001782":
+  version: 1.0.30001791
+  resolution: "caniuse-lite@npm:1.0.30001791"
+  checksum: 10/0ec6ef60ca9f5da3da37a57c8b7b645878b6aca406eb5b569dda0bdfa518fe83320e3e2e9e25450a40a8f34854c1537c287f8bd107830aa6f39c3018f98fe408
   languageName: node
   linkType: hard
 
@@ -2084,10 +1982,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ci-info@npm:^4.3.1":
-  version: 4.3.1
-  resolution: "ci-info@npm:4.3.1"
-  checksum: 10/9dc952bef67e665ccde2e7a552d42d5d095529d21829ece060a00925ede2dfa136160c70ef2471ea6ed6c9b133218b47c007f56955c0f1734a2e57f240aa7445
+"ci-info@npm:^4.4.0":
+  version: 4.4.0
+  resolution: "ci-info@npm:4.4.0"
+  checksum: 10/dfded0c630267d89660c8abb988ac8395a382bdfefedcc03e3e2858523312c5207db777c239c34774e3fcff11f015477c19d2ac8a58ea58aa476614a2e64f434
   languageName: node
   linkType: hard
 
@@ -2097,22 +1995,6 @@ __metadata:
   dependencies:
     escape-string-regexp: "npm:^1.0.5"
   checksum: 10/0b1ce281b07da2463c6882ea2e8409119b6cabbd9f687cdbdcee942c45b2b9049a2084f7b5f228c63ef9f21e722963ae0bfe56a735dbdbdd92512867625a7e40
-  languageName: node
-  linkType: hard
-
-"color-convert@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "color-convert@npm:2.0.1"
-  dependencies:
-    color-name: "npm:~1.1.4"
-  checksum: 10/fa00c91b4332b294de06b443923246bccebe9fab1b253f7fe1772d37b06a2269b4039a85e309abe1fe11b267b11c08d1d0473fda3badd6167f57313af2887a64
-  languageName: node
-  linkType: hard
-
-"color-name@npm:~1.1.4":
-  version: 1.1.4
-  resolution: "color-name@npm:1.1.4"
-  checksum: 10/b0445859521eb4021cd0fb0cc1a75cecf67fceecae89b63f62b201cca8d345baf8b952c966862a9d9a2632987d4f6581f0ec8d957dfacece86f0a7919316f610
   languageName: node
   linkType: hard
 
@@ -2154,12 +2036,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-js-compat@npm:^3.46.0":
-  version: 3.46.0
-  resolution: "core-js-compat@npm:3.46.0"
+"core-js-compat@npm:^3.49.0":
+  version: 3.49.0
+  resolution: "core-js-compat@npm:3.49.0"
   dependencies:
-    browserslist: "npm:^4.26.3"
-  checksum: 10/bee0523541d0e646c98dbff5b55bafa2e1674db82f769d851670a364bf4456b2a0364e393a70b09c4263f5dcb1fba3be32ddb4cffab11a79b53efbe32f4b76fb
+    browserslist: "npm:^4.28.1"
+  checksum: 10/eb35ad9b31a613092d32e5eb0c9fecb695e680bb29509fe04ae297ef790cea47d06864ef8939c8f5f189cce0bd2807fef8b2d6450f7eeb917ffaaf38a775dece
   languageName: node
   linkType: hard
 
@@ -2321,22 +2203,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dayjs@npm:^1.11.19":
+"dayjs@npm:^1.11.20":
   version: 1.11.20
   resolution: "dayjs@npm:1.11.20"
   checksum: 10/5347533f21a55b8bb1b1ef559be9b805514c3a8fb7e68b75fb7e73808131c59e70909c073aa44ce8a0d159195cd110cdd4081cf87ab96cb06fee3edacae791c6
-  languageName: node
-  linkType: hard
-
-"debug@npm:4, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.4.3":
-  version: 4.4.3
-  resolution: "debug@npm:4.4.3"
-  dependencies:
-    ms: "npm:^2.1.3"
-  peerDependenciesMeta:
-    supports-color:
-      optional: true
-  checksum: 10/9ada3434ea2993800bd9a1e320bd4aa7af69659fb51cca685d390949434bc0a8873c21ed7c9b852af6f2455a55c6d050aa3937d52b3c69f796dab666f762acad
   languageName: node
   linkType: hard
 
@@ -2346,6 +2216,18 @@ __metadata:
   dependencies:
     ms: "npm:^2.1.1"
   checksum: 10/d86fd7be2b85462297ea16f1934dc219335e802f629ca9a69b63ed8ed041dda492389bb2ee039217c02e5b54792b1c51aa96ae954cf28634d363a2360c7a1639
+  languageName: node
+  linkType: hard
+
+"debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.4.3":
+  version: 4.4.3
+  resolution: "debug@npm:4.4.3"
+  dependencies:
+    ms: "npm:^2.1.3"
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: 10/9ada3434ea2993800bd9a1e320bd4aa7af69659fb51cca685d390949434bc0a8873c21ed7c9b852af6f2455a55c6d050aa3937d52b3c69f796dab666f762acad
   languageName: node
   linkType: hard
 
@@ -2385,10 +2267,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"diff-sequences@npm:^27.5.1":
-  version: 27.5.1
-  resolution: "diff-sequences@npm:27.5.1"
-  checksum: 10/34d852a13eb82735c39944a050613f952038614ce324256e1c3544948fa090f1ca7f329a4f1f57c31fe7ac982c17068d8915b633e300f040b97708c81ceb26cd
+"diff-sequences@npm:^29.6.3":
+  version: 29.6.3
+  resolution: "diff-sequences@npm:29.6.3"
+  checksum: 10/179daf9d2f9af5c57ad66d97cb902a538bcf8ed64963fa7aa0c329b3de3665ce2eb6ffdc2f69f29d445fa4af2517e5e55e5b6e00c00a9ae4f43645f97f7078cb
   languageName: node
   linkType: hard
 
@@ -2402,9 +2284,9 @@ __metadata:
   linkType: hard
 
 "dotenv@npm:^17.2.1":
-  version: 17.2.3
-  resolution: "dotenv@npm:17.2.3"
-  checksum: 10/f8b78626ebfff6e44420f634773375c9651808b3e1a33df6d4cc19120968eea53e100f59f04ec35f2a20b2beb334b6aba4f24040b2f8ad61773f158ac042a636
+  version: 17.4.2
+  resolution: "dotenv@npm:17.4.2"
+  checksum: 10/ca1b6f54d58e39914901e1518958e86083aca8deb5aa2e7f2a51acd53291d97852479b0ab26ed949b6a45a0e9adcc7b0d1c3c72375e8ea670f7005e341c6daba
   languageName: node
   linkType: hard
 
@@ -2419,52 +2301,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eastasianwidth@npm:^0.2.0":
-  version: 0.2.0
-  resolution: "eastasianwidth@npm:0.2.0"
-  checksum: 10/9b1d3e1baefeaf7d70799db8774149cef33b97183a6addceeba0cf6b85ba23ee2686f302f14482006df32df75d32b17c509c143a3689627929e4a8efaf483952
-  languageName: node
-  linkType: hard
-
 "eciesjs@npm:^0.4.10":
-  version: 0.4.16
-  resolution: "eciesjs@npm:0.4.16"
+  version: 0.4.18
+  resolution: "eciesjs@npm:0.4.18"
   dependencies:
-    "@ecies/ciphers": "npm:^0.2.4"
+    "@ecies/ciphers": "npm:^0.2.5"
     "@noble/ciphers": "npm:^1.3.0"
     "@noble/curves": "npm:^1.9.7"
     "@noble/hashes": "npm:^1.8.0"
-  checksum: 10/0b179dc8ad470b976edb1c7f59770c934a36854d22ccab979fea32ae559f017d843c468f8a551523877251e7340df1babef0777acebcf6518341337d8ed7bb94
+  checksum: 10/c2e58ce1ce67c7959da064372081bea38b9769a1db61bf91e084001a3906ce7cc1ce77536737446eb83365ec567e50c879209b5647a00d45c9727dd3a79b0543
   languageName: node
   linkType: hard
 
-"electron-to-chromium@npm:^1.5.238":
-  version: 1.5.240
-  resolution: "electron-to-chromium@npm:1.5.240"
-  checksum: 10/35210acbd189e58e1447157498e23f53a4e0562145caac56bf103a1f3d88259d9dd59663a9396ecf64adbdef487873b327ff8c0688ece95b5531b10d27fb4e7d
-  languageName: node
-  linkType: hard
-
-"emoji-regex@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "emoji-regex@npm:8.0.0"
-  checksum: 10/c72d67a6821be15ec11997877c437491c313d924306b8da5d87d2a2bcc2cec9903cb5b04ee1a088460501d8e5b44f10df82fdc93c444101a7610b80c8b6938e1
-  languageName: node
-  linkType: hard
-
-"emoji-regex@npm:^9.2.2":
-  version: 9.2.2
-  resolution: "emoji-regex@npm:9.2.2"
-  checksum: 10/915acf859cea7131dac1b2b5c9c8e35c4849e325a1d114c30adb8cd615970f6dca0e27f64f3a4949d7d6ed86ecd79a1c5c63f02e697513cddd7b5835c90948b8
-  languageName: node
-  linkType: hard
-
-"encoding@npm:^0.1.13":
-  version: 0.1.13
-  resolution: "encoding@npm:0.1.13"
-  dependencies:
-    iconv-lite: "npm:^0.6.2"
-  checksum: 10/bb98632f8ffa823996e508ce6a58ffcf5856330fde839ae42c9e1f436cc3b5cc651d4aeae72222916545428e54fd0f6aa8862fd8d25bdbcc4589f1e3f3715e7f
+"electron-to-chromium@npm:^1.5.328":
+  version: 1.5.345
+  resolution: "electron-to-chromium@npm:1.5.345"
+  checksum: 10/69d9eaf94721fb9f0ac2c682174883d3d1d412e1eb7c5cf8e6237751737bd4514aabf2e8e7d70edcf9895acfed68a5038810d0e658853b14784d4a386ae43f83
   languageName: node
   linkType: hard
 
@@ -2493,16 +2345,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"err-code@npm:^2.0.2":
-  version: 2.0.3
-  resolution: "err-code@npm:2.0.3"
-  checksum: 10/1d20d825cdcce8d811bfbe86340f4755c02655a7feb2f13f8c880566d9d72a3f6c92c192a6867632e490d6da67b678271f46e01044996a6443e870331100dfdd
-  languageName: node
-  linkType: hard
-
 "es-abstract@npm:^1.23.2, es-abstract@npm:^1.23.5, es-abstract@npm:^1.23.9, es-abstract@npm:^1.24.0":
-  version: 1.24.0
-  resolution: "es-abstract@npm:1.24.0"
+  version: 1.24.2
+  resolution: "es-abstract@npm:1.24.2"
   dependencies:
     array-buffer-byte-length: "npm:^1.0.2"
     arraybuffer.prototype.slice: "npm:^1.0.4"
@@ -2558,7 +2403,7 @@ __metadata:
     typed-array-length: "npm:^1.0.7"
     unbox-primitive: "npm:^1.1.0"
     which-typed-array: "npm:^1.1.19"
-  checksum: 10/64e07a886f7439cf5ccfc100f9716e6173e10af6071a50a5031afbdde474a3dbc9619d5965da54e55f8908746a9134a46be02af8c732d574b7b81ed3124e2daf
+  checksum: 10/e2c97263d87b7faf65102d887074af421db7e48cd92b8b3cd308216cdd2547b647e8f61bf51429bdb13adc463bb7f421989544cbfd2e7f7469ef7a69ae8a4205
   languageName: node
   linkType: hard
 
@@ -2577,9 +2422,9 @@ __metadata:
   linkType: hard
 
 "es-module-lexer@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "es-module-lexer@npm:2.0.0"
-  checksum: 10/b075855289b5f40ee496f3d7525c5c501d029c3da15c22298a0030d625bf36d1da0768b26278f7f4bada2a602459b505888e20b77c414fba5da5619b0e84dbd1
+  version: 2.1.0
+  resolution: "es-module-lexer@npm:2.1.0"
+  checksum: 10/554c4374e78a812a1fa3673871ce7d42236438c414ea80c2ec35521cd9bb26d1d9155287529057d07431fd91df50d6a26d9bee5afd755fb7f6f7c81905a03956
   languageName: node
   linkType: hard
 
@@ -2625,35 +2470,35 @@ __metadata:
   linkType: hard
 
 "esbuild@npm:~0.27.0":
-  version: 0.27.1
-  resolution: "esbuild@npm:0.27.1"
+  version: 0.27.7
+  resolution: "esbuild@npm:0.27.7"
   dependencies:
-    "@esbuild/aix-ppc64": "npm:0.27.1"
-    "@esbuild/android-arm": "npm:0.27.1"
-    "@esbuild/android-arm64": "npm:0.27.1"
-    "@esbuild/android-x64": "npm:0.27.1"
-    "@esbuild/darwin-arm64": "npm:0.27.1"
-    "@esbuild/darwin-x64": "npm:0.27.1"
-    "@esbuild/freebsd-arm64": "npm:0.27.1"
-    "@esbuild/freebsd-x64": "npm:0.27.1"
-    "@esbuild/linux-arm": "npm:0.27.1"
-    "@esbuild/linux-arm64": "npm:0.27.1"
-    "@esbuild/linux-ia32": "npm:0.27.1"
-    "@esbuild/linux-loong64": "npm:0.27.1"
-    "@esbuild/linux-mips64el": "npm:0.27.1"
-    "@esbuild/linux-ppc64": "npm:0.27.1"
-    "@esbuild/linux-riscv64": "npm:0.27.1"
-    "@esbuild/linux-s390x": "npm:0.27.1"
-    "@esbuild/linux-x64": "npm:0.27.1"
-    "@esbuild/netbsd-arm64": "npm:0.27.1"
-    "@esbuild/netbsd-x64": "npm:0.27.1"
-    "@esbuild/openbsd-arm64": "npm:0.27.1"
-    "@esbuild/openbsd-x64": "npm:0.27.1"
-    "@esbuild/openharmony-arm64": "npm:0.27.1"
-    "@esbuild/sunos-x64": "npm:0.27.1"
-    "@esbuild/win32-arm64": "npm:0.27.1"
-    "@esbuild/win32-ia32": "npm:0.27.1"
-    "@esbuild/win32-x64": "npm:0.27.1"
+    "@esbuild/aix-ppc64": "npm:0.27.7"
+    "@esbuild/android-arm": "npm:0.27.7"
+    "@esbuild/android-arm64": "npm:0.27.7"
+    "@esbuild/android-x64": "npm:0.27.7"
+    "@esbuild/darwin-arm64": "npm:0.27.7"
+    "@esbuild/darwin-x64": "npm:0.27.7"
+    "@esbuild/freebsd-arm64": "npm:0.27.7"
+    "@esbuild/freebsd-x64": "npm:0.27.7"
+    "@esbuild/linux-arm": "npm:0.27.7"
+    "@esbuild/linux-arm64": "npm:0.27.7"
+    "@esbuild/linux-ia32": "npm:0.27.7"
+    "@esbuild/linux-loong64": "npm:0.27.7"
+    "@esbuild/linux-mips64el": "npm:0.27.7"
+    "@esbuild/linux-ppc64": "npm:0.27.7"
+    "@esbuild/linux-riscv64": "npm:0.27.7"
+    "@esbuild/linux-s390x": "npm:0.27.7"
+    "@esbuild/linux-x64": "npm:0.27.7"
+    "@esbuild/netbsd-arm64": "npm:0.27.7"
+    "@esbuild/netbsd-x64": "npm:0.27.7"
+    "@esbuild/openbsd-arm64": "npm:0.27.7"
+    "@esbuild/openbsd-x64": "npm:0.27.7"
+    "@esbuild/openharmony-arm64": "npm:0.27.7"
+    "@esbuild/sunos-x64": "npm:0.27.7"
+    "@esbuild/win32-arm64": "npm:0.27.7"
+    "@esbuild/win32-ia32": "npm:0.27.7"
+    "@esbuild/win32-x64": "npm:0.27.7"
   dependenciesMeta:
     "@esbuild/aix-ppc64":
       optional: true
@@ -2709,7 +2554,7 @@ __metadata:
       optional: true
   bin:
     esbuild: bin/esbuild
-  checksum: 10/534148f01e85ca93ec3a4ae8bef133680f5659e639915cd3a453d6ec9ead94c9a2e9bfd61380301471447e182beb62841cb72e0fa18251cdce3454a2511d7cf4
+  checksum: 10/262b16c4a33cb70e9f054759a7ce420541649315eef7b064172c795021ccce322e56c3f5fd52e8842873f1c23745f3ab62311a24860950bd5406ba77b36b8529
   languageName: node
   linkType: hard
 
@@ -2734,17 +2579,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-compat-utils@npm:^0.6.4":
-  version: 0.6.5
-  resolution: "eslint-compat-utils@npm:0.6.5"
-  dependencies:
-    semver: "npm:^7.5.4"
-  peerDependencies:
-    eslint: ">=6.0.0"
-  checksum: 10/bb95e89ed11e9a29b2e9184967292b4b52be1e10fb36c84e89de95b4a5b23764a456b3818a867e232aec685186bd954e19f165cbe50b39659f729d97f1125820
-  languageName: node
-  linkType: hard
-
 "eslint-config-prettier@npm:10.1.8":
   version: 10.1.8
   resolution: "eslint-config-prettier@npm:10.1.8"
@@ -2757,28 +2591,28 @@ __metadata:
   linkType: hard
 
 "eslint-import-resolver-node@npm:^0.3.9":
-  version: 0.3.9
-  resolution: "eslint-import-resolver-node@npm:0.3.9"
+  version: 0.3.10
+  resolution: "eslint-import-resolver-node@npm:0.3.10"
   dependencies:
     debug: "npm:^3.2.7"
-    is-core-module: "npm:^2.13.0"
-    resolve: "npm:^1.22.4"
-  checksum: 10/d52e08e1d96cf630957272e4f2644dcfb531e49dcfd1edd2e07e43369eb2ec7a7d4423d417beee613201206ff2efa4eb9a582b5825ee28802fc7c71fcd53ca83
+    is-core-module: "npm:^2.16.1"
+    resolve: "npm:^2.0.0-next.6"
+  checksum: 10/f0ad564d345fc53076b46f726b6f9ba96a40d1b7cb33d515ea89d41d1dba37db4ff9b864550608756c2ba061c9e243bf10b920d975848616d0c6c4474f4ea415
   languageName: node
   linkType: hard
 
-"eslint-json-compat-utils@npm:^0.2.1":
-  version: 0.2.1
-  resolution: "eslint-json-compat-utils@npm:0.2.1"
+"eslint-json-compat-utils@npm:^0.2.3":
+  version: 0.2.3
+  resolution: "eslint-json-compat-utils@npm:0.2.3"
   dependencies:
     esquery: "npm:^1.6.0"
   peerDependencies:
     eslint: "*"
-    jsonc-eslint-parser: ^2.4.0
+    jsonc-eslint-parser: ^2.4.0 || ^3.0.0
   peerDependenciesMeta:
     "@eslint/json":
       optional: true
-  checksum: 10/083272c0cdbc6acd9fe9bfe939e0c76493a426400141203d7f0e76344d5874c5a88535c59300045e4c6f95baa5084eff512013f82bcd9e7426404c785e2ea55d
+  checksum: 10/4fcd5cbd17ba2f99215b27b8992eae788b4d7786a50c9c0a9b031074708e2e18b3ca77084bc91314ff1db4bc3eeb8c0648b33e701e0ed3616e587c9c94cec52c
   languageName: node
   linkType: hard
 
@@ -2823,26 +2657,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-jsonc@npm:^2.21.0":
-  version: 2.21.1
-  resolution: "eslint-plugin-jsonc@npm:2.21.1"
+"eslint-plugin-jsonc@npm:^3.1.2":
+  version: 3.1.2
+  resolution: "eslint-plugin-jsonc@npm:3.1.2"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.5.1"
-    diff-sequences: "npm:^27.5.1"
-    eslint-compat-utils: "npm:^0.6.4"
-    eslint-json-compat-utils: "npm:^0.2.1"
-    espree: "npm:^9.6.1 || ^10.3.0"
-    graphemer: "npm:^1.4.0"
-    jsonc-eslint-parser: "npm:^2.4.0"
+    "@eslint/core": "npm:^1.0.1"
+    "@eslint/plugin-kit": "npm:^0.6.0"
+    "@ota-meshi/ast-token-store": "npm:^0.3.0"
+    diff-sequences: "npm:^29.6.3"
+    eslint-json-compat-utils: "npm:^0.2.3"
+    jsonc-eslint-parser: "npm:^3.1.0"
     natural-compare: "npm:^1.4.0"
-    synckit: "npm:^0.6.2 || ^0.7.3 || ^0.11.5"
+    synckit: "npm:^0.11.12"
   peerDependencies:
-    eslint: ">=6.0.0"
-  checksum: 10/4bcdb6eda95766533772f51e8ea929342a2e653ba2b1b44fef12b6b7d7f628626dafbbd1942113f4aeee0d4d652fb2032b0088cf22ad053f7157e3a8edb9a4db
+    eslint: ">=9.38.0"
+  checksum: 10/d7de8884d1a4369cb0e5cf3b424191dad8a65340943356d0ae0d4d10afd6f05db47d905c2500cbe5d517e7d4d394b51367cf32631c39cce7732b9cbf613cf852
   languageName: node
   linkType: hard
 
-"eslint-plugin-no-unsanitized@npm:^4.1.4":
+"eslint-plugin-no-unsanitized@npm:^4.1.5":
   version: 4.1.5
   resolution: "eslint-plugin-no-unsanitized@npm:4.1.5"
   peerDependencies:
@@ -2851,7 +2685,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-prettier@npm:^5.5.4":
+"eslint-plugin-prettier@npm:^5.5.5":
   version: 5.5.5
   resolution: "eslint-plugin-prettier@npm:5.5.5"
   dependencies:
@@ -2880,16 +2714,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-simple-import-sort@npm:^12.1.1":
-  version: 12.1.1
-  resolution: "eslint-plugin-simple-import-sort@npm:12.1.1"
+"eslint-plugin-simple-import-sort@npm:^13.0.0":
+  version: 13.0.0
+  resolution: "eslint-plugin-simple-import-sort@npm:13.0.0"
   peerDependencies:
     eslint: ">=5.0.0"
-  checksum: 10/2a690cea9243fbefa70345687bca8952f5e185fa459b7a8db687a908cc31082435cfee236c619d5245548fa5f89a2f2c4f8499f80512e048d2bedc60e3662d5a
+  checksum: 10/4ef64b0e13e6c22d929b4d8f4c68dcb001ecc273b0be7ef1318278bafef4942dcb1454f099e506dcf8bcf729311ad3f7c255a688ab06e71265f5dec4111cb71d
   languageName: node
   linkType: hard
 
-"eslint-plugin-sonarjs@npm:^4.0.0":
+"eslint-plugin-sonarjs@npm:^4.0.3":
   version: 4.0.3
   resolution: "eslint-plugin-sonarjs@npm:4.0.3"
   dependencies:
@@ -2923,29 +2757,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-unicorn@npm:^63.0.0":
-  version: 63.0.0
-  resolution: "eslint-plugin-unicorn@npm:63.0.0"
+"eslint-plugin-unicorn@npm:^64.0.0":
+  version: 64.0.0
+  resolution: "eslint-plugin-unicorn@npm:64.0.0"
   dependencies:
     "@babel/helper-validator-identifier": "npm:^7.28.5"
-    "@eslint-community/eslint-utils": "npm:^4.9.0"
+    "@eslint-community/eslint-utils": "npm:^4.9.1"
     change-case: "npm:^5.4.4"
-    ci-info: "npm:^4.3.1"
+    ci-info: "npm:^4.4.0"
     clean-regexp: "npm:^1.0.0"
-    core-js-compat: "npm:^3.46.0"
+    core-js-compat: "npm:^3.49.0"
     find-up-simple: "npm:^1.0.1"
-    globals: "npm:^16.4.0"
+    globals: "npm:^17.4.0"
     indent-string: "npm:^5.0.0"
     is-builtin-module: "npm:^5.0.0"
     jsesc: "npm:^3.1.0"
     pluralize: "npm:^8.0.0"
     regexp-tree: "npm:^0.1.27"
     regjsparser: "npm:^0.13.0"
-    semver: "npm:^7.7.3"
+    semver: "npm:^7.7.4"
     strip-indent: "npm:^4.1.1"
   peerDependencies:
     eslint: ">=9.38.0"
-  checksum: 10/bfcaf383e8e244c13311900d4e152b1a4134f844ddc8514d86aca7da932a4663b144fceca7a32a796faaf53a84a203dcd3052ef846c05990dd285c19ed6c9f17
+  checksum: 10/3211dadefe8ec43526372a302e48503da42f5e1d3b45d8e20bc29e30dd142b442d70d22ea8617a4ca5494b184b36656d0e81c1e299d12a8e991ac1a86ed35e42
   languageName: node
   linkType: hard
 
@@ -2968,7 +2802,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-visitor-keys@npm:^3.0.0, eslint-visitor-keys@npm:^3.4.1, eslint-visitor-keys@npm:^3.4.3":
+"eslint-visitor-keys@npm:^3.4.3":
   version: 3.4.3
   resolution: "eslint-visitor-keys@npm:3.4.3"
   checksum: 10/3f357c554a9ea794b094a09bd4187e5eacd1bc0d0653c3adeb87962c548e6a1ab8f982b86963ae1337f5d976004146536dcee5d0e2806665b193fbfbf1a9231b
@@ -2982,14 +2816,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-visitor-keys@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "eslint-visitor-keys@npm:5.0.0"
-  checksum: 10/05334d637c73d02f644b8dbfd6f555f049a229654b543b4b701944051072808d944368164c8b291cecb60e157a54d05f221eb45945a1bdd06c3e0e298ddb4678
-  languageName: node
-  linkType: hard
-
-"eslint-visitor-keys@npm:^5.0.1":
+"eslint-visitor-keys@npm:^5.0.0, eslint-visitor-keys@npm:^5.0.1":
   version: 5.0.1
   resolution: "eslint-visitor-keys@npm:5.0.1"
   checksum: 10/f9cc1a57b75e0ef949545cac33d01e8367e302de4c1483266ed4d8646ee5c306376660196bbb38b004e767b7043d1e661cb4336b49eff634a1bbe75c1db709ec
@@ -3041,7 +2868,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"espree@npm:^10.0.1, espree@npm:^9.6.1 || ^10.3.0":
+"espree@npm:^10.0.1":
   version: 10.4.0
   resolution: "espree@npm:10.4.0"
   dependencies:
@@ -3074,17 +2901,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"espree@npm:^9.0.0":
-  version: 9.6.1
-  resolution: "espree@npm:9.6.1"
-  dependencies:
-    acorn: "npm:^8.9.0"
-    acorn-jsx: "npm:^5.3.2"
-    eslint-visitor-keys: "npm:^3.4.1"
-  checksum: 10/255ab260f0d711a54096bdeda93adff0eadf02a6f9b92f02b323e83a2b7fc258797919437ad331efec3930475feb0142c5ecaaf3cdab4befebd336d47d3f3134
-  languageName: node
-  linkType: hard
-
 "esprima@npm:^4.0.1":
   version: 4.0.1
   resolution: "esprima@npm:4.0.1"
@@ -3095,16 +2911,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esquery@npm:^1.6.0":
-  version: 1.6.0
-  resolution: "esquery@npm:1.6.0"
-  dependencies:
-    estraverse: "npm:^5.1.0"
-  checksum: 10/c587fb8ec9ed83f2b1bc97cf2f6854cc30bf784a79d62ba08c6e358bf22280d69aee12827521cf38e69ae9761d23fb7fde593ce315610f85655c139d99b05e5a
-  languageName: node
-  linkType: hard
-
-"esquery@npm:^1.7.0":
+"esquery@npm:^1.6.0, esquery@npm:^1.7.0":
   version: 1.7.0
   resolution: "esquery@npm:1.7.0"
   dependencies:
@@ -3177,9 +2984,9 @@ __metadata:
   linkType: hard
 
 "fast-copy@npm:^4.0.0":
-  version: 4.0.1
-  resolution: "fast-copy@npm:4.0.1"
-  checksum: 10/849f6208fec2356fdf91bd67d5c107b3ad14bf0fc24039b4254044e824ff3bea7e2e26125e5f83defcf6d3d8db103eaf536b32a78c99151223903f91829b9efd
+  version: 4.0.3
+  resolution: "fast-copy@npm:4.0.3"
+  checksum: 10/1e74e8b18a83f125b697b0dc7d802b4c73ec2aba7b181458e5e72d46a261faefcdee22ad9fa682c77f4606133451342f95de9835c2c804c481472585fa6ded26
   languageName: node
   linkType: hard
 
@@ -3274,9 +3081,9 @@ __metadata:
   linkType: hard
 
 "flatted@npm:^3.2.9":
-  version: 3.3.3
-  resolution: "flatted@npm:3.3.3"
-  checksum: 10/8c96c02fbeadcf4e8ffd0fa24983241e27698b0781295622591fc13585e2f226609d95e422bcf2ef044146ffacb6b68b1f20871454eddf75ab3caa6ee5f4a1fe
+  version: 3.4.2
+  resolution: "flatted@npm:3.4.2"
+  checksum: 10/a9e78fe5c2c1fcd98209a015ccee3a6caa953e01729778e83c1fe92e68601a63e1e69cd4e573010ca99eaf585a581b80ccf1018b99283e6cbc2117bcba1e030f
   languageName: node
   linkType: hard
 
@@ -3286,25 +3093,6 @@ __metadata:
   dependencies:
     is-callable: "npm:^1.2.7"
   checksum: 10/330cc2439f85c94f4609de3ee1d32c5693ae15cdd7fe3d112c4fd9efd4ce7143f2c64ef6c2c9e0cfdb0058437f33ef05b5bdae5b98fcc903fb2143fbaf0fea0f
-  languageName: node
-  linkType: hard
-
-"foreground-child@npm:^3.1.0":
-  version: 3.3.1
-  resolution: "foreground-child@npm:3.3.1"
-  dependencies:
-    cross-spawn: "npm:^7.0.6"
-    signal-exit: "npm:^4.0.1"
-  checksum: 10/427b33f997a98073c0424e5c07169264a62cda806d8d2ded159b5b903fdfc8f0a1457e06b5fc35506497acb3f1e353f025edee796300209ac6231e80edece835
-  languageName: node
-  linkType: hard
-
-"fs-minipass@npm:^3.0.0":
-  version: 3.0.3
-  resolution: "fs-minipass@npm:3.0.3"
-  dependencies:
-    minipass: "npm:^7.0.3"
-  checksum: 10/af143246cf6884fe26fa281621d45cfe111d34b30535a475bfa38dafe343dadb466c047a924ffc7d6b7b18265df4110224ce3803806dbb07173bf2087b648d7f
   languageName: node
   linkType: hard
 
@@ -3426,11 +3214,11 @@ __metadata:
   linkType: hard
 
 "get-tsconfig@npm:^4.7.5":
-  version: 4.13.0
-  resolution: "get-tsconfig@npm:4.13.0"
+  version: 4.14.0
+  resolution: "get-tsconfig@npm:4.14.0"
   dependencies:
     resolve-pkg-maps: "npm:^1.0.0"
-  checksum: 10/3603c6da30e312636e4c20461e779114c9126601d1eca70ee4e36e3e3c00e3c21892d2d920027333afa2cc9e20998a436b14abe03a53cde40742581cb0e9ceb2
+  checksum: 10/f5626971905ca386c9ddeb302504e8a2301b9c05641803267223ebd50b7c81aaf9324d29cf9f4e4ff3f245632c3392aa83719dc6cb3e98b4e4a1702a27c5cc5d
   languageName: node
   linkType: hard
 
@@ -3440,22 +3228,6 @@ __metadata:
   dependencies:
     is-glob: "npm:^4.0.3"
   checksum: 10/c13ee97978bef4f55106b71e66428eb1512e71a7466ba49025fc2aec59a5bfb0954d5abd58fc5ee6c9b076eef4e1f6d3375c2e964b88466ca390da4419a786a8
-  languageName: node
-  linkType: hard
-
-"glob@npm:^10.2.2":
-  version: 10.5.0
-  resolution: "glob@npm:10.5.0"
-  dependencies:
-    foreground-child: "npm:^3.1.0"
-    jackspeak: "npm:^3.1.2"
-    minimatch: "npm:^9.0.4"
-    minipass: "npm:^7.1.2"
-    package-json-from-dist: "npm:^1.0.0"
-    path-scurry: "npm:^1.11.1"
-  bin:
-    glob: dist/esm/bin.mjs
-  checksum: 10/ab3bccfefcc0afaedbd1f480cd0c4a2c0e322eb3f0aa7ceaa31b3f00b825069f17cf0f1fc8b6f256795074b903f37c0ade37ddda6a176aa57f1c2bbfe7240653
   languageName: node
   linkType: hard
 
@@ -3475,17 +3247,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globals@npm:^16.4.0":
-  version: 16.4.0
-  resolution: "globals@npm:16.4.0"
-  checksum: 10/1627a9f42fb4c82d7af6a0c8b6cd616e00110908304d5f1ddcdf325998f3aed45a4b29d8a1e47870f328817805263e31e4f1673f00022b9c2b210552767921cf
-  languageName: node
-  linkType: hard
-
 "globals@npm:^17.4.0":
-  version: 17.4.0
-  resolution: "globals@npm:17.4.0"
-  checksum: 10/ffad244617e94efcb3da72b7beefc941167c21316148ce378f322db7af72db06468f370e23224b3c7b17b5173a7c75b134e5e7b0949f2828519054a76892508d
+  version: 17.5.0
+  resolution: "globals@npm:17.5.0"
+  checksum: 10/c405a95e1ecf14a1a17caaecd4dadbad38166b3c1b514e07924604ee224e922c043fc93ae21164d124dae5536e5a812566355469e34a689601db7d3d424dc8e7
   languageName: node
   linkType: hard
 
@@ -3510,13 +3275,6 @@ __metadata:
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: 10/bf152d0ed1dc159239db1ba1f74fdbc40cb02f626770dcd5815c427ce0688c2635a06ed69af364396da4636d0408fcf7d4afdf7881724c3307e46aff30ca49e2
-  languageName: node
-  linkType: hard
-
-"graphemer@npm:^1.4.0":
-  version: 1.4.0
-  resolution: "graphemer@npm:1.4.0"
-  checksum: 10/6dd60dba97007b21e3a829fab3f771803cc1292977fe610e240ea72afd67e5690ac9eeaafc4a99710e78962e5936ab5a460787c2a1180f1cb0ccfac37d29f897
   languageName: node
   linkType: hard
 
@@ -3569,11 +3327,11 @@ __metadata:
   linkType: hard
 
 "hasown@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "hasown@npm:2.0.2"
+  version: 2.0.3
+  resolution: "hasown@npm:2.0.3"
   dependencies:
     function-bind: "npm:^1.1.2"
-  checksum: 10/7898a9c1788b2862cf0f9c345a6bec77ba4a0c0983c7f19d610c382343d4f98fa260686b225dfb1f88393a66679d2ec58ee310c1d6868c081eda7918f32cc70a
+  checksum: 10/619526379cda755409d856cbf3c65b82ea342151719a0a550920cf7d6a7f58f7cf079e5a78f3acd162324fc784a3d3d6f6f61aff613b47a0163c16fbe09ea89f
   languageName: node
   linkType: hard
 
@@ -3591,46 +3349,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-cache-semantics@npm:^4.1.1":
-  version: 4.2.0
-  resolution: "http-cache-semantics@npm:4.2.0"
-  checksum: 10/4efd2dfcfeea9d5e88c84af450b9980be8a43c2c8179508b1c57c7b4421c855f3e8efe92fa53e0b3f4a43c85824ada930eabbc306d1b3beab750b6dcc5187693
-  languageName: node
-  linkType: hard
-
-"http-proxy-agent@npm:^7.0.0":
-  version: 7.0.2
-  resolution: "http-proxy-agent@npm:7.0.2"
-  dependencies:
-    agent-base: "npm:^7.1.0"
-    debug: "npm:^4.3.4"
-  checksum: 10/d062acfa0cb82beeb558f1043c6ba770ea892b5fb7b28654dbc70ea2aeea55226dd34c02a294f6c1ca179a5aa483c4ea641846821b182edbd9cc5d89b54c6848
-  languageName: node
-  linkType: hard
-
-"https-proxy-agent@npm:^7.0.1":
-  version: 7.0.6
-  resolution: "https-proxy-agent@npm:7.0.6"
-  dependencies:
-    agent-base: "npm:^7.1.2"
-    debug: "npm:4"
-  checksum: 10/784b628cbd55b25542a9d85033bdfd03d4eda630fb8b3c9477959367f3be95dc476ed2ecbb9836c359c7c698027fc7b45723a302324433590f45d6c1706e8c13
-  languageName: node
-  linkType: hard
-
 "human-signals@npm:^2.1.0":
   version: 2.1.0
   resolution: "human-signals@npm:2.1.0"
   checksum: 10/df59be9e0af479036798a881d1f136c4a29e0b518d4abb863afbd11bf30efa3eeb1d0425fc65942dcc05ab3bf40205ea436b0ff389f2cd20b75b8643d539bf86
-  languageName: node
-  linkType: hard
-
-"iconv-lite@npm:^0.6.2":
-  version: 0.6.3
-  resolution: "iconv-lite@npm:0.6.3"
-  dependencies:
-    safer-buffer: "npm:>= 2.1.2 < 3.0.0"
-  checksum: 10/24e3292dd3dadaa81d065c6f8c41b274a47098150d444b96e5f53b4638a9a71482921ea6a91a1f59bb71d9796de25e04afd05919fa64c360347ba65d3766f10f
   languageName: node
   linkType: hard
 
@@ -3704,13 +3426,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-address@npm:^10.0.1":
-  version: 10.0.1
-  resolution: "ip-address@npm:10.0.1"
-  checksum: 10/09731acda32cd8e14c46830c137e7e5940f47b36d63ffb87c737331270287d631cf25aa95570907a67d3f919fdb25f4470c404eda21e62f22e0a55927f4dd0fb
-  languageName: node
-  linkType: hard
-
 "is-array-buffer@npm:^3.0.4, is-array-buffer@npm:^3.0.5":
   version: 3.0.5
   resolution: "is-array-buffer@npm:3.0.5"
@@ -3770,7 +3485,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-core-module@npm:^2.13.0, is-core-module@npm:^2.16.1":
+"is-core-module@npm:^2.16.1":
   version: 2.16.1
   resolution: "is-core-module@npm:2.16.1"
   dependencies:
@@ -3813,13 +3528,6 @@ __metadata:
   dependencies:
     call-bound: "npm:^1.0.3"
   checksum: 10/0bfb145e9a1ba852ddde423b0926d2169ae5fe9e37882cde9e8f69031281a986308df4d982283e152396e88b86562ed2256cbaa5e6390fb840a4c25ab54b8a80
-  languageName: node
-  linkType: hard
-
-"is-fullwidth-code-point@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "is-fullwidth-code-point@npm:3.0.0"
-  checksum: 10/44a30c29457c7fb8f00297bce733f0a64cd22eca270f83e58c105e0d015e45c019491a4ab2faef91ab51d4738c670daff901c799f6a700e27f7314029e99e348
   languageName: node
   linkType: hard
 
@@ -3982,9 +3690,16 @@ __metadata:
   linkType: hard
 
 "isexe@npm:^3.1.1":
-  version: 3.1.1
-  resolution: "isexe@npm:3.1.1"
-  checksum: 10/7fe1931ee4e88eb5aa524cd3ceb8c882537bc3a81b02e438b240e47012eef49c86904d0f0e593ea7c3a9996d18d0f1f3be8d3eaa92333977b0c3a9d353d5563e
+  version: 3.1.5
+  resolution: "isexe@npm:3.1.5"
+  checksum: 10/ae479f6b0505507f1a73c1d57be6d0546e59fc9202bb0d5b31ba8ff5f3e79dd385bce57a2e60c5645aba567018cbbfc663519cd28367e9962242d97dd151d2ab
+  languageName: node
+  linkType: hard
+
+"isexe@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "isexe@npm:4.0.0"
+  checksum: 10/2ead327ef596042ef9c9ec5f236b316acfaedb87f4bb61b3c3d574fb2e9c8a04b67305e04733bde52c24d9622fdebd3270aadb632adfbf9cadef88fe30f479e5
   languageName: node
   linkType: hard
 
@@ -4013,19 +3728,6 @@ __metadata:
     html-escaper: "npm:^2.0.0"
     istanbul-lib-report: "npm:^3.0.0"
   checksum: 10/6773a1d5c7d47eeec75b317144fe2a3b1da84a44b6282bebdc856e09667865e58c9b025b75b3d87f5bc62939126cbba4c871ee84254537d934ba5da5d4c4ec4e
-  languageName: node
-  linkType: hard
-
-"jackspeak@npm:^3.1.2":
-  version: 3.4.3
-  resolution: "jackspeak@npm:3.4.3"
-  dependencies:
-    "@isaacs/cliui": "npm:^8.0.2"
-    "@pkgjs/parseargs": "npm:^0.11.0"
-  dependenciesMeta:
-    "@pkgjs/parseargs":
-      optional: true
-  checksum: 10/96f8786eaab98e4bf5b2a5d6d9588ea46c4d06bbc4f2eb861fdd7b6b182b16f71d8a70e79820f335d52653b16d4843b29dd9cdcf38ae80406756db9199497cf3
   languageName: node
   linkType: hard
 
@@ -4095,15 +3797,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonc-eslint-parser@npm:^2.4.0":
-  version: 2.4.1
-  resolution: "jsonc-eslint-parser@npm:2.4.1"
+"jsonc-eslint-parser@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "jsonc-eslint-parser@npm:3.1.0"
   dependencies:
     acorn: "npm:^8.5.0"
-    eslint-visitor-keys: "npm:^3.0.0"
-    espree: "npm:^9.0.0"
+    eslint-visitor-keys: "npm:^5.0.0"
     semver: "npm:^7.3.5"
-  checksum: 10/b728fcad68a82c734f23bf1fe1694eb970d597e752b605649b0c83d98783911a6a184ede77e170059bc3efe4e43625289a39a6a518433b0466ac45c06cee3246
+  checksum: 10/ed7fa186786e042f05e51325df7409c6accc73cc567ccedb2546fd0ccb769dd076ddc3fd9add0c302278cfe6161bdc9880bff5b02a7194c51ec5f53723439544
   languageName: node
   linkType: hard
 
@@ -4269,13 +3970,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:^10.0.1, lru-cache@npm:^10.2.0":
-  version: 10.4.3
-  resolution: "lru-cache@npm:10.4.3"
-  checksum: 10/e6e90267360476720fa8e83cc168aa2bf0311f3f2eea20a6ba78b90a885ae72071d9db132f40fda4129c803e7dcec3a6b6a6fbb44ca90b081630b810b5d6a41a
-  languageName: node
-  linkType: hard
-
 "luxon@npm:~3.7.0":
   version: 3.7.2
   resolution: "luxon@npm:3.7.2"
@@ -4312,25 +4006,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"make-fetch-happen@npm:^14.0.3":
-  version: 14.0.3
-  resolution: "make-fetch-happen@npm:14.0.3"
-  dependencies:
-    "@npmcli/agent": "npm:^3.0.0"
-    cacache: "npm:^19.0.1"
-    http-cache-semantics: "npm:^4.1.1"
-    minipass: "npm:^7.0.2"
-    minipass-fetch: "npm:^4.0.0"
-    minipass-flush: "npm:^1.0.5"
-    minipass-pipeline: "npm:^1.2.4"
-    negotiator: "npm:^1.0.0"
-    proc-log: "npm:^5.0.0"
-    promise-retry: "npm:^2.0.1"
-    ssri: "npm:^12.0.0"
-  checksum: 10/fce0385840b6d86b735053dfe941edc2dd6468fda80fe74da1eeff10cbd82a75760f406194f2bc2fa85b99545b2bc1f84c08ddf994b21830775ba2d1a87e8bdf
-  languageName: node
-  linkType: hard
-
 "math-intrinsics@npm:^1.1.0":
   version: 1.1.0
   resolution: "math-intrinsics@npm:1.1.0"
@@ -4352,16 +4027,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^10.2.2, minimatch@npm:^10.2.4":
-  version: 10.2.4
-  resolution: "minimatch@npm:10.2.4"
-  dependencies:
-    brace-expansion: "npm:^5.0.2"
-  checksum: 10/aea4874e521c55bb60744685bbffe3d152e5460f84efac3ea936e6bbe2ceba7deb93345fec3f9bb17f7b6946776073a64d40ae32bf5f298ad690308121068a1f
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:^10.2.5":
+"minimatch@npm:^10.2.2, minimatch@npm:^10.2.4, minimatch@npm:^10.2.5":
   version: 10.2.5
   resolution: "minimatch@npm:10.2.5"
   dependencies:
@@ -4370,30 +4036,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^3.1.2":
-  version: 3.1.2
-  resolution: "minimatch@npm:3.1.2"
-  dependencies:
-    brace-expansion: "npm:^1.1.7"
-  checksum: 10/e0b25b04cd4ec6732830344e5739b13f8690f8a012d73445a4a19fbc623f5dd481ef7a5827fde25954cd6026fede7574cc54dc4643c99d6c6b653d6203f94634
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:^3.1.5":
+"minimatch@npm:^3.1.2, minimatch@npm:^3.1.5":
   version: 3.1.5
   resolution: "minimatch@npm:3.1.5"
   dependencies:
     brace-expansion: "npm:^1.1.7"
   checksum: 10/b11a7ee5773cd34c1a0c8436cdbe910901018fb4b6cb47aa508a18d567f6efd2148507959e35fba798389b161b8604a2d704ccef751ea36bd4582f9852b7d63f
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:^9.0.4":
-  version: 9.0.5
-  resolution: "minimatch@npm:9.0.5"
-  dependencies:
-    brace-expansion: "npm:^2.0.1"
-  checksum: 10/dd6a8927b063aca6d910b119e1f2df6d2ce7d36eab91de83167dd136bb85e1ebff97b0d3de1cb08bd1f7e018ca170b4962479fefab5b2a69e2ae12cb2edc8348
   languageName: node
   linkType: hard
 
@@ -4404,74 +4052,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minipass-collect@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "minipass-collect@npm:2.0.1"
-  dependencies:
-    minipass: "npm:^7.0.3"
-  checksum: 10/b251bceea62090f67a6cced7a446a36f4cd61ee2d5cea9aee7fff79ba8030e416327a1c5aa2908dc22629d06214b46d88fdab8c51ac76bacbf5703851b5ad342
+"minipass@npm:^7.0.4, minipass@npm:^7.1.2":
+  version: 7.1.3
+  resolution: "minipass@npm:7.1.3"
+  checksum: 10/175e4d5e20980c3cd316ae82d2c031c42f6c746467d8b1905b51060a0ba4461441a0c25bb67c025fd9617f9a3873e152c7b543c6b5ac83a1846be8ade80dffd6
   languageName: node
   linkType: hard
 
-"minipass-fetch@npm:^4.0.0":
-  version: 4.0.1
-  resolution: "minipass-fetch@npm:4.0.1"
-  dependencies:
-    encoding: "npm:^0.1.13"
-    minipass: "npm:^7.0.3"
-    minipass-sized: "npm:^1.0.3"
-    minizlib: "npm:^3.0.1"
-  dependenciesMeta:
-    encoding:
-      optional: true
-  checksum: 10/7ddfebdbb87d9866e7b5f7eead5a9e3d9d507992af932a11d275551f60006cf7d9178e66d586dbb910894f3e3458d27c0ddf93c76e94d49d0a54a541ddc1263d
-  languageName: node
-  linkType: hard
-
-"minipass-flush@npm:^1.0.5":
-  version: 1.0.5
-  resolution: "minipass-flush@npm:1.0.5"
-  dependencies:
-    minipass: "npm:^3.0.0"
-  checksum: 10/56269a0b22bad756a08a94b1ffc36b7c9c5de0735a4dd1ab2b06c066d795cfd1f0ac44a0fcae13eece5589b908ecddc867f04c745c7009be0b566421ea0944cf
-  languageName: node
-  linkType: hard
-
-"minipass-pipeline@npm:^1.2.4":
-  version: 1.2.4
-  resolution: "minipass-pipeline@npm:1.2.4"
-  dependencies:
-    minipass: "npm:^3.0.0"
-  checksum: 10/b14240dac0d29823c3d5911c286069e36d0b81173d7bdf07a7e4a91ecdef92cdff4baaf31ea3746f1c61e0957f652e641223970870e2353593f382112257971b
-  languageName: node
-  linkType: hard
-
-"minipass-sized@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "minipass-sized@npm:1.0.3"
-  dependencies:
-    minipass: "npm:^3.0.0"
-  checksum: 10/40982d8d836a52b0f37049a0a7e5d0f089637298e6d9b45df9c115d4f0520682a78258905e5c8b180fb41b593b0a82cc1361d2c74b45f7ada66334f84d1ecfdd
-  languageName: node
-  linkType: hard
-
-"minipass@npm:^3.0.0":
-  version: 3.3.6
-  resolution: "minipass@npm:3.3.6"
-  dependencies:
-    yallist: "npm:^4.0.0"
-  checksum: 10/a5c6ef069f70d9a524d3428af39f2b117ff8cd84172e19b754e7264a33df460873e6eb3d6e55758531580970de50ae950c496256bb4ad3691a2974cddff189f0
-  languageName: node
-  linkType: hard
-
-"minipass@npm:^5.0.0 || ^6.0.2 || ^7.0.0, minipass@npm:^7.0.2, minipass@npm:^7.0.3, minipass@npm:^7.0.4, minipass@npm:^7.1.2":
-  version: 7.1.2
-  resolution: "minipass@npm:7.1.2"
-  checksum: 10/c25f0ee8196d8e6036661104bacd743785b2599a21de5c516b32b3fa2b83113ac89a2358465bc04956baab37ffb956ae43be679b2262bf7be15fce467ccd7950
-  languageName: node
-  linkType: hard
-
-"minizlib@npm:^3.0.1, minizlib@npm:^3.1.0":
+"minizlib@npm:^3.1.0":
   version: 3.1.0
   resolution: "minizlib@npm:3.1.0"
   dependencies:
@@ -4503,48 +4091,63 @@ __metadata:
   languageName: node
   linkType: hard
 
-"negotiator@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "negotiator@npm:1.0.0"
-  checksum: 10/b5734e87295324fabf868e36fb97c84b7d7f3156ec5f4ee5bf6e488079c11054f818290fc33804cef7b1ee21f55eeb14caea83e7dafae6492a409b3e573153e5
+"node-exports-info@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "node-exports-info@npm:1.6.0"
+  dependencies:
+    array.prototype.flatmap: "npm:^1.3.3"
+    es-errors: "npm:^1.3.0"
+    object.entries: "npm:^1.1.9"
+    semver: "npm:^6.3.1"
+  checksum: 10/0a1667d535f499ac1fe6c6d22f8146bc8b68abc76fa355856219202f6cf5f386027e0ff054e66a22d08be02acbc63fcdc9f98d0fbc97993f5eabc66408fdadad
   languageName: node
   linkType: hard
 
 "node-gyp@npm:latest":
-  version: 11.5.0
-  resolution: "node-gyp@npm:11.5.0"
+  version: 12.3.0
+  resolution: "node-gyp@npm:12.3.0"
   dependencies:
     env-paths: "npm:^2.2.0"
     exponential-backoff: "npm:^3.1.1"
     graceful-fs: "npm:^4.2.6"
-    make-fetch-happen: "npm:^14.0.3"
-    nopt: "npm:^8.0.0"
-    proc-log: "npm:^5.0.0"
+    nopt: "npm:^9.0.0"
+    proc-log: "npm:^6.0.0"
     semver: "npm:^7.3.5"
-    tar: "npm:^7.4.3"
+    tar: "npm:^7.5.4"
     tinyglobby: "npm:^0.2.12"
-    which: "npm:^5.0.0"
+    undici: "npm:^6.25.0"
+    which: "npm:^6.0.0"
   bin:
     node-gyp: bin/node-gyp.js
-  checksum: 10/15a600b626116e1e528c49f73027c5ff84dbf6986df77b0fb61d6eb079ab4230c39f245295cb67f0590e6541a848cbd267e00c5769e8fb8bf88a5cca3701b551
+  checksum: 10/cd97bf17f0f3e6288c42cc23a6db8528a98e7530abdb72ab558272906d603362e4558069f99f8a5250bc78f65ff305b1438caca4f1b31c81904a8798c242603e
   languageName: node
   linkType: hard
 
-"node-releases@npm:^2.0.26":
-  version: 2.0.26
-  resolution: "node-releases@npm:2.0.26"
-  checksum: 10/6aa120cbf6b0e0986dfa2ee168c8357bdc79b9d9b088b9c643b5e47a28471a2aa4c55e25808e4b43140c6a1398ceab05ea9673ec1d630112f631795e4f7ceb99
+"node-releases@npm:^2.0.36":
+  version: 2.0.38
+  resolution: "node-releases@npm:2.0.38"
+  checksum: 10/0e6bba9d7e75dddf7d45c099f202ac7cb0eaeb363c36a34880c219e1697cf7369b6548e48f538490b706501ff9aa017e102adf3362184b9b64786de8377e0501
   languageName: node
   linkType: hard
 
-"nopt@npm:^8.0.0":
-  version: 8.1.0
-  resolution: "nopt@npm:8.1.0"
+"nopt@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "nopt@npm:9.0.0"
   dependencies:
-    abbrev: "npm:^3.0.0"
+    abbrev: "npm:^4.0.0"
   bin:
     nopt: bin/nopt.js
-  checksum: 10/26ab456c51a96f02a9e5aa8d1b80ef3219f2070f3f3528a040e32fb735b1e651e17bdf0f1476988d3a46d498f35c65ed662d122f340d38ce4a7e71dd7b20c4bc
+  checksum: 10/56a1ccd2ad711fb5115918e2c96828703cddbe12ba2c3bd00591758f6fa30e6f47dd905c59dbfcf9b773f3a293b45996609fb6789ae29d6bfcc3cf3a6f7d9fda
+  languageName: node
+  linkType: hard
+
+"npm-check-updates@npm:^22.0.1":
+  version: 22.0.1
+  resolution: "npm-check-updates@npm:22.0.1"
+  bin:
+    ncu: build/cli.js
+    npm-check-updates: build/cli.js
+  checksum: 10/03a8fee1b3a7bea04ffe23a68d3c6ba9f39cbb18f744d89783298bf3bdcde4071853f6487aa3431b806d1efcec41cfd2722cd4e0663d4e38601815ae81ec526e
   languageName: node
   linkType: hard
 
@@ -4589,6 +4192,18 @@ __metadata:
     has-symbols: "npm:^1.1.0"
     object-keys: "npm:^1.1.1"
   checksum: 10/3fe28cdd779f2a728a9a66bd688679ba231a2b16646cd1e46b528fe7c947494387dda4bc189eff3417f3717ef4f0a8f2439347cf9a9aa3cef722fbfd9f615587
+  languageName: node
+  linkType: hard
+
+"object.entries@npm:^1.1.9":
+  version: 1.1.9
+  resolution: "object.entries@npm:1.1.9"
+  dependencies:
+    call-bind: "npm:^1.0.8"
+    call-bound: "npm:^1.0.4"
+    define-properties: "npm:^1.2.1"
+    es-object-atoms: "npm:^1.1.1"
+  checksum: 10/24163ab1e1e013796693fc5f5d349e8b3ac0b6a34a7edb6c17d3dd45c6a8854145780c57d302a82512c1582f63720f4b4779d6c1cfba12cbb1420b978802d8a3
   languageName: node
   linkType: hard
 
@@ -4702,20 +4317,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-map@npm:^7.0.2":
-  version: 7.0.3
-  resolution: "p-map@npm:7.0.3"
-  checksum: 10/2ef48ccfc6dd387253d71bf502604f7893ed62090b2c9d73387f10006c342606b05233da0e4f29388227b61eb5aeface6197e166520c465c234552eeab2fe633
-  languageName: node
-  linkType: hard
-
-"package-json-from-dist@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "package-json-from-dist@npm:1.0.1"
-  checksum: 10/58ee9538f2f762988433da00e26acc788036914d57c71c246bf0be1b60cdbd77dd60b6a3e1a30465f0b248aeb80079e0b34cb6050b1dfa18c06953bb1cbc7602
-  languageName: node
-  linkType: hard
-
 "parent-module@npm:^1.0.0":
   version: 1.0.1
   resolution: "parent-module@npm:1.0.1"
@@ -4746,16 +4347,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-scurry@npm:^1.11.1":
-  version: 1.11.1
-  resolution: "path-scurry@npm:1.11.1"
-  dependencies:
-    lru-cache: "npm:^10.2.0"
-    minipass: "npm:^5.0.0 || ^6.0.2 || ^7.0.0"
-  checksum: 10/5e8845c159261adda6f09814d7725683257fcc85a18f329880ab4d7cc1d12830967eae5d5894e453f341710d5484b8fdbbd4d75181b4d6e1eb2f4dc7aeadc434
-  languageName: node
-  linkType: hard
-
 "pathe@npm:^2.0.3":
   version: 2.0.3
   resolution: "pathe@npm:2.0.3"
@@ -4770,14 +4361,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^4.0.3":
-  version: 4.0.3
-  resolution: "picomatch@npm:4.0.3"
-  checksum: 10/57b99055f40b16798f2802916d9c17e9744e620a0db136554af01d19598b96e45e2f00014c91d1b8b13874b80caa8c295b3d589a3f72373ec4aaf54baa5962d5
-  languageName: node
-  linkType: hard
-
-"picomatch@npm:^4.0.4":
+"picomatch@npm:^4.0.3, picomatch@npm:^4.0.4":
   version: 4.0.4
   resolution: "picomatch@npm:4.0.4"
   checksum: 10/f6ef80a3590827ce20378ae110ac78209cc4f74d39236370f1780f957b7ee41c12acde0e4651b90f39983506fd2f5e449994716f516db2e9752924aff8de93ce
@@ -4817,13 +4401,13 @@ __metadata:
   linkType: hard
 
 "pino-std-serializers@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "pino-std-serializers@npm:7.0.0"
-  checksum: 10/884e08f65aa5463d820521ead3779d4472c78fc434d8582afb66f9dcb8d8c7119c69524b68106cb8caf92c0487be7794cf50e5b9c0383ae65b24bf2a03480951
+  version: 7.1.0
+  resolution: "pino-std-serializers@npm:7.1.0"
+  checksum: 10/6e27f6f885927b6df3b424ddb8a9e0e9854f3b59f4abd51afa74e1c2cf33436a505277b004bb00ce61884a962c8fdfd977391205c7baab885d6afb35fce7396a
   languageName: node
   linkType: hard
 
-"pino@npm:^10.1.0":
+"pino@npm:^10.3.1":
   version: 10.3.1
   resolution: "pino@npm:10.3.1"
   dependencies:
@@ -4858,14 +4442,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.5.8":
-  version: 8.5.8
-  resolution: "postcss@npm:8.5.8"
+"postcss@npm:^8.5.10":
+  version: 8.5.12
+  resolution: "postcss@npm:8.5.12"
   dependencies:
     nanoid: "npm:^3.3.11"
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
-  checksum: 10/cbacbfd7f767e2c820d4bf09a3a744834dd7d14f69ff08d1f57b1a7defce9ae5efcf31981890d9697a972a64e9965de677932ef28e4c8ba23a87aad45b82c459
+  checksum: 10/ec6b79b68c363eca3c8ffceb134a4ab637274aee6ac0857614bf7c18d40ce4ce5f9036edec57b7e0be99895724d2599d0ec7328dbd7f407204e7548697b322f1
   languageName: node
   linkType: hard
 
@@ -4885,7 +4469,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:^3.7.4":
+"prettier@npm:^3.8.3":
   version: 3.8.3
   resolution: "prettier@npm:3.8.3"
   bin:
@@ -4894,10 +4478,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proc-log@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "proc-log@npm:5.0.0"
-  checksum: 10/35610bdb0177d3ab5d35f8827a429fb1dc2518d9e639f2151ac9007f01a061c30e0c635a970c9b00c39102216160f6ec54b62377c92fac3b7bfc2ad4b98d195c
+"proc-log@npm:^6.0.0":
+  version: 6.1.0
+  resolution: "proc-log@npm:6.1.0"
+  checksum: 10/9033f30f168ed5a0991b773d0c50ff88384c4738e9a0a67d341de36bf7293771eed648ab6a0562f62276da12fde91f3bbfc75ffff6e71ad49aafd74fc646be66
   languageName: node
   linkType: hard
 
@@ -4908,23 +4492,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"promise-retry@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "promise-retry@npm:2.0.1"
-  dependencies:
-    err-code: "npm:^2.0.2"
-    retry: "npm:^0.12.0"
-  checksum: 10/96e1a82453c6c96eef53a37a1d6134c9f2482f94068f98a59145d0986ca4e497bf110a410adf73857e588165eab3899f0ebcf7b3890c1b3ce802abc0d65967d4
-  languageName: node
-  linkType: hard
-
 "pump@npm:^3.0.0":
-  version: 3.0.3
-  resolution: "pump@npm:3.0.3"
+  version: 3.0.4
+  resolution: "pump@npm:3.0.4"
   dependencies:
     end-of-stream: "npm:^1.1.0"
     once: "npm:^1.3.1"
-  checksum: 10/52843fc933b838c0330f588388115a1b28ef2a5ffa7774709b142e35431e8ab0c2edec90de3fa34ebb72d59fef854f151eea7dfc211b6dcf586b384556bd2f39
+  checksum: 10/d043c3e710c56ffd280711e98a94e863ab334f79ea43cee0fb70e1349b2355ffd2ff287c7522e4c960a247699d5b7825f00fa090b85d6179c973be13f78a6c49
   languageName: node
   linkType: hard
 
@@ -5008,13 +4582,13 @@ __metadata:
   linkType: hard
 
 "regjsparser@npm:^0.13.0":
-  version: 0.13.0
-  resolution: "regjsparser@npm:0.13.0"
+  version: 0.13.1
+  resolution: "regjsparser@npm:0.13.1"
   dependencies:
     jsesc: "npm:~3.1.0"
   bin:
     regjsparser: bin/parser
-  checksum: 10/eeaabd3454f59394cbb3bfeb15fd789e638040f37d0bee9071a9b0b85524ddc52b5f7aaaaa4847304c36fa37429e53d109c4dbf6b878cb5ffa4f4198c1042fb7
+  checksum: 10/3383e9dab8bc8cd09efcd9538191b1e194b1921438ca69fce833d1a447d0625635229464cbc6cb03f33e5d342f2d343e2738fdac9132e2470bca621e480c02ec
   languageName: node
   linkType: hard
 
@@ -5046,60 +4620,59 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.22.4":
-  version: 1.22.11
-  resolution: "resolve@npm:1.22.11"
+"resolve@npm:^2.0.0-next.6":
+  version: 2.0.0-next.6
+  resolution: "resolve@npm:2.0.0-next.6"
   dependencies:
+    es-errors: "npm:^1.3.0"
     is-core-module: "npm:^2.16.1"
+    node-exports-info: "npm:^1.6.0"
+    object-keys: "npm:^1.1.1"
     path-parse: "npm:^1.0.7"
     supports-preserve-symlinks-flag: "npm:^1.0.0"
   bin:
     resolve: bin/resolve
-  checksum: 10/e1b2e738884a08de03f97ee71494335eba8c2b0feb1de9ae065e82c48997f349f77a2b10e8817e147cf610bfabc4b1cb7891ee8eaf5bf80d4ad514a34c4fab0a
+  checksum: 10/c95cb98b8d3f9e2a979e6eb8b7e0b0e13f08da62607a45207275f151d640152244568a9a9cd01662a21e3746792177cbf9be1dacb88f7355edf4db49d9ee27e5
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>":
-  version: 1.22.11
-  resolution: "resolve@patch:resolve@npm%3A1.22.11#optional!builtin<compat/resolve>::version=1.22.11&hash=c3c19d"
+"resolve@patch:resolve@npm%3A^2.0.0-next.6#optional!builtin<compat/resolve>":
+  version: 2.0.0-next.6
+  resolution: "resolve@patch:resolve@npm%3A2.0.0-next.6#optional!builtin<compat/resolve>::version=2.0.0-next.6&hash=c3c19d"
   dependencies:
+    es-errors: "npm:^1.3.0"
     is-core-module: "npm:^2.16.1"
+    node-exports-info: "npm:^1.6.0"
+    object-keys: "npm:^1.1.1"
     path-parse: "npm:^1.0.7"
     supports-preserve-symlinks-flag: "npm:^1.0.0"
   bin:
     resolve: bin/resolve
-  checksum: 10/fd342cad25e52cd6f4f3d1716e189717f2522bfd6641109fe7aa372f32b5714a296ed7c238ddbe7ebb0c1ddfe0b7f71c9984171024c97cf1b2073e3e40ff71a8
+  checksum: 10/1b26738af76c80b341075e6bf4b202ef85f85f4a2cbf2934246c3b5f20c682cf352833fc6e32579c6967419226d3ab63e8d321328da052c87a31eaad91e3571a
   languageName: node
   linkType: hard
 
-"retry@npm:^0.12.0":
-  version: 0.12.0
-  resolution: "retry@npm:0.12.0"
-  checksum: 10/1f914879f97e7ee931ad05fe3afa629bd55270fc6cf1c1e589b6a99fab96d15daad0fa1a52a00c729ec0078045fe3e399bd4fd0c93bcc906957bdc17f89cb8e6
-  languageName: node
-  linkType: hard
-
-"rolldown@npm:1.0.0-rc.12":
-  version: 1.0.0-rc.12
-  resolution: "rolldown@npm:1.0.0-rc.12"
+"rolldown@npm:1.0.0-rc.17":
+  version: 1.0.0-rc.17
+  resolution: "rolldown@npm:1.0.0-rc.17"
   dependencies:
-    "@oxc-project/types": "npm:=0.122.0"
-    "@rolldown/binding-android-arm64": "npm:1.0.0-rc.12"
-    "@rolldown/binding-darwin-arm64": "npm:1.0.0-rc.12"
-    "@rolldown/binding-darwin-x64": "npm:1.0.0-rc.12"
-    "@rolldown/binding-freebsd-x64": "npm:1.0.0-rc.12"
-    "@rolldown/binding-linux-arm-gnueabihf": "npm:1.0.0-rc.12"
-    "@rolldown/binding-linux-arm64-gnu": "npm:1.0.0-rc.12"
-    "@rolldown/binding-linux-arm64-musl": "npm:1.0.0-rc.12"
-    "@rolldown/binding-linux-ppc64-gnu": "npm:1.0.0-rc.12"
-    "@rolldown/binding-linux-s390x-gnu": "npm:1.0.0-rc.12"
-    "@rolldown/binding-linux-x64-gnu": "npm:1.0.0-rc.12"
-    "@rolldown/binding-linux-x64-musl": "npm:1.0.0-rc.12"
-    "@rolldown/binding-openharmony-arm64": "npm:1.0.0-rc.12"
-    "@rolldown/binding-wasm32-wasi": "npm:1.0.0-rc.12"
-    "@rolldown/binding-win32-arm64-msvc": "npm:1.0.0-rc.12"
-    "@rolldown/binding-win32-x64-msvc": "npm:1.0.0-rc.12"
-    "@rolldown/pluginutils": "npm:1.0.0-rc.12"
+    "@oxc-project/types": "npm:=0.127.0"
+    "@rolldown/binding-android-arm64": "npm:1.0.0-rc.17"
+    "@rolldown/binding-darwin-arm64": "npm:1.0.0-rc.17"
+    "@rolldown/binding-darwin-x64": "npm:1.0.0-rc.17"
+    "@rolldown/binding-freebsd-x64": "npm:1.0.0-rc.17"
+    "@rolldown/binding-linux-arm-gnueabihf": "npm:1.0.0-rc.17"
+    "@rolldown/binding-linux-arm64-gnu": "npm:1.0.0-rc.17"
+    "@rolldown/binding-linux-arm64-musl": "npm:1.0.0-rc.17"
+    "@rolldown/binding-linux-ppc64-gnu": "npm:1.0.0-rc.17"
+    "@rolldown/binding-linux-s390x-gnu": "npm:1.0.0-rc.17"
+    "@rolldown/binding-linux-x64-gnu": "npm:1.0.0-rc.17"
+    "@rolldown/binding-linux-x64-musl": "npm:1.0.0-rc.17"
+    "@rolldown/binding-openharmony-arm64": "npm:1.0.0-rc.17"
+    "@rolldown/binding-wasm32-wasi": "npm:1.0.0-rc.17"
+    "@rolldown/binding-win32-arm64-msvc": "npm:1.0.0-rc.17"
+    "@rolldown/binding-win32-x64-msvc": "npm:1.0.0-rc.17"
+    "@rolldown/pluginutils": "npm:1.0.0-rc.17"
   dependenciesMeta:
     "@rolldown/binding-android-arm64":
       optional: true
@@ -5133,20 +4706,20 @@ __metadata:
       optional: true
   bin:
     rolldown: bin/cli.mjs
-  checksum: 10/b8cc0d9df80b495a57b63d69a16a5566c600162046edd407f335a6d27e5b6618a2d88d63e82c4e77a1447d18edcc6900696e041c33236ef38ab51d33cf5da2fe
+  checksum: 10/5e7415a7cb732c4f7168ab6dcc841ed9ec4ad614058294a53d94821a762c274a69b009e41e9c8e4983a059907f02d462030a36b42543c0f41ce702fcd68d10d5
   languageName: node
   linkType: hard
 
 "safe-array-concat@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "safe-array-concat@npm:1.1.3"
+  version: 1.1.4
+  resolution: "safe-array-concat@npm:1.1.4"
   dependencies:
-    call-bind: "npm:^1.0.8"
-    call-bound: "npm:^1.0.2"
-    get-intrinsic: "npm:^1.2.6"
+    call-bind: "npm:^1.0.9"
+    call-bound: "npm:^1.0.4"
+    get-intrinsic: "npm:^1.3.0"
     has-symbols: "npm:^1.1.0"
     isarray: "npm:^2.0.5"
-  checksum: 10/fac4f40f20a3f7da024b54792fcc61059e814566dcbb04586bfefef4d3b942b2408933f25b7b3dd024affd3f2a6bbc916bef04807855e4f192413941369db864
+  checksum: 10/89e6a4d2759225515e5ea6b9f21a62dfad74c3aef45c769c9bf000b1c681f15568183e62935711ec9d10c35712c4f21f0d6acb094bd35138608b4a57fa64667d
   languageName: node
   linkType: hard
 
@@ -5187,13 +4760,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safer-buffer@npm:>= 2.1.2 < 3.0.0":
-  version: 2.1.2
-  resolution: "safer-buffer@npm:2.1.2"
-  checksum: 10/7eaf7a0cf37cc27b42fb3ef6a9b1df6e93a1c6d98c6c6702b02fe262d5fcbd89db63320793b99b21cb5348097d0a53de81bd5f4e8b86e20cc9412e3f1cfb4e83
-  languageName: node
-  linkType: hard
-
 "scslre@npm:^0.3.0":
   version: 0.3.0
   resolution: "scslre@npm:0.3.0"
@@ -5221,16 +4787,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.3.5, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.7.3":
-  version: 7.7.3
-  resolution: "semver@npm:7.7.3"
-  bin:
-    semver: bin/semver.js
-  checksum: 10/8dbc3168e057a38fc322af909c7f5617483c50caddba135439ff09a754b20bdd6482a5123ff543dad4affa488ecf46ec5fb56d61312ad20bb140199b88dfaea9
-  languageName: node
-  linkType: hard
-
-"semver@npm:^7.7.4":
+"semver@npm:^7.3.5, semver@npm:^7.5.3, semver@npm:^7.7.3, semver@npm:^7.7.4":
   version: 7.7.4
   resolution: "semver@npm:7.7.4"
   bin:
@@ -5293,12 +4850,12 @@ __metadata:
   linkType: hard
 
 "side-channel-list@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "side-channel-list@npm:1.0.0"
+  version: 1.0.1
+  resolution: "side-channel-list@npm:1.0.1"
   dependencies:
     es-errors: "npm:^1.3.0"
-    object-inspect: "npm:^1.13.3"
-  checksum: 10/603b928997abd21c5a5f02ae6b9cc36b72e3176ad6827fab0417ead74580cc4fb4d5c7d0a8a2ff4ead34d0f9e35701ed7a41853dac8a6d1a664fcce1a044f86f
+    object-inspect: "npm:^1.13.4"
+  checksum: 10/3499671cd52adaee739eac1e14d07530b8e3530192741aeb05e7fe4ad1b51d1368ceea2cd3c21b0f62b05410a5c70a7c4d997ba4b143303ef73d0c65dfd1c252
   languageName: node
   linkType: hard
 
@@ -5354,20 +4911,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"signal-exit@npm:^4.0.1":
-  version: 4.1.0
-  resolution: "signal-exit@npm:4.1.0"
-  checksum: 10/c9fa63bbbd7431066174a48ba2dd9986dfd930c3a8b59de9c29d7b6854ec1c12a80d15310869ea5166d413b99f041bfa3dd80a7947bcd44ea8e6eb3ffeabfa1f
-  languageName: node
-  linkType: hard
-
-"smart-buffer@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "smart-buffer@npm:4.2.0"
-  checksum: 10/927484aa0b1640fd9473cee3e0a0bcad6fce93fd7bbc18bac9ad0c33686f5d2e2c422fba24b5899c184524af01e11dd2bd051c2bf2b07e47aff8ca72cbfc60d2
-  languageName: node
-  linkType: hard
-
 "smol-toml@npm:^1.6.1":
   version: 1.6.1
   resolution: "smol-toml@npm:1.6.1"
@@ -5375,33 +4918,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"socks-proxy-agent@npm:^8.0.3":
-  version: 8.0.5
-  resolution: "socks-proxy-agent@npm:8.0.5"
-  dependencies:
-    agent-base: "npm:^7.1.2"
-    debug: "npm:^4.3.4"
-    socks: "npm:^2.8.3"
-  checksum: 10/ee99e1dacab0985b52cbe5a75640be6e604135e9489ebdc3048635d186012fbaecc20fbbe04b177dee434c319ba20f09b3e7dfefb7d932466c0d707744eac05c
-  languageName: node
-  linkType: hard
-
-"socks@npm:^2.8.3":
-  version: 2.8.7
-  resolution: "socks@npm:2.8.7"
-  dependencies:
-    ip-address: "npm:^10.0.1"
-    smart-buffer: "npm:^4.2.0"
-  checksum: 10/d19366c95908c19db154f329bbe94c2317d315dc933a7c2b5101e73f32a555c84fb199b62174e1490082a593a4933d8d5a9b297bde7d1419c14a11a965f51356
-  languageName: node
-  linkType: hard
-
 "sonic-boom@npm:^4.0.1":
-  version: 4.2.0
-  resolution: "sonic-boom@npm:4.2.0"
+  version: 4.2.1
+  resolution: "sonic-boom@npm:4.2.1"
   dependencies:
     atomic-sleep: "npm:^1.0.0"
-  checksum: 10/385ef7fb5ea5976c1d2a1fef0b6df8df6b7caba8696d2d67f689d60c05e3ea2d536752ce7e1c69b9fad844635f1036d07c446f8e8149f5c6a80e0040a455b310
+  checksum: 10/161af46b3e6debc4ad3865b0db47f37289741a0b3005b8cf056f93a4e0e1a347e24ca1a2d8ccc864f7f19caa6185a766797f8382cdbfd2f3d046a0323d73a542
   languageName: node
   linkType: hard
 
@@ -5419,15 +4941,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ssri@npm:^12.0.0":
-  version: 12.0.0
-  resolution: "ssri@npm:12.0.0"
-  dependencies:
-    minipass: "npm:^7.0.3"
-  checksum: 10/7024c1a6e39b3f18aa8f1c8290e884fe91b0f9ca5a6c6d410544daad54de0ba664db879afe16412e187c6c292fd60b937f047ee44292e5c2af2dcc6d8e1a9b48
-  languageName: node
-  linkType: hard
-
 "stackback@npm:0.0.2":
   version: 0.0.2
   resolution: "stackback@npm:0.0.2"
@@ -5436,9 +4949,9 @@ __metadata:
   linkType: hard
 
 "std-env@npm:^4.0.0-rc.1":
-  version: 4.0.0
-  resolution: "std-env@npm:4.0.0"
-  checksum: 10/19ef21cd85da52dc1178288d1b69e242b6579c0a76ddba2374f859aa58678797ec4a34c4f1fe6b9007a032e04d6fd3fca4e27349c88809265a9cbd90d924203f
+  version: 4.1.0
+  resolution: "std-env@npm:4.1.0"
+  checksum: 10/008146cdb834010383138d356e0dd3e3b0ac127a8229f711b8c518bb22940813cc0dcd654fc76b17f0b18179f56089f8b8e52bd6a7ffa0041a966581e7a44dbe
   languageName: node
   linkType: hard
 
@@ -5449,28 +4962,6 @@ __metadata:
     es-errors: "npm:^1.3.0"
     internal-slot: "npm:^1.1.0"
   checksum: 10/ff36c4db171ee76c936ccfe9541946b77017f12703d4c446652017356816862d3aa029a64e7d4c4ceb484e00ed4a81789333896390d808458638f3a216aa1f41
-  languageName: node
-  linkType: hard
-
-"string-width-cjs@npm:string-width@^4.2.0, string-width@npm:^4.1.0":
-  version: 4.2.3
-  resolution: "string-width@npm:4.2.3"
-  dependencies:
-    emoji-regex: "npm:^8.0.0"
-    is-fullwidth-code-point: "npm:^3.0.0"
-    strip-ansi: "npm:^6.0.1"
-  checksum: 10/e52c10dc3fbfcd6c3a15f159f54a90024241d0f149cf8aed2982a2d801d2e64df0bf1dc351cf8e95c3319323f9f220c16e740b06faecd53e2462df1d2b5443fb
-  languageName: node
-  linkType: hard
-
-"string-width@npm:^5.0.1, string-width@npm:^5.1.2":
-  version: 5.1.2
-  resolution: "string-width@npm:5.1.2"
-  dependencies:
-    eastasianwidth: "npm:^0.2.0"
-    emoji-regex: "npm:^9.2.2"
-    strip-ansi: "npm:^7.0.1"
-  checksum: 10/7369deaa29f21dda9a438686154b62c2c5f661f8dda60449088f9f980196f7908fc39fdd1803e3e01541970287cf5deae336798337e9319a7055af89dafa7193
   languageName: node
   linkType: hard
 
@@ -5509,24 +5000,6 @@ __metadata:
     define-properties: "npm:^1.2.1"
     es-object-atoms: "npm:^1.0.0"
   checksum: 10/160167dfbd68e6f7cb9f51a16074eebfce1571656fc31d40c3738ca9e30e35496f2c046fe57b6ad49f65f238a152be8c86fd9a2dd58682b5eba39dad995b3674
-  languageName: node
-  linkType: hard
-
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1, strip-ansi@npm:^6.0.0, strip-ansi@npm:^6.0.1":
-  version: 6.0.1
-  resolution: "strip-ansi@npm:6.0.1"
-  dependencies:
-    ansi-regex: "npm:^5.0.1"
-  checksum: 10/ae3b5436d34fadeb6096367626ce987057713c566e1e7768818797e00ac5d62023d0f198c4e681eae9e20701721980b26a64a8f5b91238869592a9c6800719a2
-  languageName: node
-  linkType: hard
-
-"strip-ansi@npm:^7.0.1":
-  version: 7.1.2
-  resolution: "strip-ansi@npm:7.1.2"
-  dependencies:
-    ansi-regex: "npm:^6.0.1"
-  checksum: 10/db0e3f9654e519c8a33c50fc9304d07df5649388e7da06d3aabf66d29e5ad65d5e6315d8519d409c15b32fa82c1df7e11ed6f8cd50b0e4404463f0c9d77c8d0b
   languageName: node
   linkType: hard
 
@@ -5590,15 +5063,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"synckit@npm:^0.6.2 || ^0.7.3 || ^0.11.5":
-  version: 0.11.11
-  resolution: "synckit@npm:0.11.11"
-  dependencies:
-    "@pkgr/core": "npm:^0.2.9"
-  checksum: 10/6ecd88212b5be80004376b6ea74babcba284566ff59a50d8803afcaa78c165b5d268635c1dd84532ee3f690a979409e1eda225a8a35bed2d135ffdcea06ce7b0
-  languageName: node
-  linkType: hard
-
 "tagged-tag@npm:^1.0.0":
   version: 1.0.0
   resolution: "tagged-tag@npm:1.0.0"
@@ -5606,16 +5070,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^7.4.3":
-  version: 7.5.6
-  resolution: "tar@npm:7.5.6"
+"tar@npm:^7.5.4":
+  version: 7.5.13
+  resolution: "tar@npm:7.5.13"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10/cf4a84d79b9327fcf765f2ea16de4702b9b8dd7dc6b1840b16e0f999628d96b81b2c7efbf83d4eb42b0164856f1db887a5a61ffef97d36cdb77cac742219f9ee
+  checksum: 10/2bc2b6f0349038a6621dbba1c4522d45752d5071b2994692257113c2050cd23fafc30308f820e5f8ad6fda3f7d7f92adc9a432aa733daa04c42af2061c021c3f
   languageName: node
   linkType: hard
 
@@ -5636,19 +5100,19 @@ __metadata:
   linkType: hard
 
 "tinyexec@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "tinyexec@npm:1.0.2"
-  checksum: 10/cb709ed4240e873d3816e67f851d445f5676e0ae3a52931a60ff571d93d388da09108c8057b62351766133ee05ff3159dd56c3a0fbd39a5933c6639ce8771405
+  version: 1.1.2
+  resolution: "tinyexec@npm:1.1.2"
+  checksum: 10/2bbe37f9001c6f5723ab39eb8dc1e88f77e830d7cf2e8f34bb75019eb505fcfe3b061b4799c502ff31fa63aa1a9adc649add5ff1e17b7fbd8c16e1afb75d0b9e
   languageName: node
   linkType: hard
 
-"tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.15":
-  version: 0.2.15
-  resolution: "tinyglobby@npm:0.2.15"
+"tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.15, tinyglobby@npm:^0.2.16":
+  version: 0.2.16
+  resolution: "tinyglobby@npm:0.2.16"
   dependencies:
     fdir: "npm:^6.5.0"
-    picomatch: "npm:^4.0.3"
-  checksum: 10/d72bd826a8b0fa5fa3929e7fe5ba48fceb2ae495df3a231b6c5408cd7d8c00b58ab5a9c2a76ba56a62ee9b5e083626f1f33599734bed1ffc4b792406408f0ca2
+    picomatch: "npm:^4.0.4"
+  checksum: 10/5c2c41b572ada38449e7c86a5fe034f204a1dbba577225a761a14f29f48dc3f2fc0d81a6c56fcc67c5a742cc3aa9fb5e2ca18dbf22b610b0bc0e549b34d5a0f8
   languageName: node
   linkType: hard
 
@@ -5712,7 +5176,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:^5.3.1":
+"type-fest@npm:^5.6.0":
   version: 5.6.0
   resolution: "type-fest@npm:5.6.0"
   dependencies:
@@ -5774,23 +5238,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:>=5, typescript@npm:^5.9.3":
-  version: 5.9.3
-  resolution: "typescript@npm:5.9.3"
+"typescript@npm:>=5, typescript@npm:^6.0.3":
+  version: 6.0.3
+  resolution: "typescript@npm:6.0.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/c089d9d3da2729fd4ac517f9b0e0485914c4b3c26f80dc0cffcb5de1719a17951e92425d55db59515c1a7ddab65808466debb864d0d56dcf43f27007d0709594
+  checksum: 10/0ef2357a4cffd916b52b683a021cdab0f81eea4e9aa35f2d254581c9a5106da02224e3392e1b0ed42b7a48f80c966e5f52b8e1a27941fa0523c1705a9c2e0330
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A>=5#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.9.3#optional!builtin<compat/typescript>":
-  version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
+"typescript@patch:typescript@npm%3A>=5#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^6.0.3#optional!builtin<compat/typescript>":
+  version: 6.0.3
+  resolution: "typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>::version=6.0.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/696e1b017bc2635f4e0c94eb4435357701008e2f272f553d06e35b494b8ddc60aa221145e286c28ace0c89ee32827a28c2040e3a69bdc108b1a5dc8fb40b72e3
+  checksum: 10/22b67a18dafedf9b1468b64ca20d9aa02ea61d449b65413d8aa6552aeb63f52ef369e86beb25b6b4c91a803d9726ee5c196f391a9b64201263263410a4223ee6
   languageName: node
   linkType: hard
 
@@ -5813,27 +5277,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unique-filename@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "unique-filename@npm:4.0.0"
-  dependencies:
-    unique-slug: "npm:^5.0.0"
-  checksum: 10/6a62094fcac286b9ec39edbd1f8f64ff92383baa430af303dfed1ffda5e47a08a6b316408554abfddd9730c78b6106bef4ca4d02c1231a735ddd56ced77573df
+"undici@npm:^6.25.0":
+  version: 6.25.0
+  resolution: "undici@npm:6.25.0"
+  checksum: 10/a475e45da3e1d1073283bb70531666f09a432eabff2b857bd7063d469a1ee1486192ff61dc0dadbb526673ce1120fee14d66a59b6b17d1e0bd3a4d5f0a52d0a6
   languageName: node
   linkType: hard
 
-"unique-slug@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "unique-slug@npm:5.0.0"
-  dependencies:
-    imurmurhash: "npm:^0.1.4"
-  checksum: 10/beafdf3d6f44990e0a5ce560f8f881b4ee811be70b6ba0db25298c31c8cf525ed963572b48cd03be1c1349084f9e339be4241666d7cf1ebdad20598d3c652b27
-  languageName: node
-  linkType: hard
-
-"update-browserslist-db@npm:^1.1.4":
-  version: 1.1.4
-  resolution: "update-browserslist-db@npm:1.1.4"
+"update-browserslist-db@npm:^1.2.3":
+  version: 1.2.3
+  resolution: "update-browserslist-db@npm:1.2.3"
   dependencies:
     escalade: "npm:^3.2.0"
     picocolors: "npm:^1.1.1"
@@ -5841,7 +5294,7 @@ __metadata:
     browserslist: ">= 4.21.0"
   bin:
     update-browserslist-db: cli.js
-  checksum: 10/79b2c0a31e9b837b49dc55d5cb7b77f44a69502847c7be352a44b1d35ac2032bf0e1bb7543f992809ed427bf9d32aa3f7ad41cef96198fa959c1666870174c06
+  checksum: 10/059f774300efb4b084a49293143c511f3ae946d40397b5c30914e900cd5691a12b8e61b41dd54ed73d3b56c8204165a0333107dd784ccf8f8c81790bcc423175
   languageName: node
   linkType: hard
 
@@ -5854,29 +5307,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^13.0.0":
-  version: 13.0.0
-  resolution: "uuid@npm:13.0.0"
+"uuid@npm:^14.0.0":
+  version: 14.0.0
+  resolution: "uuid@npm:14.0.0"
   bin:
     uuid: dist-node/bin/uuid
-  checksum: 10/2742b24d1e00257e60612572e4d28679423469998cafbaf1fe9f1482e3edf9c40754b31bfdb3d08d71b29239f227a304588f75210b3b48f2609f0673f1feccef
+  checksum: 10/8ee9b98f9650e25555515f7a28d3c3ae9364e72f7bb19b9e08b681bc135338beba5509b2830f6ae1cfaba4d45401da0d16d4d109b977097bc3d6ba0c5583341b
   languageName: node
   linkType: hard
 
 "vite@npm:^6.0.0 || ^7.0.0 || ^8.0.0":
-  version: 8.0.3
-  resolution: "vite@npm:8.0.3"
+  version: 8.0.10
+  resolution: "vite@npm:8.0.10"
   dependencies:
     fsevents: "npm:~2.3.3"
     lightningcss: "npm:^1.32.0"
     picomatch: "npm:^4.0.4"
-    postcss: "npm:^8.5.8"
-    rolldown: "npm:1.0.0-rc.12"
-    tinyglobby: "npm:^0.2.15"
+    postcss: "npm:^8.5.10"
+    rolldown: "npm:1.0.0-rc.17"
+    tinyglobby: "npm:^0.2.16"
   peerDependencies:
     "@types/node": ^20.19.0 || >=22.12.0
     "@vitejs/devtools": ^0.1.0
-    esbuild: ^0.27.0
+    esbuild: ^0.27.0 || ^0.28.0
     jiti: ">=1.21.0"
     less: ^4.0.0
     sass: ^1.70.0
@@ -5916,21 +5369,21 @@ __metadata:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: 10/745b791cb71297ac3877af061da44751d93f198413426bbb76a1f8384d76d4162a6ad739b2bcdf5fb966cd1295db59412614aee60738e40e1c99cee561e682f0
+  checksum: 10/64c6fa4efa1a9ca3e1cacbcca16487b75ea25d62efbfb99c4e571b5f716296dc4f8af825eb624e273b11c3bee4e87daec35815fb6a56e01c843659c003ed2bcd
   languageName: node
   linkType: hard
 
-"vitest@npm:^4.0.16":
-  version: 4.1.4
-  resolution: "vitest@npm:4.1.4"
+"vitest@npm:^4.1.5":
+  version: 4.1.5
+  resolution: "vitest@npm:4.1.5"
   dependencies:
-    "@vitest/expect": "npm:4.1.4"
-    "@vitest/mocker": "npm:4.1.4"
-    "@vitest/pretty-format": "npm:4.1.4"
-    "@vitest/runner": "npm:4.1.4"
-    "@vitest/snapshot": "npm:4.1.4"
-    "@vitest/spy": "npm:4.1.4"
-    "@vitest/utils": "npm:4.1.4"
+    "@vitest/expect": "npm:4.1.5"
+    "@vitest/mocker": "npm:4.1.5"
+    "@vitest/pretty-format": "npm:4.1.5"
+    "@vitest/runner": "npm:4.1.5"
+    "@vitest/snapshot": "npm:4.1.5"
+    "@vitest/spy": "npm:4.1.5"
+    "@vitest/utils": "npm:4.1.5"
     es-module-lexer: "npm:^2.0.0"
     expect-type: "npm:^1.3.0"
     magic-string: "npm:^0.30.21"
@@ -5948,12 +5401,12 @@ __metadata:
     "@edge-runtime/vm": "*"
     "@opentelemetry/api": ^1.9.0
     "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
-    "@vitest/browser-playwright": 4.1.4
-    "@vitest/browser-preview": 4.1.4
-    "@vitest/browser-webdriverio": 4.1.4
-    "@vitest/coverage-istanbul": 4.1.4
-    "@vitest/coverage-v8": 4.1.4
-    "@vitest/ui": 4.1.4
+    "@vitest/browser-playwright": 4.1.5
+    "@vitest/browser-preview": 4.1.5
+    "@vitest/browser-webdriverio": 4.1.5
+    "@vitest/coverage-istanbul": 4.1.5
+    "@vitest/coverage-v8": 4.1.5
+    "@vitest/ui": 4.1.5
     happy-dom: "*"
     jsdom: "*"
     vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -5984,7 +5437,7 @@ __metadata:
       optional: false
   bin:
     vitest: vitest.mjs
-  checksum: 10/c5608c506ae9ab3d0baa7445290c240941ad54a93eb853a005b2fe518efb1b28282945e0565ca16a624cca5b23af0c33ee34fbc2c38e6664ea54b08b9a22a653
+  checksum: 10/8b768514993d8908fc9b5f2d619943d23b81aaba9443132583bd58aeb441bf76d152961326de9ca328ff0efcddbf8a58f4568a7b66a4391202542ed772613d81
   languageName: node
   linkType: hard
 
@@ -6049,8 +5502,8 @@ __metadata:
   linkType: hard
 
 "which-typed-array@npm:^1.1.16, which-typed-array@npm:^1.1.19":
-  version: 1.1.19
-  resolution: "which-typed-array@npm:1.1.19"
+  version: 1.1.20
+  resolution: "which-typed-array@npm:1.1.20"
   dependencies:
     available-typed-arrays: "npm:^1.0.7"
     call-bind: "npm:^1.0.8"
@@ -6059,7 +5512,7 @@ __metadata:
     get-proto: "npm:^1.0.1"
     gopd: "npm:^1.2.0"
     has-tostringtag: "npm:^1.0.2"
-  checksum: 10/12be30fb88567f9863186bee1777f11bea09dd59ed8b3ce4afa7dd5cade75e2f4cc56191a2da165113cc7cf79987ba021dac1e22b5b62aa7e5c56949f2469a68
+  checksum: 10/e56da3fc995d330ff012f682476f7883c16b12d36c6717c87c7ca23eb5a5ef957fa89115dacb389b11a9b4e99d5dbe2d12689b4d5d08c050b5aed0eae385b840
   languageName: node
   linkType: hard
 
@@ -6085,14 +5538,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "which@npm:5.0.0"
+"which@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "which@npm:6.0.1"
   dependencies:
-    isexe: "npm:^3.1.1"
+    isexe: "npm:^4.0.0"
   bin:
     node-which: bin/which.js
-  checksum: 10/6ec99e89ba32c7e748b8a3144e64bfc74aa63e2b2eacbb61a0060ad0b961eb1a632b08fb1de067ed59b002cec3e21de18299216ebf2325ef0f78e0f121e14e90
+  checksum: 10/dbea77c7d3058bf6c78bf9659d2dce4d2b57d39a15b826b2af6ac2e5a219b99dc8a831b79fdbc453c0598adb4f3f84cf9c2491fd52beb9f5d2dececcad117f68
   languageName: node
   linkType: hard
 
@@ -6115,28 +5568,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version: 7.0.0
-  resolution: "wrap-ansi@npm:7.0.0"
-  dependencies:
-    ansi-styles: "npm:^4.0.0"
-    string-width: "npm:^4.1.0"
-    strip-ansi: "npm:^6.0.0"
-  checksum: 10/cebdaeca3a6880da410f75209e68cd05428580de5ad24535f22696d7d9cab134d1f8498599f344c3cf0fb37c1715807a183778d8c648d6cc0cb5ff2bb4236540
-  languageName: node
-  linkType: hard
-
-"wrap-ansi@npm:^8.1.0":
-  version: 8.1.0
-  resolution: "wrap-ansi@npm:8.1.0"
-  dependencies:
-    ansi-styles: "npm:^6.1.0"
-    string-width: "npm:^5.0.1"
-    strip-ansi: "npm:^7.0.1"
-  checksum: 10/7b1e4b35e9bb2312d2ee9ee7dc95b8cb5f8b4b5a89f7dde5543fe66c1e3715663094defa50d75454ac900bd210f702d575f15f3f17fa9ec0291806d2578d1ddf
-  languageName: node
-  linkType: hard
-
 "wrappy@npm:1":
   version: 1.0.2
   resolution: "wrappy@npm:1.0.2"
@@ -6148,13 +5579,6 @@ __metadata:
   version: 5.1.0
   resolution: "xdg-basedir@npm:5.1.0"
   checksum: 10/b60e8a2c663ccb1dac77c2d913f3b96de48dafbfa083657171d3d50e10820b8a04bb4edfe9f00808c8c20e5f5355e1927bea9029f03136e29265cb98291e1fea
-  languageName: node
-  linkType: hard
-
-"yallist@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "yallist@npm:4.0.0"
-  checksum: 10/4cb02b42b8a93b5cf50caf5d8e9beb409400a8a4d85e83bb0685c1457e9ac0b7a00819e9f5991ac25ffabb56a78e2f017c1acc010b3a1babfe6de690ba531abd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 📬 Changes

### Functional Change

- env vars may now be loaded in a `{module}_{config}` (old format) as well as `{module}__{config}` format (1 v 2 underscores)

Helps align vars with AI/LLM first guesses for format to they guess wrong less often

### Non-functional changes

Added additional documentation for LLMs. Primarily targeted at persistent llms that hate docs and love searching through `node_modules` 🙄 

- Added `CLAUDE.md` (included in published package)
- Added lots of tsdoc (translates into build giving more docs to LLMs)

## 🗒️ Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the
  [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme and [docs](https://docs.digital-alchemy.app/) (updated or not needed)
- [x] Tests (added, updated or not needed)
