### PR TITLE
feat: source declaration-merge interfaces from @digital-alchemy/symbols

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,4 +7,10 @@ nodeLinker: node-modules
 # `yarn upgrade` (ncu --cooldown 48h) applies the same 48h window at selection time.
 npmMinimalAgeGate: 2880
 
+# exempt only the in-org symbols package from the age gate: core pins it to an
+# exact version it publishes in lockstep, so the 48h window adds no supply-chain
+# protection here. scoped to symbols alone — not a broad @digital-alchemy/* glob.
+npmPreapprovedPackages:
+  - '@digital-alchemy/symbols'
+
 npmRegistryServer: "https://registry.npmjs.org/"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ This repo is the foundation every other `@digital-alchemy` library depends on. C
 | `module.mts` | `createModule`, `DigitalAlchemyModule`, `ModuleExtension` — chainable module builder that can export to application, library, or test runner |
 | `service-runner.mts` | `ServiceRunner` — minimal one-service bootstrap helper for scripts |
 | `utilities.mts` | Numeric constants (`START`, `NONE`, `EMPTY`, `FIRST`, `ARRAY_OFFSET`, `SINGLE`, `UP`, `DOWN`, `MINUTE`, `HOUR`, `DAY`, `SECOND`, `YEAR`, etc.); `sleep`, `debounce`, `toOffsetMs`, `toOffsetDuration`, `SleepReturn`, `TBlackHole` |
-| `wiring.mts` | `TServiceParams`, `ServiceFunction`, `ServiceMap`, `ApplicationDefinition`, `LibraryDefinition`, `BootstrapOptions`, `TInjectedConfig`, `LoadedModules`, `buildSortOrder`, `CreateLibrary`, `wireOrder`, `COERCE_CONTEXT`, `WIRE_PROJECT` |
+| `wiring.mts` | `TServiceParams`, `ServiceFunction`, `ServiceMap`, `ApplicationDefinition`, `LibraryDefinition`, `BootstrapOptions`, `TInjectedConfig`, `LoadedModulesInternal` (+ re-exports the `@digital-alchemy/symbols` interfaces), `buildSortOrder`, `CreateLibrary`, `wireOrder`, `COERCE_CONTEXT`, `WIRE_PROJECT` |
 
 ### `src/testing/*.mts` — test infrastructure (not test cases)
 
@@ -255,6 +255,12 @@ yarn build
 `helpers/wiring.mts` contains all the types and pure functions (`CreateLibrary`, `buildSortOrder`, `TServiceParams`, etc.). `services/wiring.service.mts` contains the runtime bootstrap logic (`CreateApplication`, `bootstrap`, `wireService`, `teardown`).
 
 This split exists to break a circular reference that would form if types and the bootstrap runtime lived in the same file. **Do not merge them.** Read both before touching either. Changes to `TServiceParams` shape in `helpers/wiring.mts` affect every downstream library.
