### PR TITLE
fix: tear down prior instance on hot reload re-bootstrap

### DIFF
--- a/src/services/wiring.service.mts
+++ b/src/services/wiring.service.mts
@@ -197,7 +197,30 @@ function createBoilerplate() {
 // (re)defined at bootstrap; exported so downstream code can reference its type
 export let LIB_BOILERPLATE: ReturnType<typeof createBoilerplate>;
 type GenericApp = ApplicationDefinition<ServiceMap, OptionalModuleConfiguration>;
-const RUNNING_APPLICATIONS = new Map<string, GenericApp>();
+
+// `bun --hot` re-evaluates the entire module graph in the SAME process on every
+// file change — no restart, no signal — so module-level state is recreated each
+// reload. Anchoring the running-app registry and the "handlers installed" flag on
+// globalThis (which Bun preserves across reloads) lets a freshly re-evaluated
+// generation find the prior instance to tear it down, and keeps SIGINT/SIGTERM
+// handlers from being re-registered on every boot.
+// https://github.com/Digital-Alchemy-TS/core/issues/89
+const WIRING_RUNTIME = Symbol.for("digital-alchemy:wiring-runtime");
+type WiringRuntime = {
+  applications: Map<string, GenericApp>;
+  signalHandlersInstalled: boolean;
+};
+function wiringRuntime(): WiringRuntime {
+  const store = globalThis as unknown as Partial<Record<symbol, WiringRuntime>>;
+  const existing = store[WIRING_RUNTIME];
+  if (existing) {
+    return existing;
+  }
+  const created: WiringRuntime = { applications: new Map(), signalHandlersInstalled: false };
+  store[WIRING_RUNTIME] = created;
+  return created;
+}
+const RUNNING_APPLICATIONS = wiringRuntime().applications;
 
 // #MARK: QuickShutdown
 /**
@@ -238,6 +261,32 @@ const processEvents = new Map([
   // ["uncaughtException", () => {}],
   // ["unhandledRejection", (reason, promise) => {}],
 ]);
+
+// #MARK: installSignalHandlers
+/**
+ * Register the SIGINT/SIGTERM handlers exactly once per process.
+ *
+ * @remarks
+ * Bootstrap calls this on every boot, but the handlers must attach only once.
+ * Under `bun --hot` each reload would otherwise stack another listener — they are
+ * never removed on reload, since no teardown runs — and even a normal re-bootstrap
+ * in a single process would double them. The one installed handler drains the
+ * shared {@link RUNNING_APPLICATIONS} registry, so it stays correct no matter how
+ * many times the module is re-evaluated.
+ *
+ * @internal
+ */
+function installSignalHandlers(logger: ILogger) {
+  const runtime = wiringRuntime();
+  if (runtime.signalHandlersInstalled) {
+    return;
+  }
+  runtime.signalHandlersInstalled = true;
+  processEvents.forEach((callback, event) => {
+    process.on(event, callback);
+    logger.trace({ event, name: bootstrap }, "register shutdown event");
+  });
+}
 
 const DECIMALS = 2;
 const BOILERPLATE = (internal: InternalDefinition) =>
@@ -400,6 +449,14 @@ export function CreateApplication<S extends ServiceMap, C extends OptionalModule
           "Application is already booted! Cannot bootstrap again",
         );
       }
+      // hot-reload re-entry: `bun --hot` re-runs CreateApplication + bootstrap for
+      // the same name in the same process with no teardown signal in between. Drain
+      // a prior, still-booted generation first so its server port / sockets / timers
+      // don't leak. https://github.com/Digital-Alchemy-TS/core/issues/89
+      const previous = RUNNING_APPLICATIONS.get(name);
+      if (previous && previous !== application && previous.booted) {
+        await previous.teardown();
+      }
       internal = new InternalDefinition();
       internal.utils.is = is;
       const out = await bootstrap(application, options, internal);
@@ -416,14 +473,14 @@ export function CreateApplication<S extends ServiceMap, C extends OptionalModule
     services,
     async teardown() {
       if (!application.booted) {
-        // remove signal handlers even for un-booted teardown so they don't
-        // accumulate across test re-runs
-        processEvents.forEach((callback, event) => process.removeListener(event, callback));
         return;
       }
       await teardown(internal, application.logger);
       internal?.utils?.event?.removeAllListeners?.();
       application.booted = false;
+      // drop from the shared registry so a later signal sweep or same-name
+      // re-bootstrap doesn't try to tear this instance down again
+      RUNNING_APPLICATIONS.delete(name);
       internal = undefined;
     },
     type: "application",
@@ -640,12 +697,9 @@ async function bootstrap<S extends ServiceMap, C extends OptionalModuleConfigura
     application.logger = logger;
     logger.debug({ name: bootstrap }, `[boilerplate] wiring complete`);
 
