### PR TITLE
docs: repoint dead SEE DOCS link to live DI guide

### DIFF
--- a/src/helpers/wiring.mts
+++ b/src/helpers/wiring.mts
@@ -313,7 +313,7 @@ export type TInjectedConfig = {
 };
 
 // #region Special
-// SEE DOCS http://docs.digital-alchemy.app/docs/core/declaration-merging
+// SEE DOCS https://docs.digital-alchemy.app/docs/core/guides/dependency-injection
 
 /**
  * Per-request log data, intersected with `core`'s coupled `logger` member.
@@ -325,7 +325,7 @@ export type TInjectedConfig = {
  * `logger` member into that frozen interface, so this internal alias carries it.
  * The ALS service types its log payload as `AsyncLogDataInternal`.
  *
- * SEE DOCS http://docs.digital-alchemy.app/docs/core/declaration-merging
+ * SEE DOCS https://docs.digital-alchemy.app/docs/core/guides/dependency-injection
  */
 export type AsyncLogDataInternal = AsyncLogData & {
   /**


### PR DESCRIPTION
## Changes

- Repoints the two `SEE DOCS` comments in `helpers/wiring.mts` from the dead `…/docs/core/declaration-merging` (returns HTTP 404) to the live `…/docs/core/guides/dependency-injection` guide, which now documents the `LoadedModules` declaration-merge model.

Follow-up to #335 — the dead link predated and survived that merge. The target guide was corrected for the symbols decoupling in Digital-Alchemy-TS/documentation#69.