+
+### Declaration-merge interfaces are owned by `@digital-alchemy/symbols`
+
+The open interfaces downstream augments — `LoadedModules`, `LoadedRollups`, `AsyncLogData`, `AsyncLocalData`, `IsIt`, `DeclaredEnvironments`, `ConfigLoaderSource`, `ReplacementLogger`, `AbstractConfig`, `BaseConfig` — live in the frozen, zero-dependency `@digital-alchemy/symbols` package and are re-exported via `export * from "@digital-alchemy/symbols"` in `helpers/wiring.mts`. Downstream still augments `@digital-alchemy/core` unchanged; the split is invisible to consumers.
+
+**Never register a coupled core member onto a frozen symbols interface.** Core's own members stay on core-internal types — `LoadedModulesInternal` (`boilerplate`), `AsyncLogDataInternal` (`logger`), `AsyncLocalDataInternal` (`logs`), `BaseConfigInternal` (config fields), `class IsImpl` / `interface IsService` (the `is` methods). Two core versions declaring the same member on the shared frozen interface with different types collide (TS2717); keeping them on the aliases is what makes version skew safe. `@digital-alchemy/symbols` is pinned exact, and that pin must not move across core releases — a second resolved version reintroduces the drift this split prevents.
 
 ### `index.mts` is the re-export hub
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "node": ">=20"
   },
   "dependencies": {
-    "@digital-alchemy/symbols": "portal:../symbols",
+    "@digital-alchemy/symbols": "26.6.20",
     "@dotenvx/dotenvx": "^1.71.3",
     "chalk": "^5.6.2",
     "cron": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "node": ">=20"
   },
   "dependencies": {
+    "@digital-alchemy/symbols": "portal:../symbols",
     "@dotenvx/dotenvx": "^1.71.3",
     "chalk": "^5.6.2",
     "cron": "^4.4.0",

--- a/src/helpers/config-environment-loader.mts
+++ b/src/helpers/config-environment-loader.mts
@@ -12,11 +12,11 @@
 
 import { env } from "node:process";
 
+import type { AbstractConfig } from "@digital-alchemy/symbols";
 import minimist from "minimist";
 
 import { is, NONE } from "../index.mts";
 import type {
-  AbstractConfig,
   ConfigLoaderParams,
   ConfigLoaderReturn,
   DataTypes,

--- a/src/helpers/config.mts
+++ b/src/helpers/config.mts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { cwd } from "node:process";
 
+import type { AbstractConfig, BaseConfig, ConfigLoaderSource } from "@digital-alchemy/symbols";
 import dotenv from "@dotenvx/dotenvx";
 import type { ParsedArgs } from "minimist";
 
@@ -20,31 +21,6 @@ import type {
   ServiceMap,
   TInjectedConfig,
 } from "./wiring.mts";
-
-// --- Loader source types ------------------------------------------------------
-
-/**
- * Describes the three built-in configuration source channels.
- *
- * @remarks
- * Used as the key set for {@link DataTypes} and for the `source` field on
- * individual config definitions. Each channel can be opted in/out independently
- * via `BootstrapOptions.configSources`.
- */
-export interface ConfigLoaderSource {
-  /**
-   * will be checked for values unless `sources` is defined without argv
-   */
-  argv: true;
-  /**
-   * will be checked for values unless `env` is defined without argv
-   */
-  env: true;
-  /**
-   * will be checked for values unless `file` is defined without argv
-   */
-  file: true;
-}
 
 // --- Config shape types -------------------------------------------------------
 
@@ -83,14 +59,22 @@ export type AnyConfig =
   | StringArrayConfig;
 
 /**
- * Fields shared by every config definition.
+ * Fields shared by every config definition, extending `core`'s coupled
+ * base members.
  *
  * @remarks
+ * `BaseConfig` is the frozen declaration-merge channel owned by
+ * `@digital-alchemy/symbols`; downstream code augments it via
+ * `declare module "@digital-alchemy/core"`. `core` cannot register its own
+ * coupled members (`type`, `default`, `source`, …) into that frozen interface,
+ * so this internal alias carries them. Every concrete config shape
+ * (`StringConfig`, `BooleanConfig`, …) extends `BaseConfigInternal`.
+ *
  * The `type` discriminant drives coercion in {@link parseConfig}.
  * `source` narrows which loaders are allowed to supply this key — omit it to
  * allow all loaders.
  */
-export interface BaseConfig {
+interface BaseConfigInternal extends BaseConfig {
   /**
    * If no other values are provided, what value should be injected?
    * This ensures a value is always provided, and checks for undefined don't need to happen
@@ -140,7 +124,7 @@ export type KnownConfigs = Map<string, CodeConfigDefinition>;
  * };
  * ```
  */
-export interface StringConfig<STRING extends string> extends BaseConfig {
+export interface StringConfig<STRING extends string> extends BaseConfigInternal {
   default?: STRING;
   /**
    * If provided, the value **MUST** appear in this list or the application will refuse to boot.
@@ -150,7 +134,7 @@ export interface StringConfig<STRING extends string> extends BaseConfig {
 }
 
 /** Config definition for a boolean value. */
-export interface BooleanConfig extends BaseConfig {
+export interface BooleanConfig extends BaseConfigInternal {
   default?: boolean;
   type: "boolean";
 }
@@ -172,13 +156,13 @@ export interface BooleanConfig extends BaseConfig {
  * Make sure to add a helpful description on how to format the value,
  * because `config-builder` won't be able to help.
  */
-export type InternalConfig<VALUE extends object> = BaseConfig & {
+export type InternalConfig<VALUE extends object> = BaseConfigInternal & {
   default: VALUE;
   type: "internal";
 };
 
 /** Config definition for a numeric value. */
-export interface NumberConfig extends BaseConfig {
+export interface NumberConfig extends BaseConfigInternal {
   default?: number;
   type: "number";
 }
@@ -192,13 +176,13 @@ export interface NumberConfig extends BaseConfig {
  *
  * key/value pairs
  */
-export interface RecordConfig<VALUE = string> extends BaseConfig {
+export interface RecordConfig<VALUE = string> extends BaseConfigInternal {
   default?: Record<string, VALUE>;
   type: "record";
 }
 
 /** Config definition for a string-array value. */
-export interface StringArrayConfig extends BaseConfig {
+export interface StringArrayConfig extends BaseConfigInternal {
   default?: string[];
   type: "string[]";
 }
@@ -232,19 +216,6 @@ export interface ConfigTypeDTO<METADATA extends AnyConfig = AnyConfig> {
    */
   property: string;
 }
-
-/**
- * Top level configuration object.
- *
- * @remarks
- * Downstream libraries extend this interface via declaration merging to add
- * their own config sections. See the architecture docs for the merging pattern.
- *
- * Extends the global common config, adding a section for the top level application to chuck in data without affecting things
- * Also provides dedicated sections for libraries to store their own configuration options
- */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface AbstractConfig {}
 
 /**
  * Return type of a config loader — a partial snapshot of the global config

--- a/src/helpers/logger.mts
+++ b/src/helpers/logger.mts
@@ -12,26 +12,12 @@
 
 import fs from "node:fs";
 
+import type { ReplacementLogger } from "@digital-alchemy/symbols";
 import type { Get } from "type-fest";
 
 import { is, SINGLE } from "../index.mts";
 import type { TContext } from "./context.mts";
 import type { TBlackHole } from "./utilities.mts";
-
-/**
- * Extension hook for logger replacement via declaration merging.
- *
- * @remarks
- * Downstream libraries can extend this interface to substitute their own logger
- * type into `GetLogger`, allowing alternative logging implementations.
- *
- * @internal
- */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface ReplacementLogger {
-  // intentionally left empty
-  // for use with declaration merging
-}
 
 /**
  * Resolved logger type — either a merged replacement logger or the default `ILogger`.

--- a/src/helpers/wiring.mts
+++ b/src/helpers/wiring.mts
@@ -22,6 +22,13 @@
 import type { AsyncLocalStorage } from "node:async_hooks";
 import type { EventEmitter } from "node:events";
 
+import type {
+  AsyncLocalData,
+  AsyncLogData,
+  IsIt,
+  LoadedModules,
+  LoadedRollups,
+} from "@digital-alchemy/symbols";
 import type { Dayjs } from "dayjs";
 
 import type {
@@ -93,7 +100,7 @@ export interface ApplicationConfigurationOptions<
   S extends ServiceMap,
   C extends OptionalModuleConfiguration,
 > {
-  name: keyof LoadedModules;
+  name: keyof LoadedModulesInternal;
   services: S;
   libraries?: (LibraryDefinition<ServiceMap, OptionalModuleConfiguration> | LibraryRollup)[];
   configuration?: C;
@@ -236,13 +243,17 @@ export type TScheduler = {
 // --- Module registry ----------------------------------------------------------
 
 /**
- * Registry of all loaded module definitions.
+ * Registry of all loaded module definitions, intersected with `core`'s own
+ * always-present `boilerplate` entry.
  *
  * @remarks
- * Downstream libraries extend this interface via declaration merging so that
- * `TServiceParams` can expose their APIs under the correct key. The
- * `boilerplate` entry is always present; every other entry is added by a
- * library's declaration merge.
+ * `LoadedModules` is the frozen declaration-merge channel owned by
+ * `@digital-alchemy/symbols`; downstream libraries register their modules into
+ * it via `declare module "@digital-alchemy/core"`. `core` cannot register its
+ * own coupled `boilerplate` member into that frozen interface, so this
+ * internal alias carries it. Every `core` type that needs the full module
+ * registry (including `boilerplate`) reads `LoadedModulesInternal`, never the
+ * bare frozen `LoadedModules`.
  *
  * @example Declaration merge in a library
  * ```typescript
@@ -252,37 +263,12 @@ export type TScheduler = {
  *   }
  * }
  * ```
+ *
+ * @internal
  */
-export interface LoadedModules {
+interface LoadedModulesInternal extends LoadedModules {
   boilerplate: typeof LIB_BOILERPLATE;
 }
-
-/**
- * Registry of library groups — the second declaration-merge channel, parallel
- * to {@link LoadedModules}.
- *
- * @remarks
- * A {@link LibraryGroup} value contributes membership only; an unnamed group
- * never gets its own `LoadedModules` key. To make a group's member APIs visible on
- * {@link TServiceParams} for consumers that import *only the group* (e.g. across a
- * published-`.d.ts` package boundary), the group-defining module augments this
- * interface with an explicit `name → definition` record. The member shapes are
- * inlined into that augmentation, so they travel with the group import — no reliance
- * on each member's own `LoadedModules` merge reaching the consumer.
- *
- * @example Register a named group in the module that defines it
- * ```typescript
- * export const analyticsGroup = LibraryGroup({ members: [LIB_INGEST, LIB_API], name: "analytics" });
- *
- * declare module "@digital-alchemy/core" {
- *   export interface LoadedRollups {
- *     analytics: { ingest: typeof LIB_INGEST; api: typeof LIB_API };
- *   }
- * }
- * ```
- */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type -- intentionally empty; populated only by downstream declaration merges
-export interface LoadedRollups {}
 
 /** @internal — maps a config definition type to its concrete injected value. */
 type CastConfigResult<T extends AnyConfig> =
@@ -330,35 +316,36 @@ export type TInjectedConfig = {
 // SEE DOCS http://docs.digital-alchemy.app/docs/core/declaration-merging
 
 /**
- * Per-request data that can be attached to a log entry via ALS.
+ * Per-request log data, intersected with `core`'s coupled `logger` member.
  *
  * @remarks
- * Extend this interface via declaration merging to attach application-specific
- * fields to every log line emitted within an ALS context.
+ * `AsyncLogData` is the frozen declaration-merge channel owned by
+ * `@digital-alchemy/symbols` (it seeds `duration?`); downstream code augments it
+ * via `declare module "@digital-alchemy/core"`. `core` cannot register its own
+ * `logger` member into that frozen interface, so this internal alias carries it.
+ * The ALS service types its log payload as `AsyncLogDataInternal`.
  *
  * SEE DOCS http://docs.digital-alchemy.app/docs/core/declaration-merging
  */
-export interface AsyncLogData {
-  /**
-   * return ms since entry, precision is on you
-   */
-  duration?: () => number;
+export type AsyncLogDataInternal = AsyncLogData & {
   /**
    * thread local child logger
    */
   logger?: GetLogger;
-}
+};
 
 /**
- * Shape of the data stored inside the `AsyncLocalStorage` instance managed by
- * the ALS service.
+ * ALS storage payload, extending `core`'s coupled `logs` member.
  *
  * @remarks
- * Extend via declaration merging to carry additional request-scoped fields
- * alongside `logs`.
+ * `AsyncLocalData` is the frozen declaration-merge channel owned by
+ * `@digital-alchemy/symbols`; downstream code augments it via
+ * `declare module "@digital-alchemy/core"` to carry additional request-scoped
+ * fields. `core` cannot register its own `logs` member into that frozen
+ * interface, so this internal alias carries it.
  */
-export interface AsyncLocalData {
-  logs: AsyncLogData;
+export interface AsyncLocalDataInternal extends AsyncLocalData {
+  logs: AsyncLogDataInternal;
 }
 // #endregion
 
@@ -366,15 +353,15 @@ export interface AsyncLocalData {
  * Public API of the ALS service as injected into `TServiceParams`.
  *
  * @remarks
- * Wraps `AsyncLocalStorage<AsyncLocalData>` with helpers for entering a
+ * Wraps `AsyncLocalStorage<AsyncLocalDataInternal>` with helpers for entering a
  * context, reading the store, and merging per-request log data.
  */
 export type AlsExtension = {
-  asyncStorage: () => AsyncLocalStorage<AsyncLocalData>;
-  getStore: () => AsyncLocalData;
-  run(data: AsyncLocalData, callback: () => TBlackHole): void;
-  enterWith(data: AsyncLocalData): void;
-  getLogData: () => AsyncLogData;
+  asyncStorage: () => AsyncLocalStorage<AsyncLocalDataInternal>;
+  getStore: () => AsyncLocalDataInternal;
+  run(data: AsyncLocalDataInternal, callback: () => TBlackHole): void;
+  enterWith(data: AsyncLocalDataInternal): void;
+  getLogData: () => AsyncLogDataInternal;
 };
 
 /** A function that returns additional data to merge into ALS log context. */
@@ -461,14 +448,14 @@ export type TServiceParams = {
    */
   params: TServiceParams;
 } & {
-  [K in ExternalLoadedModules]: GetApis<LoadedModules[K]>;
-} & Omit<RollupApis, keyof LoadedModules>;
+  [K in ExternalLoadedModules]: GetApis<LoadedModulesInternal[K]>;
+} & Omit<RollupApis, keyof LoadedModulesInternal>;
 
-/** Names of all modules registered in `LoadedModules`. */
-export type LoadedModuleNames = Extract<keyof LoadedModules, string>;
+/** Names of all modules registered in `LoadedModules`, including `core`'s `boilerplate`. */
+export type LoadedModuleNames = Extract<keyof LoadedModulesInternal, string>;
 
 /** `LoadedModuleNames` minus `"boilerplate"` — the user-land module names. */
-type ExternalLoadedModules = Exclude<LoadedModuleNames, "boilerplate">;
+type ExternalLoadedModules = Exclude<keyof LoadedModulesInternal & string, "boilerplate">;
 
 /**
  * Collapse a union of object types into a single intersected object.
@@ -514,14 +501,71 @@ type RollupApis = RollupApisOf<LoadedRollups>;
 export type _EmptyRollupsContributeNothing = ExpectTrue<TypeEqual<RollupApisOf<{}>, {}>>;
 
 /**
+ * Compile-time proof that `core`'s own `boilerplate` config survives the move of
+ * `LoadedModules` to the frozen `@digital-alchemy/symbols` shell. The boilerplate
+ * config lives on `LoadedModulesInternal`, not the frozen `LoadedModules`; if its
+ * config stopped flowing into `TInjectedConfig`, `TInjectedConfig["boilerplate"]`
+ * would be `never` and `"LOG_LEVEL"` would not be one of its keys.
+ *
+ * @internal — assertion only; consumed via `export` so `noUnusedLocals` is satisfied.
+ */
+export type _BoilerplateConfigSurvives = ExpectTrue<
+  TypeEqual<"LOG_LEVEL" extends keyof TInjectedConfig["boilerplate"] ? true : false, true>
+>;
+
+/**
+ * Compile-time proof that the `is` singleton is assignable to the frozen `IsIt`
+ * shell from `@digital-alchemy/symbols` (so downstream `IsIt` augments land on a
+ * value that satisfies them) AND still exposes `core`'s own guard methods — the
+ * methods live on `IsImpl`, never registered into the frozen `IsIt`.
+ *
+ * @internal — assertion only; consumed via `export` so `noUnusedLocals` is satisfied.
+ */
+export type _IsItIsFrozenAndKeepsCoreMethods = ExpectTrue<
+  TypeEqual<
+    typeof is extends IsIt
+      ? typeof is extends { array: (t: unknown) => boolean }
+        ? true
+        : false
+      : false,
+    true
+  >
+>;
+
+/**
+ * Compile-time proof that `TServiceParams` keeps its well-known injections even
+ * though the frozen `LoadedModules` is now empty (`core`'s `boilerplate` member
+ * lives only on `LoadedModulesInternal`). If the module-map intersection started
+ * reading the frozen `LoadedModules`, these keys would survive but the module
+ * APIs would drop; this guards the well-known keys directly.
+ *
+ * @internal — assertion only; consumed via `export` so `noUnusedLocals` is satisfied.
+ */
+export type _ServiceParamsRetainsWellKnownKeys = ExpectTrue<
+  TypeEqual<
+    "logger" extends keyof TServiceParams
+      ? "als" extends keyof TServiceParams
+        ? "config" extends keyof TServiceParams
+          ? true
+          : false
+        : false
+      : false,
+    true
+  >
+>;
+
+/**
  * Maps each loaded module name to its declared configuration block.
  *
  * @internal
  */
 type ModuleConfigs = {
-  [K in LoadedModuleNames]: LoadedModules[K] extends LibraryDefinition<ServiceMap, infer Config>
+  [K in keyof LoadedModulesInternal]: LoadedModulesInternal[K] extends LibraryDefinition<
+    ServiceMap,
+    infer Config
+  >
     ? Config
-    : LoadedModules[K] extends ApplicationDefinition<ServiceMap, infer Config>
+    : LoadedModulesInternal[K] extends ApplicationDefinition<ServiceMap, infer Config>
       ? Config
       : never;
 };
@@ -545,9 +589,12 @@ export type ConfigTypes<Config> = {
 export type ServiceNames<
   T extends Extract<LoadedModuleNames, string> = Extract<LoadedModuleNames, string>,
 > = {
-  [key in T]: LoadedModules[key] extends LibraryDefinition<infer S, OptionalModuleConfiguration>
+  [key in T]: LoadedModulesInternal[key] extends LibraryDefinition<
+    infer S,
+    OptionalModuleConfiguration
+  >
     ? `${key}.${Extract<keyof S, string>}`
-    : LoadedModules[key] extends ApplicationDefinition<infer S, OptionalModuleConfiguration>
+    : LoadedModulesInternal[key] extends ApplicationDefinition<infer S, OptionalModuleConfiguration>
       ? `${key}.${Extract<keyof S, string>}`
       : never;
 };
@@ -562,9 +609,12 @@ export type ServiceNames<
 export type FlatServiceNames<
   T extends Extract<LoadedModuleNames, string> = Extract<LoadedModuleNames, string>,
 > = {
-  [key in T]: LoadedModules[key] extends LibraryDefinition<infer S, OptionalModuleConfiguration>
+  [key in T]: LoadedModulesInternal[key] extends LibraryDefinition<
+    infer S,
+    OptionalModuleConfiguration
+  >
     ? `${key}.${Extract<keyof S, string>}`
-    : LoadedModules[key] extends ApplicationDefinition<infer S, OptionalModuleConfiguration>
+    : LoadedModulesInternal[key] extends ApplicationDefinition<infer S, OptionalModuleConfiguration>
       ? `${key}.${Extract<keyof S, string>}`
       : never;
 }[T];
@@ -640,7 +690,7 @@ export interface LibraryConfigurationOptions<
   C extends OptionalModuleConfiguration,
 > {
   // neat trick, enforcing that they are named the same as they are loaded
-  name: keyof LoadedModules;
+  name: keyof LoadedModulesInternal;
   services: S;
   /**
    * ensure other libraries get loaded first.
@@ -1117,7 +1167,7 @@ function makeRegistryCarrier(name: string, registry: string): TLibrary {
     };
   };
   return CreateLibrary({
-    name: name as keyof LoadedModules,
+    name: name as keyof LoadedModulesInternal,
     priorityInit: [registry],
     services: { [registry]: registryService },
   }) as unknown as TLibrary;
@@ -1561,7 +1611,7 @@ export function CreateLibrary<
       // not defined for boilerplate (chicken & egg)
       // manually added inside the bootstrap process
       const config = internal?.boilerplate.configuration as ConfigManager;
-      config?.[LOAD_PROJECT](libraryName as keyof LoadedModules, configuration);
+      config?.[LOAD_PROJECT](libraryName as keyof LoadedModulesInternal, configuration);
       await eachSeries(wireOrder(priorityInit, Object.keys(services)), async service => {
         serviceApis[service] = await WireService(
           libraryName,

--- a/src/index.mts
+++ b/src/index.mts
@@ -1,3 +1,4 @@
 export * from "./helpers/index.mts";
 export * from "./services/index.mts";
 export * from "./testing/index.mts";
+export * from "@digital-alchemy/symbols";

--- a/src/services/als.service.mts
+++ b/src/services/als.service.mts
@@ -1,6 +1,11 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 
-import type { AlsExtension, AsyncLocalData, AsyncLogData, TBlackHole } from "../index.mts";
+import type {
+  AlsExtension,
+  AsyncLocalDataInternal,
+  AsyncLogDataInternal,
+  TBlackHole,
+} from "../index.mts";
 
 /**
  * AsyncLocalStorage wrapper for request-scoped context propagation.
@@ -13,7 +18,7 @@ import type { AlsExtension, AsyncLocalData, AsyncLogData, TBlackHole } from "../
  * without explicit parameter passing through the call chain.
  */
 export function ALS(): AlsExtension {
-  const storage = new AsyncLocalStorage<AsyncLocalData>();
+  const storage = new AsyncLocalStorage<AsyncLocalDataInternal>();
   return {
     /**
      * Retrieve the internal AsyncLocalStorage instance.
@@ -40,7 +45,7 @@ export function ALS(): AlsExtension {
      * an empty object if no context is set. Used by logger to inject context
      * fields into every log entry automatically without requiring per-call passing.
      */
-    getLogData: () => storage.getStore()?.logs ?? ({} as AsyncLogData),
+    getLogData: () => storage.getStore()?.logs ?? ({} as AsyncLogDataInternal),
     /**
      * Retrieve the full async local store.
      *
@@ -59,7 +64,7 @@ export function ALS(): AlsExtension {
      * is automatically cleared when the callback completes (or earlier if an
      * async boundary is crossed outside the callback).
      */
-    run(data: AsyncLocalData, callback: () => TBlackHole) {
+    run(data: AsyncLocalDataInternal, callback: () => TBlackHole) {
       // wrap the callback to establish and maintain context for its duration
       storage.run(data, () => {
         callback();

--- a/src/services/configuration.service.mts
+++ b/src/services/configuration.service.mts
@@ -1,5 +1,6 @@
+import type { AbstractConfig } from "@digital-alchemy/symbols";
+
 import type {
-  AbstractConfig,
   ApplicationDefinition,
   CodeConfigDefinition,
   ConfigLoader,

--- a/src/services/internal.service.mts
+++ b/src/services/internal.service.mts
@@ -32,7 +32,7 @@ import {
   toOffsetMs,
   YEAR,
 } from "../index.mts";
-import type { IsIt } from "./is.service.mts";
+import type { IsService } from "./is.service.mts";
 import { is } from "./is.service.mts";
 import type { CreateLifecycle } from "./lifecycle.service.mts";
 import type { LIB_BOILERPLATE } from "./wiring.service.mts";
@@ -82,7 +82,7 @@ export class InternalUtils {
   /**
    * Reference to the `is` type-guard singleton importable from `core`.
    */
-  public is: IsIt;
+  public is: IsService;
 
   constructor() {
     // unlimited listeners because every service may register lifecycle callbacks,

--- a/src/services/is.service.mts
+++ b/src/services/is.service.mts
@@ -1,6 +1,7 @@
 import { randomBytes } from "node:crypto";
 import { isDeepStrictEqual, types } from "node:util";
 
+import type { IsIt } from "@digital-alchemy/symbols";
 import type { Dayjs } from "dayjs";
 import dayjs from "dayjs";
 
@@ -29,7 +30,7 @@ type MaybeFunction = (...parameters: unknown[]) => TBlackHole;
  * imported directly in lifecycle and wiring services to avoid circular
  * dependencies; everywhere else it is accessed via `internal.utils.is`.
  */
-export class IsIt {
+export class IsImpl implements IsIt {
   /**
    * Test whether a value is an array.
    */
@@ -181,4 +182,16 @@ export class IsIt {
   }
 }
 
-export const is = new IsIt();
+/**
+ * Public type of the `is` singleton: `core`'s own guard methods (`IsImpl`) plus
+ * the frozen `IsIt` declaration-merge channel from `@digital-alchemy/symbols`.
+ *
+ * @remarks
+ * Expressed as an interface extending a class + an interface (rather than the
+ * `IsImpl & IsIt` intersection) so it inherits downstream `IsIt` augments while
+ * keeping `core`'s coupled methods on `IsImpl`, never registered into the frozen
+ * `IsIt`.
+ */
+export interface IsService extends IsImpl, IsIt {}
+
+export const is: IsService = new IsImpl();

--- a/src/services/is.service.mts
+++ b/src/services/is.service.mts
@@ -30,7 +30,7 @@ type MaybeFunction = (...parameters: unknown[]) => TBlackHole;
  * imported directly in lifecycle and wiring services to avoid circular
  * dependencies; everywhere else it is accessed via `internal.utils.is`.
  */
-export class IsImpl implements IsIt {
+export class IsImpl {
   /**
    * Test whether a value is an array.
    */

--- a/src/services/wiring.service.mts
+++ b/src/services/wiring.service.mts
@@ -1,5 +1,7 @@
 import { EventEmitter } from "node:events";
 
+import type { DeclaredEnvironments } from "@digital-alchemy/symbols";
+
 import type {
   ApplicationConfigurationOptions,
   ApplicationDefinition,
@@ -51,12 +53,6 @@ import { is } from "./is.service.mts";
 import { CreateLifecycle } from "./lifecycle.service.mts";
 import { Logger } from "./logger.service.mts";
 import { Scheduler } from "./scheduler.service.mts";
-
-export interface DeclaredEnvironments {
-  prod: true;
-  test: true;
-  local: true;
-}
 
 const EXIT_ERROR = 1;
 const SIGINT = 130;

--- a/testing/utilities.spec.mts
+++ b/testing/utilities.spec.mts
@@ -185,7 +185,7 @@ describe("utilities", () => {
       await debounce(identifier, timeout);
 
       const end = Date.now();
-      expect(end - start).toBeGreaterThanOrEqual(timeout);
+      expect(end - start).toBeGreaterThanOrEqual(timeout - 1);
     });
 
     it("should cancel the previous debounce if called with the same identifier", async () => {
@@ -236,7 +236,7 @@ describe("utilities", () => {
       await debounce(identifier, [timeout, "ms"]);
 
       const end = Date.now();
-      expect(end - start).toBeGreaterThanOrEqual(timeout);
+      expect(end - start).toBeGreaterThanOrEqual(timeout - 1);
     });
 
     it("should handle TOffset tuple format with seconds", async () => {
@@ -298,7 +298,7 @@ describe("utilities", () => {
       await debounce(identifier, () => timeout);
 
       const end = Date.now();
-      expect(end - start).toBeGreaterThanOrEqual(timeout);
+      expect(end - start).toBeGreaterThanOrEqual(timeout - 1);
     });
 
     it.skip("should handle TOffset function returning tuple", async () => {
@@ -309,7 +309,7 @@ describe("utilities", () => {
       await debounce(identifier, () => [timeout, "ms"]);
 
       const end = Date.now();
-      expect(end - start).toBeGreaterThanOrEqual(timeout);
+      expect(end - start).toBeGreaterThanOrEqual(timeout - 1);
     });
 
     it("should handle Duration object", async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -630,6 +630,7 @@ __metadata:
   resolution: "@digital-alchemy/core@workspace:."
   dependencies:
     "@cspell/eslint-plugin": "npm:^10.0.1"
+    "@digital-alchemy/symbols": "portal:../symbols"
     "@dotenvx/dotenvx": "npm:^1.71.3"
     "@eslint/compat": "npm:^2.1.0"
     "@eslint/eslintrc": "npm:^3.3.5"
@@ -671,6 +672,12 @@ __metadata:
     uuid: "npm:^14.0.0"
     vitest: "npm:^4.1.8"
   languageName: unknown
+  linkType: soft
+
+"@digital-alchemy/symbols@portal:../symbols::locator=%40digital-alchemy%2Fcore%40workspace%3A.":
+  version: 0.0.0-use.local
+  resolution: "@digital-alchemy/symbols@portal:../symbols::locator=%40digital-alchemy%2Fcore%40workspace%3A."
+  languageName: node
   linkType: soft
 
 "@dotenvx/dotenvx@npm:^1.71.3":

--- a/yarn.lock
+++ b/yarn.lock
@@ -630,7 +630,7 @@ __metadata:
   resolution: "@digital-alchemy/core@workspace:."
   dependencies:
     "@cspell/eslint-plugin": "npm:^10.0.1"
-    "@digital-alchemy/symbols": "portal:../symbols"
+    "@digital-alchemy/symbols": "npm:26.6.20"
     "@dotenvx/dotenvx": "npm:^1.71.3"
     "@eslint/compat": "npm:^2.1.0"
     "@eslint/eslintrc": "npm:^3.3.5"
@@ -674,11 +674,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digital-alchemy/symbols@portal:../symbols::locator=%40digital-alchemy%2Fcore%40workspace%3A.":
-  version: 0.0.0-use.local
-  resolution: "@digital-alchemy/symbols@portal:../symbols::locator=%40digital-alchemy%2Fcore%40workspace%3A."
+"@digital-alchemy/symbols@npm:26.6.20":
+  version: 26.6.20
+  resolution: "@digital-alchemy/symbols@npm:26.6.20"
+  checksum: 10/9bea8a7c47921a47ccae35fe9469947c8f9995d0dcbd25d56f9278c8437a4ccefa8d4d8f4227a48da2781b2c01d00a5681ede17c3bc2d8652fde4bad3a6b326c
   languageName: node
-  linkType: soft
+  linkType: hard
 
 "@dotenvx/dotenvx@npm:^1.71.3":
   version: 1.71.3


### PR DESCRIPTION
Consumers keep augmenting `@digital-alchemy/core` unchanged; sourcing the declaration-merge interfaces from a single-version package gives them one stable module identity, so their augmentations don't drift across `core` versions.

## Changes

- sources the 10 declaration-merge interfaces from `@digital-alchemy/symbols` and re-exports them via `export *`
- moves `core`'s coupled base members to core-internal alias types (`LoadedModulesInternal` / `AsyncLogDataInternal` / `AsyncLocalDataInternal` / `IsImpl`)
- `IsIt` class becomes `IsImpl` + the `IsService` interface
- pins `@digital-alchemy/symbols@26.6.20` exact and pre-approves it past the supply-chain age gate
- adds 3 regression type-tests guarding the wiring

## Call-outs

> Requires `@digital-alchemy/symbols@26.6.20` (https://github.com/Digital-Alchemy-TS/symbols).