-    // register signal handlers now that the logger is available so teardown
-    // log lines are visible; handlers are removed on teardown/un-booted teardown
-    processEvents.forEach((callback, event) => {
-      process.on(event, callback);
-      logger.trace({ event, name: bootstrap }, "register shutdown event");
-    });
+    // register signal handlers now that the logger is available so teardown log
+    // lines are visible; install-once so reloads / re-boots don't stack listeners
+    installSignalHandlers(logger);
 
     // * Add in libraries
     application.libraries ??= [];
@@ -843,7 +897,7 @@ async function teardown(internal: InternalDefinition, logger: ILogger) {
     },
     `application terminated`,
   );
-  // deregister signal handlers so they don't fire again if the process receives
-  // another signal after teardown completes
-  processEvents.forEach((callback, event) => process.removeListener(event, callback));
+  // signal handlers are intentionally left installed: a single process-wide set
+  // (see installSignalHandlers) drains the shared RUNNING_APPLICATIONS registry,
+  // which this app has already been removed from, so a later signal is a safe no-op
 }

--- a/testing/wiring.spec.mts
+++ b/testing/wiring.spec.mts
@@ -1102,6 +1102,69 @@ describe("Teardown", () => {
   });
 });
 
+// #MARK: Hot reload re-entry
+describe("Hot reload re-entry", () => {
+  // `bun --hot` re-evaluates the entry in the SAME process with no SIGINT/SIGTERM
+  // and no new process — it just re-runs CreateApplication + bootstrap for the
+  // same app name. The prior instance (server port, sockets, timers, signal
+  // listeners) must be torn down on the new boot or it leaks until a resource
+  // ceiling kills further boots. https://github.com/Digital-Alchemy-TS/core/issues/89
+  it("tears down a prior same-name application when re-bootstrapped", async () => {
+    expect.assertions(2);
+    const firstShutdown = vi.fn();
+
+    const first = CreateApplication({
+      configurationLoaders: [],
+      // @ts-expect-error testing
+      name: "hot_reload",
+      services: {
+        Test({ lifecycle }) {
+          lifecycle.onShutdownStart(firstShutdown);
+        },
+      },
+    });
+    await first.bootstrap(BASIC_BOOT);
+
+    // second generation of the same app, exactly as a hot reload would produce
+    application = CreateApplication({
+      configurationLoaders: [],
+      // @ts-expect-error testing
+      name: "hot_reload",
+      services: { Test() {} },
+    });
+    await application.bootstrap(BASIC_BOOT);
+
+    expect(firstShutdown).toHaveBeenCalledTimes(1);
+    expect(first.booted).toBe(false);
+  });
+
+  it("does not accumulate SIGINT/SIGTERM listeners across re-bootstraps", async () => {
+    expect.assertions(2);
+    const sigtermBefore = process.listenerCount("SIGTERM");
+    const sigintBefore = process.listenerCount("SIGINT");
+
+    const first = CreateApplication({
+      configurationLoaders: [],
+      // @ts-expect-error testing
+      name: "hot_reload_listeners",
+      services: { Test() {} },
+    });
+    await first.bootstrap(BASIC_BOOT);
+
+    application = CreateApplication({
+      configurationLoaders: [],
+      // @ts-expect-error testing
+      name: "hot_reload_listeners",
+      services: { Test() {} },
+    });
+    await application.bootstrap(BASIC_BOOT);
+
+    // a single set of handlers serves the whole process regardless of reloads
+    expect(process.listenerCount("SIGTERM")).toBeLessThanOrEqual(sigtermBefore + 1);
+    expect(process.listenerCount("SIGINT")).toBeLessThanOrEqual(sigintBefore + 1);
+  });
+});
+
 // #MARK: Internal
 describe("Internal", () => {
   it("populates maps during bootstrap", async () => {


### PR DESCRIPTION
Closes #89

`bun run --hot` re-evaluates the entry in the same process on every file change — no restart, no `SIGINT`/`SIGTERM` — so the framework re-ran `bootstrap()` for a brand-new app instance without ever tearing the previous one down. Old server ports, outbound sockets, timers, and a freshly-registered `SIGINT`/`SIGTERM` listener leaked on every reload until a resource ceiling killed further boots.

## Changes

- Tears down a prior still-booted instance of the same app name when `bootstrap()` runs again, so each hot reload hands off cleanly instead of stacking live apps.
- Registers the `SIGINT`/`SIGTERM` handlers once per process and drains the shared registry, instead of re-adding a listener on every boot.
- Anchors the running-application registry and the handlers-installed flag on `globalThis` so they survive `bun --hot` module re-evaluation.
- Removes a torn-down app from the registry so later signal sweeps and same-name re-boots don't re-process it.
- Adds regression tests for same-name re-bootstrap teardown and `SIGINT`/`SIGTERM` listener non-accumulation.