### PR TITLE
fix(config): support RecordConfig in CastConfigResult

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": {
     "url": "git+https://github.com/Digital-Alchemy-TS/core"
   },
-  "version": "26.5.28",
+  "version": "26.5.30",
   "author": {
     "url": "https://github.com/zoe-codez",
     "name": "Zoe Codez"

--- a/src/helpers/config.mts
+++ b/src/helpers/config.mts
@@ -192,7 +192,8 @@ export interface NumberConfig extends BaseConfig {
  *
  * key/value pairs
  */
-export interface RecordConfig extends BaseConfig {
+export interface RecordConfig<VALUE = string> extends BaseConfig {
+  default?: Record<string, VALUE>;
   type: "record";
 }
 

--- a/src/helpers/wiring.mts
+++ b/src/helpers/wiring.mts
@@ -39,6 +39,7 @@ import type {
   InternalConfig,
   NumberConfig,
   OptionalModuleConfiguration,
+  RecordConfig,
   StringArrayConfig,
   StringConfig,
 } from "./config.mts";
@@ -266,9 +267,25 @@ type CastConfigResult<T extends AnyConfig> =
         ? number
         : T extends StringArrayConfig
           ? string[]
-          : T extends InternalConfig<infer VALUE>
-            ? VALUE
-            : never;
+          : T extends RecordConfig<infer VALUE>
+            ? Record<string, VALUE>
+            : T extends InternalConfig<infer VALUE>
+              ? VALUE
+              : never;
+
+/**
+ * Compile-time proof that a `record` config injects as `Record<string, V>` and not `never`.
+ * If the `RecordConfig` branch above regresses, `ExpectTrue<false>` fails `tsc` (`yarn build`).
+ */
+type TypeEqual<A, B> =
+  // eslint-disable-next-line @typescript-eslint/no-magic-numbers -- `1`/`2` are the standard sentinel literals of the type-equality idiom
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+type ExpectTrue<T extends true> = T;
+
+/** @internal — assertion only; consumed via `export` so `noUnusedLocals` is satisfied. */
+export type _RecordConfigCastsToStringRecord = ExpectTrue<
+  TypeEqual<CastConfigResult<RecordConfig>, Record<string, string>>
+>;
 
 /**
  * The fully-typed config object injected as `config` into `TServiceParams`.

--- a/testing/configuration.spec.mts
+++ b/testing/configuration.spec.mts
@@ -261,6 +261,20 @@ describe("Configuration", () => {
         });
     });
 
+    it("injects a record config as a typed object", async () => {
+      expect.assertions(1);
+      await TestRunner()
+        .setOptions({
+          module_config: {
+            MY_RECORD: { default: { foo: "bar" }, type: "record" },
+          },
+        })
+        .run(({ config }) => {
+          // @ts-expect-error testing
+          expect(config.testing.MY_RECORD).toEqual({ foo: "bar" });
+        });
+    });
+
     it("should generate the correct structure for libraries", async () => {
       expect.assertions(1);
       await TestRunner()


### PR DESCRIPTION
## Changes

- Adds a `RecordConfig` branch to `CastConfigResult` so a `record`-typed config injects as `Record<string, V>` instead of resolving to `never`.
- Makes `RecordConfig` generic (`RecordConfig<VALUE = string>`) with a typed `default?: Record<string, VALUE>`.
- Adds a compile-time guard that fails `yarn build` if the cast regresses, plus a runtime test asserting a `record` config injects as a typed object.